### PR TITLE
fix bug #3812 Blog : Le flux RSS remonte les billets en brouillon

### DIFF
--- a/blog/blog-jar/src/main/java/com/silverpeas/blog/control/BlogService.java
+++ b/blog/blog-jar/src/main/java/com/silverpeas/blog/control/BlogService.java
@@ -46,6 +46,8 @@ public interface BlogService extends SilverpeasComponentService<PostDetail> {
   public void deletePost(String postId, String instanceId);
 
   public Collection<PostDetail> getAllPosts(String instanceId, int nbReturned);
+  
+  public Collection<PostDetail> getAllValidPosts(String instanceId, int nbReturned);
 
   public Collection<PostDetail> getLastPosts(String instanceId);
 

--- a/blog/blog-jar/src/main/java/com/silverpeas/blog/control/DefaultBlogService.java
+++ b/blog/blog-jar/src/main/java/com/silverpeas/blog/control/DefaultBlogService.java
@@ -367,6 +367,33 @@ public class DefaultBlogService implements BlogService {
       closeConnection(con);
     }
   }
+  
+  @Override
+  public Collection<PostDetail> getAllValidPosts(String instanceId, int nbReturned) {
+    PublicationPK pubPK = new PublicationPK("useless", instanceId);
+    Connection con = openConnection();
+
+    Collection<PostDetail> posts = new ArrayList<PostDetail>();
+    try {
+      // rechercher les publications classées par date d'évènement
+      Collection<String> lastEvents = PostDAO.getLastEvents(con, instanceId, nbReturned);
+      Collection<PublicationDetail> publications =
+          getPublicationBm().getAllPublications(pubPK);
+      for (String pubId : lastEvents) {
+        for (PublicationDetail publication : publications) {
+          if (publication.getPK().getId().equals(pubId) && PublicationDetail.VALID.equals(publication.getStatus())) {
+            posts.add(getPost(publication));
+          }
+        }
+      }
+      return posts;
+    } catch (Exception e) {
+      throw new BlogRuntimeException("BlogBmEJB.getAllValidPosts()", SilverpeasRuntimeException.ERROR,
+          "post.MSG_POST_NOT_CREATE", e);
+    } finally {
+      closeConnection(con);
+    }
+  }
 
   @Override
   public Collection<PostDetail> getLastPosts(String instanceId) {

--- a/blog/blog-war/src/main/java/com/silverpeas/blog/servlets/BlogRssServlet.java
+++ b/blog/blog-war/src/main/java/com/silverpeas/blog/servlets/BlogRssServlet.java
@@ -45,7 +45,7 @@ public class BlogRssServlet extends RssServlet<PostDetail> {
       throws RemoteException {
     // récupération de la liste des 10 prochains billets du Blog
     BlogService service = BlogServiceFactory.getFactory().getBlogService();
-    return service.getAllPosts(instanceId, nbReturned);
+    return service.getAllValidPosts(instanceId, nbReturned);
   }
 
   /*


### PR DESCRIPTION
Add getAllValidPosts method in the BlogService class to return all the posts which are in the valid status (that is to say, not in draft status).
