### PR TITLE
Bug #3897. Update according to the change in Silverpeas-Core (branch bug-3897)

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
@@ -1,25 +1,22 @@
 /**
  * Copyright (C) 2000 - 2011 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.com/legal/licensing"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 package com.stratelia.webactiv.kmelia.control;
 
@@ -193,7 +190,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 
 public class KmeliaSessionController extends AbstractComponentSessionController implements
-        ExportFileNameProducer {
+    ExportFileNameProducer {
 
   /**
    * The different export formats the KmeliaPublicationExporter should support.
@@ -202,7 +199,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   /**
    * All the formats that are available for the export of publications.
    */
-  private static final String[] AVAILABLE_EXPORT_FORMATS = { "zip", "pdf", "odt", "doc" };
+  private static final String[] AVAILABLE_EXPORT_FORMATS = {"zip", "pdf", "odt", "doc"};
 
   /* EJBs used by sessionController */
   private ThumbnailService thumbnailService = null;
@@ -271,20 +268,20 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   Fields saveFields = new Fields();
   boolean isDragAndDropEnableByUser = false;
   boolean componentManageable = false;
-
   private List<String> selectedPublicationIds = new ArrayList<String>();
   private boolean customPublicationTemplateUsed = false;
   private String customPublicationTemplateName = null;
 
   /**
    * Creates new sessionClientController
+   *
    * @param mainSessionCtrl
    * @param context
    */
   public KmeliaSessionController(MainSessionController mainSessionCtrl, ComponentContext context) {
     super(mainSessionCtrl, context, "com.stratelia.webactiv.kmelia.multilang.kmeliaBundle",
-            "com.stratelia.webactiv.kmelia.settings.kmeliaIcons",
-            "com.stratelia.webactiv.kmelia.settings.kmeliaSettings");
+        "com.stratelia.webactiv.kmelia.settings.kmeliaIcons",
+        "com.stratelia.webactiv.kmelia.settings.kmeliaSettings");
     init();
   }
 
@@ -296,10 +293,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       isDragAndDropEnableByUser = isDragAndDropEnableByUser();
     }
     componentManageable = GeneralPropertiesManager.getGeneralResourceLocator().getBoolean(
-            "AdminFromComponentEnable", true);
+        "AdminFromComponentEnable", true);
     if (componentManageable) {
       componentManageable = getOrganizationController().isComponentManageable(getComponentId(),
-              getUserId());
+          getUserId());
     }
     defaultSortValue = getComponentParameterValue("publicationSort");
     if (!StringUtil.isDefined(defaultSortValue)) {
@@ -314,6 +311,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Gets a business service of comments.
+   *
    * @return a DefaultCommentService instance.
    */
   protected CommentService getCommentService() {
@@ -326,11 +324,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public KmeliaBm getKmeliaBm() {
     try {
       KmeliaBmHome kscEjbHome = EJBUtilitaire.getEJBObjectRef(JNDINames.KMELIABM_EJBHOME,
-              KmeliaBmHome.class);
+          KmeliaBmHome.class);
       return kscEjbHome.create();
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.getKmeliaBm()",
-              SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
+          SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
     }
   }
 
@@ -339,11 +337,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       try {
         StatisticBmHome statisticHome =
             EJBUtilitaire.getEJBObjectRef(JNDINames.STATISTICBM_EJBHOME,
-                StatisticBmHome.class);
+            StatisticBmHome.class);
         statisticBm = statisticHome.create();
       } catch (Exception e) {
         throw new StatisticRuntimeException("KmeliaSessionController.getStatisticBm()",
-                SilverpeasException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
+            SilverpeasException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
       }
     }
 
@@ -354,11 +352,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     if (versioningBm == null) {
       try {
         VersioningBmHome vscEjbHome = EJBUtilitaire.getEJBObjectRef(JNDINames.VERSIONING_EJBHOME,
-                VersioningBmHome.class);
+            VersioningBmHome.class);
         versioningBm = vscEjbHome.create();
       } catch (Exception e) {
         throw new VersioningRuntimeException("KmeliaSessionController.getVersioningBm()",
-                SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
+            SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
       }
     }
     return versioningBm;
@@ -367,8 +365,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public ResourceLocator getPublicationSettings() {
     if (publicationSettings == null) {
       publicationSettings =
-              new ResourceLocator("com.stratelia.webactiv.util.publication.publicationSettings",
-                  getLanguage());
+          new ResourceLocator("com.stratelia.webactiv.util.publication.publicationSettings",
+          getLanguage());
     }
     return publicationSettings;
   }
@@ -578,7 +576,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public boolean isThumbnailMandatory() {
     return "yes".equals(getComponentParameterValue("thumbnailMandatory"));
   }
-  
+
   public boolean isFolderSharingEnabled() {
     return "yes".equals(getComponentParameterValue("useFolderSharing"));
   }
@@ -678,6 +676,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Generates a document in the specified format from the specified publication.
+   *
    * @param inFormat the format of the document to generate.
    * @param fromPubId the unique identifier of the publication from which the document will be
    * generated.
@@ -685,29 +684,29 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    */
   public File generateDocument(final DocumentFormat inFormat, String fromPubId) {
     SilverTrace.info("kmelia", "KmeliaSessionControl.KmeliaSessionController.generateDocument()",
-            "root.MSG_ENTRY_METHOD");
+        "root.MSG_ENTRY_METHOD");
     if (!isFormatSupported(inFormat.name())) {
       throw new KmeliaRuntimeException("kmelia", SilverTrace.TRACE_LEVEL_ERROR,
-              "kmelia.EX_EXPORT_FORMAT_NOT_SUPPORTED");
+          "kmelia.EX_EXPORT_FORMAT_NOT_SUPPORTED");
     }
     File document = null;
     if (fromPubId != null) {
       try {
         KmeliaPublication publication =
-                KmeliaPublication.aKmeliaPublicationWithPk(new PublicationPK(
-                    fromPubId, getComponentId()));
+            KmeliaPublication.aKmeliaPublicationWithPk(new PublicationPK(
+            fromPubId, getComponentId()));
         if (isVersionControlled()) {
           publication.versioned();
         }
         String fileName = getPublicationExportFileName(publication, getLanguage());
         document = new File(FileRepositoryManager.getTemporaryPath() + fileName + "." + inFormat.
-                name());
+            name());
         FileOutputStream output = new FileOutputStream(document);
         ExportDescriptor descriptor = ExportDescriptor.withOutputStream(output).
-                withParameter(EXPORT_FOR_USER, getUserDetail()).
-                withParameter(EXPORT_LANGUAGE, getLanguage()).
-                withParameter(EXPORT_TOPIC, getSessionTopic()).
-                inFormat(inFormat.name());
+            withParameter(EXPORT_FOR_USER, getUserDetail()).
+            withParameter(EXPORT_LANGUAGE, getLanguage()).
+            withParameter(EXPORT_TOPIC, getSessionTopic()).
+            inFormat(inFormat.name());
         aKmeliaPublicationExporter().export(descriptor, publication);
       } catch (Exception ex) {
         Logger.getLogger(getClass().getSimpleName()).log(Level.SEVERE, ex.getMessage(), ex);
@@ -715,17 +714,21 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           document.delete();
         }
         throw new KmeliaRuntimeException("KmeliaSessionController.generateDocument()",
-                SilverpeasRuntimeException.ERROR, "kmelia.EX_CANT_EXPORT_PUBLICATION", ex);
+            SilverpeasRuntimeException.ERROR, "kmelia.EX_CANT_EXPORT_PUBLICATION", ex);
       }
     }
     return document;
   }
 
-  /************************************************************************************************/
+  /**
+   * *********************************************************************************************
+   */
   // Current User operations
   /**
    * ********************************************************************************************
-   * /**
+   * /
+   *
+   **
    * @return
    * @throws RemoteException
    */
@@ -753,7 +756,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     if (node != null && node.haveRights()) {
       int rightsDependsOn = node.getRightsDependsOn();
       return KmeliaHelper.getProfile(getOrganizationController().getUserProfiles(getUserId(),
-              getComponentId(), rightsDependsOn, ObjectType.NODE));
+          getComponentId(), rightsDependsOn, ObjectType.NODE));
     } else {
       return KmeliaHelper.getProfile(getUserRoles());
     }
@@ -778,8 +781,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       profileNames.add(KmeliaHelper.ROLE_WRITER);
       profileNames.add(KmeliaHelper.ROLE_READER);
       String[] userIds =
-              getOrganizationController().getUsersIdsByRoleNames(getComponentId(),
-                  Integer.toString(rightsDependsOn), ObjectType.NODE, profileNames);
+          getOrganizationController().getUsersIdsByRoleNames(getComponentId(),
+          Integer.toString(rightsDependsOn), ObjectType.NODE, profileNames);
       return Arrays.asList(userIds);
     } else {
       return null;
@@ -790,7 +793,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     if (isRightsOnTopicsEnabled() && getSessionTopic().getNodeDetail().haveRights()) {
       int rightsDependsOn = getSessionTopic().getNodeDetail().getRightsDependsOn();
       return getOrganizationController().isObjectAvailable(rightsDependsOn, ObjectType.NODE,
-              getComponentId(), getUserId());
+          getComponentId(), getUserId());
     }
     return true;
   }
@@ -811,34 +814,34 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized TopicDetail getTopic(String id, boolean resetSessionPublication)
-          throws RemoteException {
+      throws RemoteException {
     if (resetSessionPublication) {
       setSessionPublication(null);
     }
     if (getSessionTopic() == null || !id.equals(
-            getSessionTopic().getNodeDetail().getNodePK().getId())) {
+        getSessionTopic().getNodeDetail().getNodePK().getId())) {
       indexOfFirstPubToDisplay = 0;
     }
 
     TopicDetail currentTopic = null;
     if (isUserComponentAdmin()) {
       currentTopic =
-              getKmeliaBm().goTo(getNodePK(id), getUserId(), isTreeStructure(), "admin", false);
+          getKmeliaBm().goTo(getNodePK(id), getUserId(), isTreeStructure(), "admin", false);
     } else {
       currentTopic =
-              getKmeliaBm().goTo(getNodePK(id), getUserId(), isTreeStructure(),
-                  getUserTopicProfile(id), isRightsOnTopicsEnabled());
+          getKmeliaBm().goTo(getNodePK(id), getUserId(), isTreeStructure(),
+          getUserTopicProfile(id), isRightsOnTopicsEnabled());
     }
 
     List<NodeDetail> treeview = null;
     if (isTreeviewUsed() || displayNbPublis()) {
       if (isUserComponentAdmin()) {
         treeview = getKmeliaBm().getTreeview(getNodePK("0"), "admin", isCoWritingEnable(),
-                isDraftVisibleWithCoWriting(), getUserId(), displayNbPublis(), false);
+            isDraftVisibleWithCoWriting(), getUserId(), displayNbPublis(), false);
       } else {
         treeview = getKmeliaBm().getTreeview(getNodePK("0"), getProfile(), isCoWritingEnable(),
-                isDraftVisibleWithCoWriting(), getUserId(), displayNbPublis(),
-                isRightsOnTopicsEnabled());
+            isDraftVisibleWithCoWriting(), getUserId(), displayNbPublis(),
+            isRightsOnTopicsEnabled());
       }
       setSessionTreeview(treeview);
     }
@@ -866,7 +869,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public synchronized TopicDetail getPublicationTopic(String pubId) throws RemoteException {
     TopicDetail currentTopic = getKmeliaBm().getPublicationFather(getPublicationPK(pubId),
-            isTreeStructure(), getUserId(), isRightsOnTopicsEnabled());
+        isTreeStructure(), getUserId(), isRightsOnTopicsEnabled());
     setSessionTopic(currentTopic);
     applyVisibilityFilter();
     return currentTopic;
@@ -887,23 +890,23 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public synchronized void flushTrashCan() throws RemoteException {
     SilverTrace.info("kmelia", "KmeliaSessionControl.flushTrashCan", "root.MSG_ENTRY_METHOD");
     TopicDetail td = getKmeliaBm().goTo(getNodePK(NodePK.BIN_NODE_ID), getUserId(), false,
-            getUserTopicProfile("1"), isRightsOnTopicsEnabled());
+        getUserTopicProfile("1"), isRightsOnTopicsEnabled());
     setSessionTopic(td);
     Collection<KmeliaPublication> pds = td.getKmeliaPublications();
     Iterator<KmeliaPublication> ipds = pds.iterator();
     SilverTrace.info("kmelia", "KmeliaSessionControl.flushTrashCan", "root.MSG_PARAM_VALUE",
-            "NbPubli=" + pds.size());
+        "NbPubli=" + pds.size());
     while (ipds.hasNext()) {
       String theId = (ipds.next()).getDetail().getPK().getId();
       SilverTrace.info("kmelia", "KmeliaSessionControl.flushTrashCan", "root.MSG_PARAM_VALUE",
-              "Deleting Publi #" + theId);
+          "Deleting Publi #" + theId);
       deletePublication(theId);
     }
     indexOfFirstPubToDisplay = 0;
   }
 
   public synchronized NodePK updateTopicHeader(NodeDetail nd, String alertType)
-          throws RemoteException {
+      throws RemoteException {
     nd.getNodePK().setSpace(getSpaceId());
     nd.getNodePK().setComponentName(getComponentId());
     return getKmeliaBm().updateTopic(nd, alertType);
@@ -914,7 +917,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized NodePK addSubTopic(NodeDetail nd, String alertType, String parentId)
-          throws RemoteException {
+      throws RemoteException {
     nd.getNodePK().setSpace(getSpaceId());
     nd.getNodePK().setComponentName(getComponentId());
     nd.setCreatorId(getUserId());
@@ -928,7 +931,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     NodeDetail node = getNodeHeader(topicId);
     // check if user is allowed to delete this topic
     if (SilverpeasRole.admin.isInRole(getUserTopicProfile(topicId))
-            || SilverpeasRole.admin.isInRole(getUserTopicProfile(node.getFatherPK().getId()))) {
+        || SilverpeasRole.admin.isInRole(getUserTopicProfile(node.getFatherPK().getId()))) {
       // First, remove rights on topic and its descendants
       List<NodeDetail> treeview = getNodeBm().getSubTree(getNodePK(topicId));
       for (NodeDetail nodeToDelete : treeview) {
@@ -943,21 +946,20 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized void changeSubTopicsOrder(String way, String subTopicId)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().changeSubTopicsOrder(way, getNodePK(subTopicId), getSessionTopic().getNodePK());
   }
 
   public synchronized void changeTopicStatus(String newStatus, String topicId,
-          boolean recursiveChanges) throws RemoteException {
+      boolean recursiveChanges) throws RemoteException {
     getKmeliaBm().changeTopicStatus(newStatus, getNodePK(topicId), recursiveChanges);
   }
 
   /**
-   * @return
-   * @throws RemoteException
+   * @return @throws RemoteException
    */
   public synchronized Collection<Collection<NodeDetail>> getSubscriptionList() throws
-          RemoteException {
+      RemoteException {
     return getKmeliaBm().getSubscriptionList(getUserId(), getComponentId());
   }
 
@@ -983,12 +985,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized Collection<NodePK> getPublicationFathers(String pubId)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().getPublicationFathers(getPublicationPK(pubId));
   }
 
   public synchronized String createPublication(PublicationDetail pubDetail,
-          final PdcClassificationEntity classification) throws RemoteException {
+      final PdcClassificationEntity classification) throws RemoteException {
     pubDetail.getPK().setSpace(getSpaceId());
     pubDetail.getPK().setComponentName(getComponentId());
     pubDetail.setCreatorId(getUserId());
@@ -1003,21 +1005,21 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       } else {
         List<PdcPosition> pdcPositions = classification.getPdcPositions();
         PdcClassification withClassification = aPdcClassificationOfContent(pubDetail.getId(),
-                pubDetail.getComponentInstanceId()).withPositions(pdcPositions);
+            pubDetail.getComponentInstanceId()).withPositions(pdcPositions);
         result = getKmeliaBm().createPublicationIntoTopic(pubDetail, getSessionTopic().getNodePK(),
-                withClassification);
+            withClassification);
       }
     }
 
     SilverTrace.info("kmelia", "KmeliaSessionController.createPublication(pubDetail)",
-            "Kmelia.MSG_ENTRY_METHOD");
+        "Kmelia.MSG_ENTRY_METHOD");
     SilverTrace.spy("kmelia", "KmeliaSessionController.createPublication(pubDetail)", getSpaceId(),
-            getComponentId(), result, getUserDetail().getId(), SilverTrace.SPY_ACTION_CREATE);
+        getComponentId(), result, getUserDetail().getId(), SilverTrace.SPY_ACTION_CREATE);
     return result;
   }
 
   private String createPublicationIntoTopic(PublicationDetail pubDetail, String fatherId)
-          throws RemoteException {
+      throws RemoteException {
     pubDetail.getPK().setSpace(getSpaceId());
     pubDetail.getPK().setComponentName(getComponentId());
     pubDetail.setCreatorId(getUserId());
@@ -1030,9 +1032,9 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
     String result = getKmeliaBm().createPublicationIntoTopic(pubDetail, getNodePK(fatherId));
     SilverTrace.spy("kmelia",
-            "KmeliaSessionController.createPublicationIntoTopic(pubDetail, fatherId)",
+        "KmeliaSessionController.createPublicationIntoTopic(pubDetail, fatherId)",
         getSpaceId(),
-            getComponentId(), result, getUserDetail().getId(), SilverTrace.SPY_ACTION_CREATE);
+        getComponentId(), result, getUserDetail().getId(), SilverTrace.SPY_ACTION_CREATE);
     return result;
   }
 
@@ -1042,20 +1044,20 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     pubDetail.setUpdaterId(getUserId());
 
     SilverTrace.info("kmelia", "KmeliaSessionController.updatePublication(pubDetail)",
-            "root.MSG_GEN_PARAM_VALUE", "isPublicationAlwaysVisibleEnabled() = "
-                + isPublicationAlwaysVisibleEnabled());
+        "root.MSG_GEN_PARAM_VALUE", "isPublicationAlwaysVisibleEnabled() = "
+        + isPublicationAlwaysVisibleEnabled());
     SilverTrace.info("kmelia", "KmeliaSessionController.updatePublication(pubDetail)",
-            "root.MSG_GEN_PARAM_VALUE",
-            "'writer'.equals(KmeliaHelper.getProfile(getUserRoles())) = "
-                + "writer".equals(KmeliaHelper.getProfile(getUserRoles())));
+        "root.MSG_GEN_PARAM_VALUE",
+        "'writer'.equals(KmeliaHelper.getProfile(getUserRoles())) = "
+        + "writer".equals(KmeliaHelper.getProfile(getUserRoles())));
     SilverTrace.info("kmelia", "KmeliaSessionController.updatePublication(pubDetail)",
-            "root.MSG_GEN_PARAM_VALUE",
-            "(getSessionClone() == null) = " + (getSessionClone() == null));
+        "root.MSG_GEN_PARAM_VALUE",
+        "(getSessionClone() == null) = " + (getSessionClone() == null));
     if (isCloneNeeded()) {
       clonePublication(pubDetail);
     } else {
       if (getSessionTopic() == null || NodePK.BIN_NODE_ID.equals(
-              getSessionTopic().getNodePK().getId())) {
+          getSessionTopic().getNodePK().getId())) {
         // la publication est dans la corbeille
         pubDetail.setIndexOperation(IndexManager.NONE);
       }
@@ -1069,18 +1071,18 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       getKmeliaBm().updatePublication(pubDetail);
     }
     SilverTrace.spy("kmelia", "KmeliaSessionController.updatePublication", getSpaceId(),
-            getComponentId(),
-            pubDetail.getId(), getUserDetail().getId(), SilverTrace.SPY_ACTION_UPDATE);
+        getComponentId(),
+        pubDetail.getId(), getUserDetail().getId(), SilverTrace.SPY_ACTION_UPDATE);
   }
 
   public boolean isCloneNeeded() throws RemoteException {
     String currentStatus =
-            getSessionPublication().getDetail().getStatus();
+        getSessionPublication().getDetail().getStatus();
     return (isPublicationAlwaysVisibleEnabled()
-            && "writer".equals(
-                getUserTopicProfile()) && (getSessionClone() == null) && PublicationDetail.VALID
+        && "writer".equals(
+        getUserTopicProfile()) && (getSessionClone() == null) && PublicationDetail.VALID
         .equals(
-            currentStatus));
+        currentStatus));
   }
 
   public boolean isCloneNeededWithDraft() {
@@ -1103,6 +1105,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * Clone current publication. Create new publication based on pubDetail object if not null or
    * sessionPublication otherwise. Original publication must not be modified (except references to
    * clone : cloneId and cloneStatus).
+   *
    * @param pubDetail If not null, attribute values are set to the clone
    * @param nextStatus Draft or ToValidate
    * @return
@@ -1116,7 +1119,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       setSessionClone(getPublication(cloneId));
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.clonePublication",
-              SilverpeasException.ERROR, "kmelia.CANT_CLONE_PUBLICATION", e);
+          SilverpeasException.ERROR, "kmelia.CANT_CLONE_PUBLICATION", e);
     }
     return cloneId;
   }
@@ -1126,7 +1129,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized void deletePublication(String pubId, boolean kmaxMode)
-          throws RemoteException {
+      throws RemoteException {
     // récupération de la position de la publication pour savoir si elle se trouve déjà dans
     // la corbeille node=1
     // si elle se trouve déjà au node 1, il est nécessaire de supprimer les fichier joints
@@ -1141,7 +1144,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         WysiwygController.deleteWysiwygAttachments(getSpaceId(), getComponentId(), pubId);
       } catch (Exception e) {
         throw new KmeliaRuntimeException("KmeliaSessionController.deletePublication",
-                SilverpeasRuntimeException.ERROR, "root.EX_DELETE_ATTACHMENT_FAILED", e);
+            SilverpeasRuntimeException.ERROR, "root.EX_DELETE_ATTACHMENT_FAILED", e);
       }
 
       removeXMLContentOfPublication(getPublicationPK(pubId));
@@ -1150,7 +1153,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       getKmeliaBm().sendPublicationToBasket(getPublicationPK(pubId), kmaxMode);
     }
     SilverTrace.spy("kmelia", "KmeliaSessionController.deletePublication", getSpaceId(),
-            getComponentId(), pubId, getUserDetail().getId(), SilverTrace.SPY_ACTION_DELETE);
+        getComponentId(), pubId, getUserDetail().getId(), SilverTrace.SPY_ACTION_DELETE);
   }
 
   public synchronized void deleteClone() throws RemoteException {
@@ -1175,7 +1178,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       getKmeliaBm().updatePublication(pubDetail);
 
       SilverTrace.spy("kmelia", "KmeliaSessionController.deleteClone", getSpaceId(),
-              getComponentId(), cloneId, getUserDetail().getId(), SilverTrace.SPY_ACTION_DELETE);
+          getComponentId(), cloneId, getUserDetail().getId(), SilverTrace.SPY_ACTION_DELETE);
     }
   }
 
@@ -1186,7 +1189,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       if (!isInteger(infoId)) {
         String xmlFormShortName = infoId;
         PublicationTemplate pubTemplate = getPublicationTemplateManager().getPublicationTemplate(
-                pubDetail.getPK().getInstanceId() + ":" + xmlFormShortName);
+            pubDetail.getPK().getInstanceId() + ":" + xmlFormShortName);
 
         RecordSet set = pubTemplate.getRecordSet();
         DataRecord data = set.getRecord(pubDetail.getPK().getId());
@@ -1194,12 +1197,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       }
     } catch (PublicationTemplateException e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.removeXMLContentOfPublication()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_SUPPRIMER_LE_CONTENU_XML",
-              e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_SUPPRIMER_LE_CONTENU_XML",
+          e);
     } catch (FormException e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.removeXMLContentOfPublication()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_SUPPRIMER_LE_CONTENU_XML",
-              e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_SUPPRIMER_LE_CONTENU_XML",
+          e);
     }
   }
 
@@ -1213,7 +1216,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized void addPublicationToTopic(String pubId, String fatherId)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().addPublicationToTopic(getPublicationPK(pubId), getNodePK(fatherId), false);
   }
 
@@ -1230,7 +1233,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized void createInfoModelDetail(String pubId, String modelId, InfoDetail infos)
-          throws RemoteException {
+      throws RemoteException {
     String currentPubId = pubId;
     currentPubId = getSessionPubliOrClone().getDetail().getPK().getId();
     if (isCloneNeeded()) {
@@ -1239,8 +1242,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     if (getSessionClone() != null) {
       ModelPK modelPK = new ModelPK(modelId, getPublicationPK(currentPubId));
       getKmeliaBm().getPublicationBm().createInfoModelDetail(getPublicationPK(currentPubId),
-              modelPK,
-              infos);
+          modelPK,
+          infos);
     } else {
       getKmeliaBm().createInfoModelDetail(getPublicationPK(currentPubId), modelId, infos);
     }
@@ -1255,7 +1258,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     } else {
       // refresh de la publi de référence
       KmeliaPublication pub = getPublication(getSessionPublication().
-              getDetail().getPK().getId());
+          getDetail().getPK().getId());
       setSessionPublication(pub);
     }
   }
@@ -1280,6 +1283,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * removes links between specified publication and other publications contained in links parameter
+   *
    * @param pubId publication which you want removes the external link
    * @param links list of links to remove
    * @throws RemoteException
@@ -1294,6 +1298,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * adds links between specified publication and other publications contained in links parameter
+   *
    * @param pubId publication which you want removes the external link
    * @param links list of links to remove
    * @throws RemoteException
@@ -1309,6 +1314,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   /**
    * Get publications explicitly referenced by current publication. Only valid publications which
    * are not in bin are returned. Rights of user are checked (applications and folders).
+   *
    * @return a List of KmeliaPublication
    * @see KmeliaPublication
    * @throws RemoteException
@@ -1319,8 +1325,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     for (ForeignPK curFPK : seeAlsoList) {
       String curComponentId = curFPK.getComponentName();
       // check if user have access to application
-      if (curComponentId != null &&
-          getOrganizationController().isComponentAvailable(curComponentId, getUserId())) {
+      if (curComponentId != null && getOrganizationController().isComponentAvailable(curComponentId,
+          getUserId())) {
         authorizedSeeAlsoList.add(curFPK);
       }
     }
@@ -1341,7 +1347,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized KmeliaPublication getPublication(String pubId,
-          boolean processIndex) throws RemoteException {
+      boolean processIndex) throws RemoteException {
     PublicationPK pubPK = getPublicationPK(pubId);
     // get publication
     KmeliaPublication publication = getKmeliaBm().getPublication(pubPK);
@@ -1374,7 +1380,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized CompletePublication getCompletePublication(String pubId)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().getCompletePublication(getPublicationPK(pubId));
   }
 
@@ -1416,7 +1422,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
             filteredPublications.add(userPub);
           } else {
             if (getProfile().equals("admin") || getUserId().equals(detail.getUpdaterId())
-                    || (!getProfile().equals("user") && isCoWritingEnable())) {
+                || (!getProfile().equals("user") && isCoWritingEnable())) {
               filteredPublications.add(userPub);
             }
           }
@@ -1426,17 +1432,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
             // toutes les publications en mode brouillon sont visibles par tous, sauf les lecteurs
             // sinon, seule les publications brouillon de l'utilisateur sont visibles
             if (getUserId().equals(detail.getUpdaterId())
-                    ||
-                (isCoWritingEnable() && isDraftVisibleWithCoWriting() && !getProfile().equals(
-                    "user"))) {
+                || (isCoWritingEnable() && isDraftVisibleWithCoWriting() && !getProfile().equals(
+                "user"))) {
               filteredPublications.add(userPub);
             }
           } else {
             // si le thème est en co-rédaction, toutes les publications sont visibles par tous,
             // sauf les lecteurs
             if (getProfile().equals("admin") || getProfile().equals("publisher")
-                    || getUserId().equals(detail.getUpdaterId())
-                    || (!getProfile().equals("user") && isCoWritingEnable())) {
+                || getUserId().equals(detail.getUpdaterId())
+                || (!getProfile().equals("user") && isCoWritingEnable())) {
               filteredPublications.add(userPub);
             }
           }
@@ -1457,7 +1462,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       sort = Integer.parseInt(sortType);
     }
     List<KmeliaPublication> publications =
-            sort(getKmeliaBm().getPublicationsToValidate(getComponentId()), sort);
+        sort(getKmeliaBm().getPublicationsToValidate(getComponentId()), sort);
     sessionPublicationsList = publications;
   }
 
@@ -1466,7 +1471,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       return null;
     }
     List<KmeliaPublication> publicationsToSort = new ArrayList<KmeliaPublication>(publications);
-    
+
     int sort = sortType;
     if (isManualSortingUsed(publicationsToSort) && sort == -1) {
       // display publications according to manual order defined by admin
@@ -1476,7 +1481,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       // level
       sort = Integer.parseInt(defaultSortValue);
     }
-    
+
     switch (sort) {
       case 0:
         Collections.sort(publicationsToSort, new PubliAuthorComparatorAsc());
@@ -1511,7 +1516,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
     return publicationsToSort;
   }
-  
+
   private boolean isManualSortingUsed(List<KmeliaPublication> publications) {
     for (KmeliaPublication publication : publications) {
       if (publication.getDetail().getExplicitRank() > 0) {
@@ -1527,7 +1532,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       boolean swapped = false;
       for (int j = 0; j < i; j++) {
         if (pubs[j].getDetail().getName(getCurrentLanguage()).compareToIgnoreCase(
-                pubs[j + 1].getDetail().getName(getCurrentLanguage())) > 0) {
+            pubs[j + 1].getDetail().getName(getCurrentLanguage())) > 0) {
           KmeliaPublication T = pubs[j];
           pubs[j] = pubs[j + 1];
           pubs[j + 1] = T;
@@ -1578,33 +1583,35 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Get all publications sorted
+   *
    * @param sortedBy (example: pubName asc)
    * @return Collection of Publications
    * @throws RemoteException
    */
   public Collection<PublicationDetail> getAllPublications(String sortedBy) throws RemoteException {
     String publication_default_sorting =
-            getSettings().getString("publication_defaultsorting", "pubId desc");
+        getSettings().getString("publication_defaultsorting", "pubId desc");
     if (StringUtil.isDefined(sortedBy)) {
       publication_default_sorting = sortedBy;
     }
     return getKmeliaBm().getPublicationBm().getAllPublications(
-            new PublicationPK("useless", getComponentId()), publication_default_sorting);
+        new PublicationPK("useless", getComponentId()), publication_default_sorting);
   }
 
   public Collection<PublicationDetail> getAllPublicationsByTopic(PublicationPK pubPK,
-          List<String> fatherIds)
-          throws RemoteException {
+      List<String> fatherIds)
+      throws RemoteException {
     Collection<PublicationDetail> result = getKmeliaBm().getPublicationBm().
-            getDetailsByFatherIdsAndStatus((ArrayList<String>) fatherIds, pubPK,
-                "P.pubUpdateDate desc, P.pubId desc", PublicationDetail.VALID);
+        getDetailsByFatherIdsAndStatus((ArrayList<String>) fatherIds, pubPK,
+        "P.pubUpdateDate desc, P.pubId desc", PublicationDetail.VALID);
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllPublicationsByTopic()",
-            "root.MSG_PARAM_VALUE", "publis=" + result.toString());
+        "root.MSG_PARAM_VALUE", "publis=" + result.toString());
     return result;
   }
 
   /**
    * Get all visible publications
+   *
    * @return List of WAAtributeValuePair (Id and InstanceId)
    * @throws RemoteException
    */
@@ -1612,21 +1619,21 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     List<WAAttributeValuePair> allVisiblesPublications = new ArrayList<WAAttributeValuePair>();
     Collection<PublicationDetail> allPublications = getAllPublications();
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublications()",
-            "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
+        "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
     for (PublicationDetail pubDetail : allPublications) {
       if (pubDetail.getStatus().equals(PublicationDetail.VALID)) {
         SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublications()",
-                "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
-                    + pubDetail.getInstanceId());
+            "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
+            + pubDetail.getInstanceId());
         allVisiblesPublications.add(new WAAttributeValuePair(pubDetail.getId(), pubDetail.
-                getInstanceId()));
+            getInstanceId()));
       }
     }
     return allVisiblesPublications;
   }
 
   public List<WAAttributeValuePair> getAllVisiblePublicationsByTopic(String topicId)
-          throws RemoteException {
+      throws RemoteException {
     List<WAAttributeValuePair> allVisiblesPublications = new ArrayList<WAAttributeValuePair>();
     // récupérer la liste des sous thèmes de topicId
     List<String> fatherIds = new ArrayList<String>();
@@ -1638,19 +1645,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     // création de pubPK
     PublicationPK pubPK = getPublicationPK("useless");
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublicationsByTopic()",
-            "root.MSG_PARAM_VALUE", "fatherIds =" + fatherIds.toString());
+        "root.MSG_PARAM_VALUE", "fatherIds =" + fatherIds.toString());
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublicationsByTopic()",
-            "root.MSG_PARAM_VALUE", "pubPK =" + pubPK.toString());
+        "root.MSG_PARAM_VALUE", "pubPK =" + pubPK.toString());
     Collection<PublicationDetail> allPublications = getAllPublicationsByTopic(pubPK, fatherIds);
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublicationsByTopic()",
-            "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
+        "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
     for (PublicationDetail pubDetail : allPublications) {
       if (pubDetail.getStatus().equals(PublicationDetail.VALID)) {
         SilverTrace.info("kmelia", "KmeliaSessionController.getAllVisiblePublicationsByTopic()",
-                "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
-                    + pubDetail.getInstanceId());
+            "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
+            + pubDetail.getInstanceId());
         allVisiblesPublications.add(new WAAttributeValuePair(pubDetail.getId(), pubDetail.
-                getInstanceId()));
+            getInstanceId()));
       }
     }
     return allVisiblesPublications;
@@ -1660,14 +1667,14 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     List<WAAttributeValuePair> allPublicationsIds = new ArrayList<WAAttributeValuePair>();
     Collection<PublicationDetail> allPublications = getAllPublications("pubName asc");
     SilverTrace.info("kmelia", "KmeliaSessionController.getAllPublicationsIds()",
-            "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
+        "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
     for (PublicationDetail pubDetail : allPublications) {
       if (pubDetail.getStatus().equals(PublicationDetail.VALID)) {
         SilverTrace.info("kmelia", "KmeliaSessionController.getAllPublicationsIds()",
-                "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
-                    + pubDetail.getInstanceId());
+            "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
+            + pubDetail.getInstanceId());
         allPublicationsIds.add(
-                new WAAttributeValuePair(pubDetail.getId(), pubDetail.getInstanceId()));
+            new WAAttributeValuePair(pubDetail.getId(), pubDetail.getInstanceId()));
       }
     }
     return allPublicationsIds;
@@ -1693,6 +1700,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   /**
    * Si le mode brouillon est activé et que le classement PDC est possible alors une publication ne
    * peut sortir du mode brouillon que si elle est classée sur le PDC
+   *
    * @return true si le PDC n'est pas utilisé ou si aucun axe n'est utilisé par le composant ou si
    * la publication est classée sur le PDC
    * @throws RemoteException
@@ -1708,7 +1716,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         return true;
       } else {
         String pubId =
-                getSessionPublication().getDetail().getPK().getId();
+            getSessionPublication().getDetail().getPK().getId();
         return isPublicationClassifiedOnPDC(pubId);
       }
     }
@@ -1720,7 +1728,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * @throws RemoteException
    */
   public synchronized Collection<KmeliaPublication> getPublications(List<ForeignPK> links)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().getPublications(links, getUserId(), true);
   }
 
@@ -1730,49 +1738,49 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public synchronized boolean validatePublication(String publicationId) throws RemoteException {
     return getKmeliaBm().validatePublication(getPublicationPK(publicationId), getUserId(),
-            getValidationType(), false);
+        getValidationType(), false);
   }
 
   public synchronized boolean forcePublicationValidation(String publicationId)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().validatePublication(getPublicationPK(publicationId), getUserId(),
-            getValidationType(), true);
+        getValidationType(), true);
   }
 
   public synchronized void unvalidatePublication(String publicationId, String refusalMotive)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().unvalidatePublication(getPublicationPK(publicationId), getUserId(),
-            refusalMotive, getValidationType());
+        refusalMotive, getValidationType());
   }
 
   public synchronized void suspendPublication(String publicationId, String defermentMotive)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().suspendPublication(getPublicationPK(publicationId), defermentMotive, getUserId());
   }
 
   public List<ValidationStep> getValidationSteps() throws RemoteException {
     List<ValidationStep> steps =
-            getPublicationBm().getValidationSteps(
-                getSessionPubliOrClone().getDetail().getPK());
+        getPublicationBm().getValidationSteps(
+        getSessionPubliOrClone().getDetail().getPK());
 
     // Get users who have already validate this publication
     List<String> validators = new ArrayList<String>();
     for (ValidationStep step : steps) {
       step.setUserFullName(getOrganizationController().getUserDetail(step.getUserId()).
-              getDisplayedName());
+          getDisplayedName());
       validators.add(step.getUserId());
     }
 
     List<String> allValidators =
-            getKmeliaBm().getAllValidators(
-                getSessionPubliOrClone().getDetail().getPK(),
-                getValidationType());
+        getKmeliaBm().getAllValidators(
+        getSessionPubliOrClone().getDetail().getPK(),
+        getValidationType());
 
     for (String allValidator : allValidators) {
       if (!validators.contains(allValidator)) {
         ValidationStep step = new ValidationStep();
         step.setUserFullName(getOrganizationController().getUserDetail(
-                allValidator).getDisplayedName());
+            allValidator).getDisplayedName());
         steps.add(step);
       }
     }
@@ -1783,7 +1791,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public ValidationStep getValidationStep() throws RemoteException {
     if (getValidationType() == KmeliaHelper.VALIDATION_TARGET_N) {
       return getPublicationBm().getValidationStepByUser(
-              getSessionPubliOrClone().getDetail().getPK(), getUserId());
+          getSessionPubliOrClone().getDetail().getPK(), getUserId());
     }
 
     return null;
@@ -1791,16 +1799,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public synchronized void draftOutPublication() throws RemoteException {
     SilverTrace.info("kmelia", "KmeliaSessionController.draftOutPublication()",
-            "root.MSG_GEN_ENTER_METHOD", "getSessionPublication().getPublication() = "
-                + getSessionPublication().getCompleteDetail());
+        "root.MSG_GEN_ENTER_METHOD", "getSessionPublication().getPublication() = "
+        + getSessionPublication().getCompleteDetail());
     if (isKmaxMode) {
       getKmeliaBm().draftOutPublication(
-              getSessionPublication().getDetail().getPK(), null,
-              getProfile());
+          getSessionPublication().getDetail().getPK(), null,
+          getProfile());
     } else {
       getKmeliaBm().draftOutPublication(
-              getSessionPublication().getDetail().getPK(),
-              getSessionTopic().getNodePK(), getProfile());
+          getSessionPublication().getDetail().getPK(),
+          getSessionTopic().getNodePK(), getProfile());
     }
 
     if (!KmeliaHelper.ROLE_WRITER.equals(getUserTopicProfile())) {
@@ -1811,6 +1819,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Change publication status from any state to draft
+   *
    * @since 3.0
    */
   public synchronized void draftInPublication() throws RemoteException {
@@ -1819,64 +1828,66 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       // getKmeliaBm().draftInPublication(getPublicationPK(cloneId));
     } else {
       getKmeliaBm().draftInPublication(
-              getSessionPublication().getDetail().getPK(), getUserId());
+          getSessionPublication().getDetail().getPK(), getUserId());
     }
     refreshSessionPubliAndClone();
   }
 
   private synchronized NotificationMetaData getAlertNotificationMetaData(String pubId)
-          throws RemoteException {
+      throws RemoteException {
     NotificationMetaData metaData = null;
     if (isKmaxMode) {
       metaData =
-              getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), null,
-                  getUserDetail().getDisplayedName());
+          getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), null,
+          getUserDetail().getDisplayedName());
     } else {
       metaData =
-              getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId),
-                  getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
+          getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId),
+          getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
     }
     metaData.setSender(getUserId());
     return metaData;
   }
 
   private synchronized NotificationMetaData getAlertNotificationMetaData(String pubId,
-          String attachmentOrDocumentId, boolean isVersionning)
-          throws RemoteException {
+      String attachmentOrDocumentId, boolean isVersionning)
+      throws RemoteException {
     NotificationMetaData metaData = null;
     if (isVersionning) {
       DocumentPK documentPk =
           new DocumentPK(Integer.parseInt(attachmentOrDocumentId), getSpaceId(),
-              getComponentId());
+          getComponentId());
       if (isKmaxMode) {
         metaData =
-                getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), documentPk,
-                    null,
-                    getUserDetail().getDisplayedName());
+            getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), documentPk,
+            null,
+            getUserDetail().getDisplayedName());
       } else {
         metaData =
-                getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), documentPk,
-                    getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
+            getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), documentPk,
+            getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
       }
     } else {
       AttachmentPK attachmentPk = new AttachmentPK(attachmentOrDocumentId, getSpaceId(),
-              getComponentId());
+          getComponentId());
       if (isKmaxMode) {
         metaData =
-                getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), attachmentPk,
-                    null,
-                    getUserDetail().getDisplayedName());
+            getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), attachmentPk,
+            null,
+            getUserDetail().getDisplayedName());
       } else {
         metaData =
-                getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), attachmentPk,
-                    getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
+            getKmeliaBm().getAlertNotificationMetaData(getPublicationPK(pubId), attachmentPk,
+            getSessionTopic().getNodePK(), getUserDetail().getDisplayedName());
       }
     }
     metaData.setSender(getUserId());
     return metaData;
   }
 
-  /**************************************************************************************/
+  /**
+   * ***********************************************************************************
+   */
   /* KMELIA - Reindexation */
   /**
    * **********************************************************************************
@@ -1890,19 +1901,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public Map<String, String> pasteFiles(PublicationPK pubPKFrom, String pubId)
-          throws RemoteException {
+      throws RemoteException {
     Map<String, String> fileIds = new HashMap<String, String>();
 
     boolean fromCompoVersion =
-            "yes".equals(getOrganizationController().getComponentParameterValue(
-                pubPKFrom.getInstanceId(), "versionControl"));
+        "yes".equals(getOrganizationController().getComponentParameterValue(
+        pubPKFrom.getInstanceId(), "versionControl"));
 
     if (!fromCompoVersion && !isVersionControlled()) {
       // attachments --> attachments
       // paste attachments
       fileIds =
-              AttachmentController.copyAttachmentByCustomerPKAndContext(pubPKFrom,
-                  getPublicationPK(pubId), "Images");
+          AttachmentController.copyAttachmentByCustomerPKAndContext(pubPKFrom,
+          getPublicationPK(pubId), "Images");
     } else if (fromCompoVersion && !isVersionControlled()) {
       // versioning --> attachments
       // Last public versions becomes the new attachment
@@ -1920,21 +1931,23 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     return fileIds;
   }
 
-  /******************************************************************************************/
+  /**
+   * ***************************************************************************************
+   */
   /* KMELIA - Copier/coller des documents versionnés */
   /**
    * **************************************************************************************
    */
   public void pasteDocuments(PublicationPK pubPKFrom, String pubId) throws RemoteException {
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocuments()",
-            "root.MSG_GEN_ENTER_METHOD",
-            "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
+        "root.MSG_GEN_ENTER_METHOD",
+        "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
 
     // paste versioning documents attached to publication
     List<Document> documents = getVersioningBm().getDocuments(new ForeignPK(pubPKFrom));
 
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocuments()",
-            "root.MSG_GEN_PARAM_VALUE", documents.size() + " to paste");
+        "root.MSG_GEN_PARAM_VALUE", documents.size() + " to paste");
 
     if (documents.isEmpty()) {
       return;
@@ -1952,7 +1965,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     // paste each document
     for (Document document : documents) {
       SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocuments()",
-              "root.MSG_GEN_PARAM_VALUE", "document name = " + document.getName());
+          "root.MSG_GEN_PARAM_VALUE", "document name = " + document.getName());
 
       // retrieve all versions of the document (from last version to first version)
       List<DocumentVersion> versions = getVersioningBm().getDocumentVersions(document.getPk());
@@ -1965,7 +1978,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
       if (pathFrom == null) {
         pathFrom = versioningUtil.createPath(document.getPk().getSpaceId(),
-                document.getPk().getInstanceId(), null);
+            document.getPk().getInstanceId(), null);
       }
 
       // change some data to paste
@@ -1996,7 +2009,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         version.setDocumentPK(documentPK);
         version.setInstanceId(getComponentId());
         SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocuments()",
-                "root.MSG_GEN_PARAM_VALUE", "paste version = " + version.getLogicalName());
+            "root.MSG_GEN_PARAM_VALUE", "paste version = " + version.getLogicalName());
 
         // paste file on fileserver
         newVersionFile = pasteVersionFile(version.getPhysicalName(), pathFrom, pathTo);
@@ -2016,14 +2029,14 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     workingProfiles.add("publisher");
     workingProfiles.add("admin");
     String[] userIds =
-            getOrganizationController().getUsersIdsByRoleNames(getComponentId(), workingProfiles);
+        getOrganizationController().getUsersIdsByRoleNames(getComponentId(), workingProfiles);
 
     String userId = null;
     Worker worker = null;
     for (int u = 0; u < userIds.length; u++) {
       userId = userIds[u];
       worker = new Worker(Integer.parseInt(userId), -1, u, false, true, getComponentId(), "U",
-              false, true, 0);
+          false, true, 0);
       workers.add(worker);
     }
 
@@ -2031,16 +2044,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public void pasteDocumentsAsAttachments(PublicationPK pubPKFrom, String pubId)
-          throws RemoteException {
+      throws RemoteException {
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocumentsAsAttachments()",
-            "root.MSG_GEN_ENTER_METHOD",
-            "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
+        "root.MSG_GEN_ENTER_METHOD",
+        "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
 
     // paste versioning documents attached to publication
     List<Document> documents = getVersioningBm().getDocuments(new ForeignPK(pubPKFrom));
 
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocumentsAsAttachments()",
-            "root.MSG_GEN_PARAM_VALUE", documents.size() + " documents to paste");
+        "root.MSG_GEN_PARAM_VALUE", documents.size() + " documents to paste");
 
     if (documents.isEmpty()) {
       return;
@@ -2054,15 +2067,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     for (Document document : documents) {
 
       SilverTrace.info("kmelia", "KmeliaSessionController.pasteDocumentsAsAttachments()",
-              "root.MSG_GEN_PARAM_VALUE", "document name = " + document.getName());
+          "root.MSG_GEN_PARAM_VALUE", "document name = " + document.getName());
 
       // retrieve last public versions of the document
       DocumentVersion version = getVersioningBm().getLastPublicDocumentVersion(document.getPk());
 
       if (pathFrom == null) {
         pathFrom =
-                versioningUtil.createPath(document.getPk().getSpaceId(),
-                    document.getPk().getInstanceId(), null);
+            versioningUtil.createPath(document.getPk().getSpaceId(),
+            document.getPk().getInstanceId(), null);
       }
 
       if (pathTo == null) {
@@ -2078,13 +2091,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           // create the attachment in DB
           // Do not index it cause made by the updatePublication call later
           AttachmentDetail attachment =
-                  new AttachmentDetail(new AttachmentPK("unknown", getComponentId()),
-                      newVersionFile,
-                      version.getLogicalName(), "", version.getMimeType(), version.getSize(),
-                      "Images",
-                      new Date(), getPublicationPK(pubId), document.getName(),
-                      document.getDescription(),
-                      0);
+              new AttachmentDetail(new AttachmentPK("unknown", getComponentId()),
+              newVersionFile,
+              version.getLogicalName(), "", version.getMimeType(), version.getSize(),
+              "Images",
+              new Date(), getPublicationPK(pubId), document.getName(),
+              document.getDescription(),
+              0);
           AttachmentController.createAttachment(attachment, false);
         }
       }
@@ -2092,16 +2105,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public void pasteAttachmentsAsDocuments(PublicationPK pubPKFrom, String pubId)
-          throws RemoteException {
+      throws RemoteException {
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteAttachmentsAsDocuments()",
-            "root.MSG_GEN_ENTER_METHOD",
-            "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
+        "root.MSG_GEN_ENTER_METHOD",
+        "pubPKFrom = " + pubPKFrom.toString() + ", pubId = " + pubId);
 
     List<AttachmentDetail> attachments =
-            AttachmentController.searchAttachmentByPKAndContext(pubPKFrom, "Images");
+        AttachmentController.searchAttachmentByPKAndContext(pubPKFrom, "Images");
 
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteAttachmentsAsDocuments()",
-            "root.MSG_GEN_PARAM_VALUE", attachments.size() + " attachments to paste");
+        "root.MSG_GEN_PARAM_VALUE", attachments.size() + " attachments to paste");
 
     if (attachments.isEmpty()) {
       return;
@@ -2117,7 +2130,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     for (AttachmentDetail attachment : attachments) {
 
       SilverTrace.info("kmelia", "KmeliaSessionController.pasteAttachmentsAsDocuments()",
-              "root.MSG_GEN_PARAM_VALUE", "attachment name = " + attachment.getLogicalName());
+          "root.MSG_GEN_PARAM_VALUE", "attachment name = " + attachment.getLogicalName());
 
       if (pathTo == null) {
         pathTo = versioningUtil.createPath(getSpaceId(), getComponentId(), null);
@@ -2133,19 +2146,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       if (newPhysicalName != null) {
         // Document creation
         Document document =
-                new Document(new DocumentPK(-1, "useless", getComponentId()),
-                    getPublicationPK(pubId),
-                    attachment.getLogicalName(), attachment.getInfo(), 0,
-                    Integer.parseInt(getUserId()), new Date(), "", getComponentId(),
-                    (ArrayList<Worker>) workers, new ArrayList<Reader>(), 0, 0);
+            new Document(new DocumentPK(-1, "useless", getComponentId()),
+            getPublicationPK(pubId),
+            attachment.getLogicalName(), attachment.getInfo(), 0,
+            Integer.parseInt(getUserId()), new Date(), "", getComponentId(),
+            (ArrayList<Worker>) workers, new ArrayList<Reader>(), 0, 0);
 
         // Version creation
         DocumentVersion version =
-                new DocumentVersion(null, null, 1, 0, Integer.parseInt(getUserId()), new Date(),
-                    "",
-                    DocumentVersion.TYPE_PUBLIC_VERSION, DocumentVersion.STATUS_VALIDATION_NOT_REQ,
-                    newPhysicalName, attachment.getLogicalName(), attachment.getType(), new Long(
-                        attachment.getSize()).intValue(), getComponentId());
+            new DocumentVersion(null, null, 1, 0, Integer.parseInt(getUserId()), new Date(),
+            "",
+            DocumentVersion.TYPE_PUBLIC_VERSION, DocumentVersion.STATUS_VALIDATION_NOT_REQ,
+            newPhysicalName, attachment.getLogicalName(), attachment.getType(), new Long(
+            attachment.getSize()).intValue(), getComponentId());
 
         getVersioningBm().createDocument(document, version);
       }
@@ -2154,7 +2167,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   private String pasteVersionFile(String fileNameFrom, String from, String to) {
     SilverTrace.info("kmelia", "KmeliaSessionController.pasteVersionFile()",
-            "root.MSG_GEN_ENTER_METHOD", "version = " + fileNameFrom);
+        "root.MSG_GEN_ENTER_METHOD", "version = " + fileNameFrom);
 
     if (!fileNameFrom.equals("dummy")) {
       // we have to rename pasted file (in case the copy/paste append in the same instance)
@@ -2166,7 +2179,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         FileRepositoryManager.copyFile(from + fileNameFrom, to + fileNameTo);
       } catch (Exception e) {
         SilverTrace.error("kmelia", "KmeliaSessionController.pasteVersionFile()",
-                "root.EX_FILE_NOT_FOUND", from + fileNameFrom);
+            "root.EX_FILE_NOT_FOUND", from + fileNameFrom);
         return null;
       }
       return fileNameTo;
@@ -2177,6 +2190,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * adds links between specified publication and other publications contained in links parameter
+   *
    * @param pubId publication which you want removes the external link
    * @param links list of links to remove
    * @return the number of links created
@@ -2232,13 +2246,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public void setSessionPublicationsList(List<KmeliaPublication> publications) {
     this.sessionPublicationsList = (publications == null ? null
-            : new ArrayList<KmeliaPublication>(publications));
+        : new ArrayList<KmeliaPublication>(publications));
     orderPubs();
   }
 
   public void setSessionCombination(List<String> combination) {
     this.sessionCombination = (combination == null ? null
-            : new ArrayList<String>(combination));
+        : new ArrayList<String>(combination));
   }
 
   public void setSessionTimeCriteria(String timeCriteria) {
@@ -2317,16 +2331,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public String initUPToSelectValidator(String pubId) {
     String m_context =
-            GeneralPropertiesManager.getGeneralResourceLocator().getString("ApplicationURL");
+        GeneralPropertiesManager.getGeneralResourceLocator().getString("ApplicationURL");
     PairObject hostComponentName = new PairObject(getComponentLabel(), "");
     PairObject[] hostPath = new PairObject[1];
     hostPath[0] = new PairObject(getString("kmelia.SelectValidator"), "");
     String hostUrl =
-            m_context + URLManager.getURL("useless", getComponentId()) + "SetValidator?PubId="
-                + pubId;
+        m_context + URLManager.getURL("useless", getComponentId()) + "SetValidator?PubId="
+        + pubId;
     String cancelUrl =
-            m_context + URLManager.getURL("useless", getComponentId()) + "SetValidator?PubId="
-                + pubId;
+        m_context + URLManager.getURL("useless", getComponentId()) + "SetValidator?PubId="
+        + pubId;
 
     Selection sel = getSelection();
     sel.resetAll();
@@ -2359,25 +2373,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     profiles.add("admin");
 
     boolean haveRights =
-            isRightsOnTopicsEnabled() && getSessionTopic().getNodeDetail().haveRights();
+        isRightsOnTopicsEnabled() && getSessionTopic().getNodeDetail().haveRights();
     if (haveRights) {
       int rightsDependsOn = getSessionTopic().getNodeDetail().getRightsDependsOn();
-      List<ProfileInst> profileInsts =
-              getAdmin().getProfilesByObject(Integer.toString(rightsDependsOn),
-                  ObjectType.NODE.getCode(),
-                  getComponentId());
-      if (profileInsts != null) {
-        for (ProfileInst profileInst : profileInsts) {
-          if (profileInst != null) {
-            if (profiles.contains(profileInst.getName())) {
-              sug.addProfileId(profileInst.getId());
-            }
-          }
-        }
-      }
-    } else {
-      sug.setProfileNames((ArrayList<String>) profiles);
+      sug.setObjectId(ObjectType.NODE.getCode() + Integer.toString(rightsDependsOn));
     }
+    sug.setProfileNames((ArrayList<String>) profiles);
 
     sel.setExtraParams(sug);
 
@@ -2406,22 +2407,22 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public String initAlertUserAttachment(String attachmentOrDocumentId, boolean isVersionning)
-          throws RemoteException {
+      throws RemoteException {
 
     initAlertUser();
 
     AlertUser sel = getAlertUser();
     String pubId = getSessionPublication().getDetail().getPK().getId();
     sel.setNotificationMetaData(getAlertNotificationMetaData(pubId, attachmentOrDocumentId,
-            isVersionning));
+        isVersionning));
     return AlertUser.getAlertUserURL();
   }
 
   public void toRecoverUserId() {
     Selection sel = getSelection();
     idSelectedUser =
-            SelectionUsersGroups.getDistinctUserIds(sel.getSelectedElements(), sel
-                .getSelectedSets());
+        SelectionUsersGroups.getDistinctUserIds(sel.getSelectedElements(), sel
+        .getSelectedSets());
   }
 
   public boolean isVersionControlled() {
@@ -2432,8 +2433,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public boolean isVersionControlled(String anotherComponentId) {
     String strVersionControlled =
-            getOrganizationController().getComponentParameterValue(anotherComponentId,
-                "versionControl");
+        getOrganizationController().getComponentParameterValue(anotherComponentId,
+        "versionControl");
     return ((strVersionControlled != null) && !("").equals(strVersionControlled) && !("no")
         .equals(strVersionControlled.toLowerCase()));
   }
@@ -2445,7 +2446,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    */
   public boolean isWriterApproval(String pubId) throws RemoteException {
     List<Document> documents =
-            getVersioningBm().getDocuments((new ForeignPK(pubId, getComponentId())));
+        getVersioningBm().getDocuments((new ForeignPK(pubId, getComponentId())));
     for (Document document : documents) {
       List<Worker> writers = document.getWorkList();
       for (Worker user : writers) {
@@ -2473,12 +2474,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public boolean isValidationTabVisible() {
     boolean tabVisible =
-            PublicationDetail.TO_VALIDATE.equalsIgnoreCase(getSessionPubliOrClone().getDetail().
-                getStatus());
+        PublicationDetail.TO_VALIDATE.equalsIgnoreCase(getSessionPubliOrClone().getDetail().
+        getStatus());
 
     return tabVisible
-            && (getValidationType() == KmeliaHelper.VALIDATION_COLLEGIATE || getValidationType()
-            == KmeliaHelper.VALIDATION_TARGET_N);
+        && (getValidationType() == KmeliaHelper.VALIDATION_COLLEGIATE || getValidationType()
+        == KmeliaHelper.VALIDATION_TARGET_N);
   }
 
   public int getValidationType() {
@@ -2508,7 +2509,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       silverObjectId = getKmeliaBm().getSilverObjectId(getPublicationPK(objectId));
     } catch (Exception e) {
       SilverTrace.error("kmelia", "KmeliaSessionController.getSilverObjectId()",
-              "root.EX_CANT_GET_LANGUAGE_RESOURCE", "objectId=" + objectId, e);
+          "root.EX_CANT_GET_LANGUAGE_RESOURCE", "objectId=" + objectId, e);
     }
     return silverObjectId;
   }
@@ -2535,11 +2536,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       try {
         int silverObjectId = getKmeliaBm().getSilverObjectId(getPublicationPK(pubId));
         List<ClassifyPosition> positions = getPdcBm().getPositions(silverObjectId,
-                getComponentId());
+            getComponentId());
         return (positions.size() > 0);
       } catch (Exception e) {
         throw new KmeliaRuntimeException("KmeliaSessionController.isPublicationClassifiedOnPDC()",
-                SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
+            SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
       }
     }
     return false;
@@ -2547,20 +2548,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public boolean isCurrentPublicationHaveContent() throws WysiwygException {
     return (getSessionPublication().getCompleteDetail().getModelDetail() != null
-            ||
-        StringUtil.isDefined(WysiwygController.load(getComponentId(), getSessionPublication().
-            getId(), getCurrentLanguage())) || !isInteger(getSessionPublication()
+        || StringUtil.isDefined(WysiwygController.load(getComponentId(), getSessionPublication().
+        getId(), getCurrentLanguage())) || !isInteger(getSessionPublication()
         .getCompleteDetail().
-            getPublicationDetail().getInfoId()));
+        getPublicationDetail().getInfoId()));
   }
 
   public void pastePdcPositions(PublicationPK fromPK, String toPubId) throws RemoteException,
-          PdcException {
+      PdcException {
     int fromSilverObjectId = getKmeliaBm().getSilverObjectId(fromPK);
     int toSilverObjectId = getKmeliaBm().getSilverObjectId(getPublicationPK(toPubId));
 
     getPdcBm().copyPositions(fromSilverObjectId, fromPK.getInstanceId(), toSilverObjectId,
-            getComponentId());
+        getComponentId());
   }
 
   public boolean isPDCClassifyingMandatory() {
@@ -2568,7 +2568,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       return getPdcBm().isClassifyingMandatory(getComponentId());
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.isPDCClassifyingMandatory()",
-              SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
     }
   }
 
@@ -2586,11 +2586,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     NodeBm nodeBm = null;
     try {
       NodeBmHome nodeBmHome =
-              EJBUtilitaire.getEJBObjectRef(JNDINames.NODEBM_EJBHOME, NodeBmHome.class);
+          EJBUtilitaire.getEJBObjectRef(JNDINames.NODEBM_EJBHOME, NodeBmHome.class);
       nodeBm = nodeBmHome.create();
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.getNodeBm()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_FABRIQUER_NODEBM_HOME", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_FABRIQUER_NODEBM_HOME", e);
     }
     return nodeBm;
   }
@@ -2599,12 +2599,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     PublicationBm pubBm = null;
     try {
       PublicationBmHome pubBmHome =
-              EJBUtilitaire.getEJBObjectRef(JNDINames.PUBLICATIONBM_EJBHOME,
-                  PublicationBmHome.class);
+          EJBUtilitaire.getEJBObjectRef(JNDINames.PUBLICATIONBM_EJBHOME,
+          PublicationBmHome.class);
       pubBm = pubBmHome.create();
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.getPublicationBm()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_FABRIQUER_NODEBM_HOME", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DE_FABRIQUER_NODEBM_HOME", e);
     }
     return pubBm;
   }
@@ -2646,11 +2646,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * @return list of publications imported
    */
   public List<PublicationDetail> importFile(File fileUploaded, String fileType, String topicId,
-          String importMode, boolean draftMode, int versionType) {
+      String importMode, boolean draftMode, int versionType) {
     SilverTrace.debug("kmelia", "KmeliaSessionController.importFile()",
-            "root.MSG_GEN_ENTER_METHOD", "fileUploaded = " + fileUploaded.getAbsolutePath()
-                + " fileType=" + fileType + " importMode=" + importMode + " draftMode=" + draftMode
-                + " versionType=" + versionType);
+        "root.MSG_GEN_ENTER_METHOD", "fileUploaded = " + fileUploaded.getAbsolutePath()
+        + " fileType=" + fileType + " importMode=" + importMode + " draftMode=" + draftMode
+        + " versionType=" + versionType);
     List<PublicationDetail> publicationDetails = null;
     FileImport fileImport = new FileImport();
     fileImport.setFileUploaded(fileUploaded);
@@ -2666,10 +2666,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     if (UNITARY_IMPORT_MODE.equals(importMode)) {
       publicationDetails = fileImport.importFile();
     } else if (MASSIVE_IMPORT_MODE_ONE_PUBLICATION.equals(importMode)
-            && FileUtil.isArchive(fileUploaded.getName())) {
+        && FileUtil.isArchive(fileUploaded.getName())) {
       publicationDetails = fileImport.importFiles();
     } else if (MASSIVE_IMPORT_MODE_MULTI_PUBLICATIONS.equals(importMode)
-            && FileUtil.isArchive(fileUploaded.getName())) {
+        && FileUtil.isArchive(fileUploaded.getName())) {
       publicationDetails = fileImport.importFilesMultiPubli();
     }
     return publicationDetails;
@@ -2685,6 +2685,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Return if publication is in the basket
+   *
    * @param pubId
    * @return true or false
    */
@@ -2693,12 +2694,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     try {
       Collection<Collection<NodeDetail>> pathList = getPathList(pk);
       SilverTrace.debug("kmelia", "KmeliaSessionController.isPublicationDeleted()",
-              "root.MSG_GEN_PARAM_VALUE", "pathList = " + pathList);
+          "root.MSG_GEN_PARAM_VALUE", "pathList = " + pathList);
       if (pathList.size() == 1) {
         for (Collection<NodeDetail> path : pathList) {
           for (NodeDetail nodeInPath : path) {
             SilverTrace.debug("kmelia", "KmeliaSessionController.isPublicationDeleted()",
-                    "root.MSG_GEN_PARAM_VALUE", "nodeInPath = " + nodeInPath);
+                "root.MSG_GEN_PARAM_VALUE", "nodeInPath = " + nodeInPath);
             if (nodeInPath.getNodePK().getId().equals(NodePK.BIN_NODE_ID)) {
               isPublicationDeleted = true;
             }
@@ -2707,10 +2708,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       }
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.isPublicationDeleted()",
-              SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
     }
     SilverTrace.debug("kmelia", "KmeliaSessionController.isPublicationDeleted()",
-            "root.MSG_GEN_PARAM_VALUE", "isPublicationDeleted=" + isPublicationDeleted);
+        "root.MSG_GEN_PARAM_VALUE", "isPublicationDeleted=" + isPublicationDeleted);
     return isPublicationDeleted;
   }
 
@@ -2723,7 +2724,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       getKmeliaBm().addModelUsed(models, getComponentId(), objectId);
     } catch (RemoteException e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.addModelUsed()",
-              SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
     }
   }
 
@@ -2737,7 +2738,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       result = getKmeliaBm().getModelUsed(getComponentId(), objectId);
     } catch (RemoteException e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.getModelUsed()",
-              SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", e);
     }
     return result;
   }
@@ -2768,6 +2769,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Parameter for time Axis visibility
+   *
    * @return
    */
   public boolean isTimeAxisUsed() {
@@ -2776,12 +2778,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Parameter for fields visibility of the publication
+   *
    * @return
    */
   public boolean isFieldDescriptionVisible() {
     String paramValue = getComponentParameterValue("useDescription");
     return "1".equalsIgnoreCase(paramValue) || "2".equalsIgnoreCase(paramValue)
-            || "".equals(paramValue);
+        || "".equals(paramValue);
   }
 
   public boolean isFieldDescriptionMandatory() {
@@ -2810,8 +2813,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public List<Integer> getTimeAxisKeys() {
     if (this.timeAxis == null) {
       ResourceLocator timeSettings =
-              new ResourceLocator("com.stratelia.webactiv.kmelia.multilang.timeAxisBundle",
-                  getLanguage());
+          new ResourceLocator("com.stratelia.webactiv.kmelia.multilang.timeAxisBundle",
+          getLanguage());
       Enumeration<String> keys = timeSettings.getKeys();
       List<Integer> orderKeys = new ArrayList<Integer>();
       Integer key = null;
@@ -2852,18 +2855,18 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized List<KmeliaPublication> search(List<String> combination)
-          throws RemoteException {
+      throws RemoteException {
     this.sessionPublicationsList =
-            new ArrayList<KmeliaPublication>(getKmeliaBm().search(combination, getComponentId()));
+        new ArrayList<KmeliaPublication>(getKmeliaBm().search(combination, getComponentId()));
     applyVisibilityFilter();
     return getSessionPublicationsList();
   }
 
   public synchronized List<KmeliaPublication> search(List<String> combination, int nbDays)
-          throws RemoteException {
+      throws RemoteException {
     this.sessionPublicationsList =
-            new ArrayList<KmeliaPublication>(getKmeliaBm().search(combination, nbDays,
-                getComponentId()));
+        new ArrayList<KmeliaPublication>(getKmeliaBm().search(combination, nbDays,
+        getComponentId()));
     applyVisibilityFilter();
     return getSessionPublicationsList();
   }
@@ -2873,12 +2876,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public synchronized NodePK addPosition(String fatherId, NodeDetail position)
-          throws RemoteException {
+      throws RemoteException {
     SilverTrace.info(
-            "kmax",
-            "KmeliaSessionController.addPosition()",
-            "root.MSG_GEN_PARAM_VALUE",
-            "fatherId = " + fatherId + " And position = " + position.toString());
+        "kmax",
+        "KmeliaSessionController.addPosition()",
+        "root.MSG_GEN_PARAM_VALUE",
+        "fatherId = " + fatherId + " And position = " + position.toString());
     return getKmeliaBm().addPosition(fatherId, position, getComponentId(), getUserId());
   }
 
@@ -2901,27 +2904,28 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * **********************************************************************************
    */
   public synchronized KmeliaPublication getKmaxCompletePublication(String pubId)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().getKmaxPublication(pubId, getUserId());
   }
 
   public synchronized Collection<Coordinate> getPublicationCoordinates(String pubId)
-          throws RemoteException {
+      throws RemoteException {
     return getKmeliaBm().getPublicationCoordinates(pubId, getComponentId());
   }
 
   public synchronized void addPublicationToCombination(String pubId, List<String> combination)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().addPublicationToCombination(pubId, combination, getComponentId());
   }
 
   public synchronized void deletePublicationFromCombination(String pubId, String combinationId)
-          throws RemoteException {
+      throws RemoteException {
     getKmeliaBm().deletePublicationFromCombination(pubId, combinationId, getComponentId());
   }
 
   /**
    * Get session publications
+   *
    * @return List of WAAtributeValuePair (Id and InstanceId)
    * @throws RemoteException
    */
@@ -2929,21 +2933,23 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     List<WAAttributeValuePair> currentPublications = new ArrayList<WAAttributeValuePair>();
     Collection<KmeliaPublication> allPublications = getSessionPublicationsList();
     SilverTrace.info("kmelia", "KmeliaSessionController.getCurrentPublicationsList()",
-            "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
+        "root.MSG_PARAM_VALUE", "NbPubli=" + allPublications.size());
     for (KmeliaPublication aPubli : allPublications) {
       PublicationDetail pubDetail = aPubli.getDetail();
       if (pubDetail.getStatus().equals(PublicationDetail.VALID)) {
         SilverTrace.info("kmelia", "KmeliaSessionController.getCurrentPublicationsList()",
-                "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
-                    + pubDetail.getInstanceId());
+            "root.MSG_PARAM_VALUE", "Get pubId" + pubDetail.getId() + "InstanceId="
+            + pubDetail.getInstanceId());
         currentPublications.add(new WAAttributeValuePair(pubDetail.getId(),
-                pubDetail.getInstanceId()));
+            pubDetail.getInstanceId()));
       }
     }
     return currentPublications;
   }
 
-  /**************************************************************************************/
+  /**
+   * ***********************************************************************************
+   */
   /* Kmax - Utils */
   /**
    * **********************************************************************************
@@ -2962,6 +2968,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Transform combination axis from String /0/1037,/0/1038 in ArrayList /0/1037 then /0/1038 etc...
+   *
    * @param axisValuesStr
    * @return Collection of combination
    */
@@ -2978,12 +2985,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Get combination Axis (ie: /0/1037)
+   *
    * @param axisValuesStr
    * @return Collection of combination
    */
   public List<String> getCombination(String axisValuesStr) {
     SilverTrace.info("kmelia", "KmeliaSessionController.getCombination(String)",
-            "root.MSG_GEN_PARAM_VALUE", "axisValuesStr=" + axisValuesStr);
+        "root.MSG_GEN_PARAM_VALUE", "axisValuesStr=" + axisValuesStr);
     return convertStringCombination2List(axisValuesStr);
   }
 
@@ -3012,6 +3020,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * getPrevious
+   *
    * @return previous publication id
    */
   public String getPrevious() {
@@ -3020,6 +3029,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * getNext
+   *
    * @return next publication id
    */
   public String getNext() {
@@ -3060,7 +3070,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public String initUserPanelForTopicProfile(String role, String nodeId) throws RemoteException {
     String m_context =
-            GeneralPropertiesManager.getGeneralResourceLocator().getString("ApplicationURL");
+        GeneralPropertiesManager.getGeneralResourceLocator().getString("ApplicationURL");
     PairObject[] hostPath = new PairObject[1];
     hostPath[0] = new PairObject(getString("kmelia.SelectValidator"), "");
 
@@ -3071,15 +3081,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     sel.setHostPath(hostPath);
 
     String hostUrl =
-            m_context + URLManager.getURL("useless", getComponentId())
-                + "TopicProfileSetUsersAndGroups?Role=" + role + "&NodeId=" + nodeId;
+        m_context + URLManager.getURL("useless", getComponentId())
+        + "TopicProfileSetUsersAndGroups?Role=" + role + "&NodeId=" + nodeId;
     String cancelUrl = m_context + URLManager.getURL("useless", getComponentId()) + "CloseWindow";
 
     sel.setGoBackURL(hostUrl);
     sel.setCancelURL(cancelUrl);
 
     List<ProfileInst> profiles =
-            getAdmin().getProfilesByObject(nodeId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(nodeId, ObjectType.NODE.getCode(), getComponentId());
     ProfileInst topicProfile = getProfile(profiles, role);
 
     SelectionUsersGroups sug = new SelectionUsersGroups();
@@ -3140,7 +3150,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       profile.removeAllUsers();
 
       profile.setGroupsAndUsers(getSelection().getSelectedSets(),
-              getSelection().getSelectedElements());
+          getSelection().getSelectedElements());
 
       getAdmin().updateProfileInst(profile);
     } else {
@@ -3150,7 +3160,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       profile.setComponentFatherId(getComponentId());
 
       profile.setGroupsAndUsers(getSelection().getSelectedSets(),
-              getSelection().getSelectedElements());
+          getSelection().getSelectedElements());
 
       getAdmin().addProfileInst(profile);
     }
@@ -3165,8 +3175,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
       // Topic profiles must be removed
       List<ProfileInst> profiles =
-              getAdmin().getProfilesByObject(node.getNodePK().getId(), ObjectType.NODE.getCode(),
-                  getComponentId());
+          getAdmin().getProfilesByObject(node.getNodePK().getId(), ObjectType.NODE.getCode(),
+          getComponentId());
       for (int p = 0; profiles != null && p < profiles.size(); p++) {
         ProfileInst profile = profiles.get(p);
         if (profile != null) {
@@ -3182,7 +3192,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public ProfileInst getTopicProfile(String role, String topicId) {
     List<ProfileInst> profiles =
-            getAdmin().getProfilesByObject(topicId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(topicId, ObjectType.NODE.getCode(), getComponentId());
     for (int p = 0; profiles != null && p < profiles.size(); p++) {
       ProfileInst profile = profiles.get(p);
       if (profile.getName().equals(role)) {
@@ -3236,11 +3246,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     String[] asAvailProfileNames = getAdmin().getAllProfilesNames("kmelia");
     for (String asAvailProfileName : asAvailProfileNames) {
       SilverTrace.info("jobStartPagePeas",
-              "JobStartPagePeasSessionController.getAllProfilesNames()",
-              "root.MSG_GEN_PARAM_VALUE", "asAvailProfileNames = " + asAvailProfileName);
+          "JobStartPagePeasSessionController.getAllProfilesNames()",
+          "root.MSG_GEN_PARAM_VALUE", "asAvailProfileNames = " + asAvailProfileName);
       ProfileInst profile = getTopicProfile(asAvailProfileName, topicId);
       profile.setLabel(getAdmin().getProfileLabelfromName("kmelia", asAvailProfileName,
-              getLanguage()));
+          getLanguage()));
       alShowProfile.add(profile);
     }
 
@@ -3296,7 +3306,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
     String profile = getUserTopicProfile();
     boolean isPublisherOrAdmin =
-            SilverpeasRole.admin.isInRole(profile) || SilverpeasRole.publisher.isInRole(profile);
+        SilverpeasRole.admin.isInRole(profile) || SilverpeasRole.publisher.isInRole(profile);
 
     if (!isPublisherOrAdmin && isRightsOnTopicsEnabled()) {
       // check if current user is publisher or admin on at least one descendant
@@ -3306,13 +3316,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         if (descendant.haveLocalRights()) {
           // check if user is admin or publisher on this topic
           String[] profiles =
-                  getAdmin().getProfilesByObjectAndUserId(descendant.getId(),
-                      ObjectType.NODE.getCode(), getComponentId(), getUserId());
+              getAdmin().getProfilesByObjectAndUserId(descendant.getId(),
+              ObjectType.NODE.getCode(), getComponentId(), getUserId());
           if (profiles != null && profiles.length > 0) {
             List<String> lProfiles = Arrays.asList(profiles);
             isPublisherOrAdmin =
-                    lProfiles.contains(SilverpeasRole.admin.name())
-                        || lProfiles.contains(SilverpeasRole.publisher.name());
+                lProfiles.contains(SilverpeasRole.admin.name())
+                || lProfiles.contains(SilverpeasRole.publisher.name());
           }
         }
       }
@@ -3323,8 +3333,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public boolean isUserCanWrite() throws RemoteException {
     String profile = getUserTopicProfile();
     boolean userCanWrite =
-            SilverpeasRole.admin.isInRole(profile) || SilverpeasRole.publisher.isInRole(profile)
-                || SilverpeasRole.writer.isInRole(profile);
+        SilverpeasRole.admin.isInRole(profile) || SilverpeasRole.publisher.isInRole(profile)
+        || SilverpeasRole.writer.isInRole(profile);
 
     if (!userCanWrite && isRightsOnTopicsEnabled()) {
       // check if current user is publisher or admin on at least one descendant
@@ -3334,14 +3344,14 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         if (descendant.haveLocalRights()) {
           // check if user is admin, publisher or writer on this topic
           String[] profiles =
-                  getAdmin().getProfilesByObjectAndUserId(descendant.getId(),
-                      ObjectType.NODE.getCode(), getComponentId(), getUserId());
+              getAdmin().getProfilesByObjectAndUserId(descendant.getId(),
+              ObjectType.NODE.getCode(), getComponentId(), getUserId());
           if (profiles != null && profiles.length > 0) {
             List<String> lProfiles = Arrays.asList(profiles);
             userCanWrite =
-                    lProfiles.contains(SilverpeasRole.admin.name())
-                        || lProfiles.contains(SilverpeasRole.publisher.name())
-                        || lProfiles.contains(SilverpeasRole.writer.name());
+                lProfiles.contains(SilverpeasRole.admin.name())
+                || lProfiles.contains(SilverpeasRole.publisher.name())
+                || lProfiles.contains(SilverpeasRole.writer.name());
           }
         }
       }
@@ -3353,8 +3363,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     CompletePublication pub = getCompletePublication(pubId);
     PublicationSelection pubSelect = new PublicationSelection(pub);
     SilverTrace.info("kmelia", "KmeliaSessionController.copyPublication()",
-            "root.MSG_GEN_PARAM_VALUE",
-            "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
+        "root.MSG_GEN_PARAM_VALUE",
+        "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
     addClipboardSelection(pubSelect);
   }
 
@@ -3372,8 +3382,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     pubSelect.setCutted(true);
 
     SilverTrace.info("kmelia", "KmeliaSessionController.cutPublication()",
-            "root.MSG_GEN_PARAM_VALUE",
-            "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
+        "root.MSG_GEN_PARAM_VALUE",
+        "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
     addClipboardSelection(pubSelect);
   }
 
@@ -3389,7 +3399,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     NodeSelection nodeSelect = new NodeSelection(getNodeHeader(id));
 
     SilverTrace.info("kmelia", "KmeliaSessionController.copyTopic()", "root.MSG_GEN_PARAM_VALUE",
-            "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
+        "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
     addClipboardSelection(nodeSelect);
   }
 
@@ -3397,7 +3407,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     NodeSelection nodeSelect = new NodeSelection(getNodeHeader(id));
     nodeSelect.setCutted(true);
     SilverTrace.info("kmelia", "KmeliaSessionController.cutTopic()", "root.MSG_GEN_PARAM_VALUE",
-            "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
+        "clipboard = " + getClipboardName() + "' count=" + getClipboardCount());
     addClipboardSelection(nodeSelect);
   }
 
@@ -3405,18 +3415,18 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     List<Object> pastedItems = new ArrayList<Object>();
     try {
       SilverTrace.info("kmelia", "KmeliaRequestRooter.paste()", "root.MSG_GEN_PARAM_VALUE",
-              "clipboard = " + getClipboardName() + " count=" + getClipboardCount());
+          "clipboard = " + getClipboardName() + " count=" + getClipboardCount());
       Collection<ClipboardSelection> clipObjects = getClipboardSelectedObjects();
       for (ClipboardSelection clipObject : clipObjects) {
         if (clipObject != null) {
           if (clipObject.isDataFlavorSupported(PublicationSelection.CompletePublicationFlavor)) {
             CompletePublication pub = (CompletePublication) clipObject.getTransferData(
-                    PublicationSelection.CompletePublicationFlavor);
+                PublicationSelection.CompletePublicationFlavor);
             pastePublication(pub, clipObject.isCutted());
             pastedItems.add(pub.getPublicationDetail());
           } else if (clipObject.isDataFlavorSupported(NodeSelection.NodeDetailFlavor)) {
             NodeDetail node =
-                    (NodeDetail) clipObject.getTransferData(NodeSelection.NodeDetailFlavor);
+                (NodeDetail) clipObject.getTransferData(NodeSelection.NodeDetailFlavor);
 
             // check if current topic is a subTopic of node
             boolean pasteAllowed = true;
@@ -3427,10 +3437,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
               String nodePath = node.getPath() + node.getId() + "/";
               String currentPath =
-                      getSessionTopic().getNodeDetail().getPath()
-                          + getSessionTopic().getNodePK().getId() + "/";
+                  getSessionTopic().getNodeDetail().getPath()
+                  + getSessionTopic().getNodePK().getId() + "/";
               SilverTrace.info("kmelia", "KmeliaRequestRooter.paste()", "root.MSG_GEN_PARAM_VALUE",
-                      "nodePath = " + nodePath + ", currentPath = " + currentPath);
+                  "nodePath = " + nodePath + ", currentPath = " + currentPath);
               if (pasteAllowed && currentPath.startsWith(nodePath)) {
                 pasteAllowed = false;
               }
@@ -3438,7 +3448,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
             if (pasteAllowed) {
               NodeDetail newNode =
-                      pasteNode(node, getSessionTopic().getNodeDetail(), clipObject.isCutted());
+                  pasteNode(node, getSessionTopic().getNodeDetail(), clipObject.isCutted());
               pastedItems.add(newNode);
             }
           }
@@ -3446,14 +3456,14 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       }
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.paste()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_PASTE_ERROR", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_PASTE_ERROR", e);
     }
     clipboardPasteDone();
     return pastedItems;
   }
 
   private NodeDetail pasteNode(NodeDetail nodeToPaste, NodeDetail father, boolean isCutted)
-          throws RemoteException {
+      throws RemoteException {
     NodePK nodeToPastePK = nodeToPaste.getNodePK();
 
     List<NodeDetail> treeToPaste = getNodeBm().getSubTree(nodeToPastePK);
@@ -3471,22 +3481,22 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           // move wysiwyg
           try {
             AttachmentController.moveAttachments(new ForeignPK("Node_" + fromNode.getNodePK()),
-                    new ForeignPK("Node_" + toNodePK.getId(), getComponentId()), true); // Change
+                new ForeignPK("Node_" + toNodePK.getId(), getComponentId()), true); // Change
             // instanceId +
             // move files
           } catch (AttachmentException e) {
             SilverTrace.error("kmelia", "KmeliaSessionController.pastePublication()",
-                    "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
+                "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
           }
 
           // change images path in wysiwyg
           try {
             WysiwygController.wysiwygPlaceHaveChanged(fromNode.getNodePK().getInstanceId(),
-                    "Node_" + fromNode.getNodePK().getId(), getComponentId(), "Node_"
-                        + toNodePK.getId());
+                "Node_" + fromNode.getNodePK().getId(), getComponentId(), "Node_"
+                + toNodePK.getId());
           } catch (WysiwygException e) {
             SilverTrace.error("kmelia", "KmeliaSessionController.pastePublication()",
-                    "root.MSG_GEN_PARAM_VALUE", e);
+                "root.MSG_GEN_PARAM_VALUE", e);
           }
 
           // move publications of topics
@@ -3510,7 +3520,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
       // paste wysiwyg attached to node
       WysiwygController.copy(null, nodeToPastePK.getInstanceId(), "Node_" + nodeToPastePK.getId(),
-              null, getComponentId(), "Node_" + nodePK.getId(), getUserId());
+          null, getComponentId(), "Node_" + nodePK.getId(), getUserId());
 
       List<NodePK> nodeIdsToPaste = new ArrayList<NodePK>();
       for (NodeDetail oneNodeToPaste : treeToPaste) {
@@ -3538,7 +3548,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   private void pastePublicationsOfTopic(NodePK fromPK, NodePK toPK, boolean isCutted,
-          List<NodePK> nodePKsToPaste) throws RemoteException {
+      List<NodePK> nodePKsToPaste) throws RemoteException {
     Collection<PublicationDetail> publications = getPublicationBm().getDetailsByFatherPK(fromPK);
     Iterator<PublicationDetail> itPublis = publications.iterator();
     PublicationDetail publi = null;
@@ -3555,7 +3565,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   private void pastePublication(CompletePublication completePub, boolean isCutted, NodePK nodePK,
-          List<NodePK> nodePKsToPaste) {
+      List<NodePK> nodePKsToPaste) {
     try {
       NodePK currentNodePK = nodePK;
       PublicationDetail publi = completePub.getPublicationDetail();
@@ -3588,8 +3598,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         } else {
           movePublication(completePub, currentNodePK, publi, fromId, fromComponentId,
               fromForeignPK,
-                  fromPubPK, toForeignPK, toPubPK, imagesSubDirectory, thumbnailsSubDirectory,
-                  toAbsolutePath, fromAbsolutePath);
+              fromPubPK, toForeignPK, toPubPK, imagesSubDirectory, thumbnailsSubDirectory,
+              toAbsolutePath, fromAbsolutePath);
         }
       } else {
         // paste the publicationDetail
@@ -3602,12 +3612,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         }
         // paste vignette
         ThumbnailDetail vignette =
-                ThumbnailController.getCompleteThumbnail(new ThumbnailDetail(fromComponentId,
-                    Integer.parseInt(fromId),
-                    ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE));
+            ThumbnailController.getCompleteThumbnail(new ThumbnailDetail(fromComponentId,
+            Integer.parseInt(fromId),
+            ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE));
         if (vignette != null) {
           pasteThumbnail(publi, thumbnailsSubDirectory, toAbsolutePath, fromAbsolutePath, id,
-                  vignette);
+              vignette);
         }
         // update id cause new publication is created
         toPubPK.setId(id);
@@ -3615,7 +3625,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         pastePdcPositions(fromPubPK, id);
         // paste wysiwyg
         WysiwygController.copy(null, fromComponentId, fromId, null, getComponentId(), id,
-                getUserId());
+            getUserId());
         // paste files
         Map<String, String> fileIds = pasteFiles(fromPubPK, id);
 
@@ -3625,7 +3635,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           if (completePub.getInfoDetail().getInfoImageList() != null) {
             for (InfoImageDetail attachment : completePub.getInfoDetail().getInfoImageList()) {
               String from = fromAbsolutePath + imagesSubDirectory + File.separatorChar
-                      + attachment.getPhysicalName();
+                  + attachment.getPhysicalName();
               String type = FilenameUtils.getExtension(attachment.getPhysicalName());
               String newName = String.valueOf(System.currentTimeMillis()) + "." + type;
               attachment.setPhysicalName(newName);
@@ -3636,7 +3646,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
           // Paste model content
           getKmeliaBm().createInfoModelDetail(toPubPK, completePub.getModelDetail().getId(),
-                  completePub.getInfoDetail());
+              completePub.getInfoDetail());
         } else {
           String infoId = publi.getInfoId();
           if (infoId != null && !"0".equals(infoId)) {
@@ -3644,12 +3654,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
             // register xmlForm to publication
             String xmlFormShortName = infoId;
             getPublicationTemplateManager().addDynamicPublicationTemplate(getComponentId() + ":"
-                    + xmlFormShortName, xmlFormShortName + ".xml");
+                + xmlFormShortName, xmlFormShortName + ".xml");
 
             // Paste images
             Map<String, String> imageIds =
-                    AttachmentController.copyAttachmentByCustomerPKAndContext(fromPubPK, fromPubPK,
-                        "XMLFormImages");
+                AttachmentController.copyAttachmentByCustomerPKAndContext(fromPubPK, fromPubPK,
+                "XMLFormImages");
 
             if (imageIds != null) {
               fileIds.putAll(imageIds);
@@ -3661,19 +3671,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
             // get xmlContent to paste
             PublicationTemplate pubTemplateFrom = getPublicationTemplateManager().
-                    getPublicationTemplate(fromComponentId + ":" + xmlFormShortName);
+                getPublicationTemplate(fromComponentId + ":" + xmlFormShortName);
             IdentifiedRecordTemplate recordTemplateFrom =
-                    (IdentifiedRecordTemplate) pubTemplateFrom.getRecordSet().getRecordTemplate();
+                (IdentifiedRecordTemplate) pubTemplateFrom.getRecordSet().getRecordTemplate();
 
             PublicationTemplate pubTemplate =
-                    getPublicationTemplateManager().getPublicationTemplate(
-                        getComponentId() + ":" + xmlFormShortName);
+                getPublicationTemplateManager().getPublicationTemplate(
+                getComponentId() + ":" + xmlFormShortName);
             IdentifiedRecordTemplate recordTemplate = (IdentifiedRecordTemplate) pubTemplate.
-                    getRecordSet().getRecordTemplate();
+                getRecordSet().getRecordTemplate();
 
             // paste xml content
             GenericRecordSetManager.getInstance().cloneRecord(recordTemplateFrom, fromId,
-                    recordTemplate, id, fileIds);
+                recordTemplate, id, fileIds);
           }
         }
 
@@ -3684,23 +3694,23 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       }
     } catch (Exception ex) {
       SilverTrace.error("kmelia", getClass().getSimpleName() + ".pastePublication()",
-              "root.EX_NO_MESSAGE", ex);
+          "root.EX_NO_MESSAGE", ex);
     }
   }
 
   private void pasteThumbnail(PublicationDetail publi, String thumbnailsSubDirectory,
-          String toAbsolutePath, String fromAbsolutePath, String id, ThumbnailDetail vignette)
-          throws IOException, ThumbnailException {
+      String toAbsolutePath, String fromAbsolutePath, String id, ThumbnailDetail vignette)
+      throws IOException, ThumbnailException {
     ThumbnailDetail thumbDetail = new ThumbnailDetail(publi.getPK().getInstanceId(),
-            Integer.valueOf(
-                id), ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE);
+        Integer.valueOf(
+        id), ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE);
 
     if (vignette.getOriginalFileName().startsWith("/")) {
       thumbDetail.setOriginalFileName(vignette.getOriginalFileName());
       thumbDetail.setMimeType(vignette.getMimeType());
     } else {
       String from = fromAbsolutePath + thumbnailsSubDirectory + File.separatorChar
-              + vignette.getOriginalFileName();
+          + vignette.getOriginalFileName();
 
       String type = FilenameUtils.getExtension(vignette.getOriginalFileName());
       String newOriginalImage = String.valueOf(System.currentTimeMillis()) + "." + type;
@@ -3712,7 +3722,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       // then copy thumnbnail image if exists
       if (vignette.getCropFileName() != null) {
         from = fromAbsolutePath + thumbnailsSubDirectory + File.separatorChar + vignette.
-                getCropFileName();
+            getCropFileName();
         type = FilenameUtils.getExtension(vignette.getCropFileName());
         String newThumbnailImage = String.valueOf(System.currentTimeMillis()) + "." + type;
         to = toAbsolutePath + thumbnailsSubDirectory + File.separatorChar + newThumbnailImage;
@@ -3729,20 +3739,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   /**
-   * Move a publication to another component. Moving in tis order :
-   * <ul>
-   * <li>moving the metadata</li>
-   * <li>moving the thumbnail</li>
-   * <li>moving the content</li>
-   * <li>moving the wysiwyg</li>
-   * <li>moving the images linked to the wysiwyg</li>
-   * <li>moving the xml form content (files and images)</li>
-   * <li>moving the db content and the images</li>
-   * <li>moving attachments</li>
-   * <li>moving versionned attached files</li>
-   * <li>moving the pdc poistion</li>
-   * <li>moving the statistics</li>
-   * </ul>
+   * Move a publication to another component. Moving in tis order : <ul> <li>moving the
+   * metadata</li> <li>moving the thumbnail</li> <li>moving the content</li> <li>moving the
+   * wysiwyg</li> <li>moving the images linked to the wysiwyg</li> <li>moving the xml form content
+   * (files and images)</li> <li>moving the db content and the images</li> <li>moving
+   * attachments</li> <li>moving versionned attached files</li> <li>moving the pdc poistion</li>
+   * <li>moving the statistics</li> </ul>
+   *
    * @param completePub
    * @param nodePK
    * @param publi
@@ -3762,11 +3765,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * @throws PdcException
    */
   private void movePublication(CompletePublication completePub, NodePK nodePK,
-          PublicationDetail publi, String fromId, String fromComponentId, ForeignPK fromForeignPK,
-          PublicationPK fromPubPK, ForeignPK toForeignPK, PublicationPK toPubPK,
-          String imagesSubDirectory, String thumbnailsSubDirectory, String toAbsolutePath,
-          String fromAbsolutePath)
-          throws RemoteException, ThumbnailException, PublicationTemplateException, PdcException {
+      PublicationDetail publi, String fromId, String fromComponentId, ForeignPK fromForeignPK,
+      PublicationPK fromPubPK, ForeignPK toForeignPK, PublicationPK toPubPK,
+      String imagesSubDirectory, String thumbnailsSubDirectory, String toAbsolutePath,
+      String fromAbsolutePath)
+      throws RemoteException, ThumbnailException, PublicationTemplateException, PdcException {
 
     boolean indexIt = false;
 
@@ -3774,10 +3777,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     int[] thumbnailSize = getThumbnailWidthAndHeight();
 
     String vignette = ThumbnailController.getImage(fromComponentId,
-            Integer.parseInt(fromId),
-            ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE,
-            thumbnailSize[0],
-            thumbnailSize[1]);
+        Integer.parseInt(fromId),
+        ThumbnailDetail.THUMBNAIL_OBJECTTYPE_PUBLICATION_VIGNETTE,
+        thumbnailSize[0],
+        thumbnailSize[1]);
     if (StringUtil.isDefined(vignette)) {
       String from = fromAbsolutePath + thumbnailsSubDirectory + File.separator + vignette;
 
@@ -3785,7 +3788,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         FileRepositoryManager.createAbsolutePath(getComponentId(), thumbnailsSubDirectory);
       } catch (Exception e) {
         SilverTrace.error("kmelia", "KmeliaSessionController.pastePublication()",
-                "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
+            "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
       }
       String to = toAbsolutePath + thumbnailsSubDirectory + File.separator + vignette;
 
@@ -3795,7 +3798,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       boolean moveOK = fromVignette.renameTo(toVignette);
 
       SilverTrace.info("kmelia", "KmeliaSessionController.pastePublication()",
-              "root.MSG_GEN_PARAM_VALUE", "vignette move = " + moveOK);
+          "root.MSG_GEN_PARAM_VALUE", "vignette move = " + moveOK);
     }
 
     // move attachments first (wysiwyg, wysiwyg images, formXML files and images, attachments)
@@ -3804,21 +3807,21 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       AttachmentController.moveAttachments(fromForeignPK, toForeignPK, indexIt);
     } catch (AttachmentException e) {
       SilverTrace.error("kmelia", "KmeliaSessionController.pastePublication()",
-              "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
+          "root.MSG_GEN_PARAM_VALUE", "kmelia.CANT_MOVE_ATTACHMENTS", e);
     }
 
     try {
       // change images path in wysiwyg
       WysiwygController.wysiwygPlaceHaveChanged(fromComponentId, publi.getPK().getId(),
-              getComponentId(), publi.getPK().getId());
+          getComponentId(), publi.getPK().getId());
     } catch (WysiwygException e) {
       SilverTrace.error("kmelia", "KmeliaSessionController.pastePublication()",
-              "root.MSG_GEN_PARAM_VALUE", e);
+          "root.MSG_GEN_PARAM_VALUE", e);
     }
 
     boolean fromCompoVersion =
-            "yes".equals(getOrganizationController().getComponentParameterValue(fromComponentId,
-                "versionControl"));
+        "yes".equals(getOrganizationController().getComponentParameterValue(fromComponentId,
+        "versionControl"));
 
     if (fromCompoVersion && isVersionControlled()) {
       // move versioning files
@@ -3859,9 +3862,9 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       if (completePub.getInfoDetail().getInfoImageList() != null) {
         for (InfoImageDetail attachment : completePub.getInfoDetail().getInfoImageList()) {
           String from = fromAbsolutePath + imagesSubDirectory + File.separator
-                  + attachment.getPhysicalName();
+              + attachment.getPhysicalName();
           String to = toAbsolutePath + imagesSubDirectory + File.separator
-                  + attachment.getPhysicalName();
+              + attachment.getPhysicalName();
 
           File fromImage = new File(from);
           File toImage = new File(to);
@@ -3869,7 +3872,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           boolean moveOK = fromImage.renameTo(toImage);
 
           SilverTrace.info("kmelia", "KmeliaSessionController.pastePublication()",
-                  "root.MSG_GEN_PARAM_VALUE", "dbImage move = " + moveOK);
+              "root.MSG_GEN_PARAM_VALUE", "dbImage move = " + moveOK);
         }
       }
     } else {
@@ -3877,26 +3880,26 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       if (infoId != null && !"0".equals(infoId)) {
         // register content to component
         getPublicationTemplateManager().addDynamicPublicationTemplate(getComponentId() + ":"
-                + publi.getInfoId(), publi.getInfoId() + ".xml");
+            + publi.getInfoId(), publi.getInfoId() + ".xml");
 
         // get xmlContent to move
         PublicationTemplate pubTemplateFrom = getPublicationTemplateManager().
-                getPublicationTemplate(fromComponentId + ":" + publi.getInfoId());
+            getPublicationTemplate(fromComponentId + ":" + publi.getInfoId());
         IdentifiedRecordTemplate recordTemplateFrom =
-                (IdentifiedRecordTemplate) pubTemplateFrom.getRecordSet().getRecordTemplate();
+            (IdentifiedRecordTemplate) pubTemplateFrom.getRecordSet().getRecordTemplate();
 
         PublicationTemplate pubTemplate =
-                getPublicationTemplateManager().getPublicationTemplate(
-                    getComponentId() + ":" + publi.getInfoId());
+            getPublicationTemplateManager().getPublicationTemplate(
+            getComponentId() + ":" + publi.getInfoId());
         IdentifiedRecordTemplate recordTemplate = (IdentifiedRecordTemplate) pubTemplate.
-                getRecordSet().getRecordTemplate();
+            getRecordSet().getRecordTemplate();
 
         try {
           GenericRecordSetManager.getInstance().moveRecord(recordTemplateFrom, fromId,
-                  recordTemplate);
+              recordTemplate);
         } catch (FormException e) {
           SilverTrace.error("kmelia", "KmeliaSessionController.movePublication",
-                  "kmelia.CANT_MOVE_PUBLICATION_CONTENT", "publication id = " + fromId, e);
+              "kmelia.CANT_MOVE_PUBLICATION_CONTENT", "publication id = " + fromId, e);
         }
       }
     }
@@ -3934,11 +3937,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     int toSilverObjectId = getKmeliaBm().getSilverObjectId(toPubPK);
 
     // add original positions to pasted publication
-    getPdcBm().addPositions(positions, toSilverObjectId, getComponentId());   
+    getPdcBm().addPositions(positions, toSilverObjectId, getComponentId());
   }
 
   /**
    * get languages of publication header and attachments
+   *
    * @param pubDetail
    * @return a List of String (language codes)
    */
@@ -3975,7 +3979,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     // get attachments languages
     List<String> languages = new ArrayList<String>();
     List<String> attLanguages = AttachmentController.getLanguagesOfAttachments(
-            new ForeignPK(pubPK.getId(), pubPK.getInstanceId()));
+        new ForeignPK(pubPK.getId(), pubPK.getInstanceId()));
     for (String language : attLanguages) {
       if (!languages.contains(language)) {
         languages.add(language);
@@ -3986,7 +3990,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public void setAliases(List<Alias> aliases) throws RemoteException {
     getKmeliaBm().setAlias(getSessionPublication().getDetail().getPK(),
-            aliases);
+        aliases);
   }
 
   public void setAliases(PublicationPK pubPK, List<Alias> aliases) throws RemoteException {
@@ -3995,8 +3999,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   public List<Alias> getAliases() throws RemoteException {
     List<Alias> aliases =
-            (List<Alias>) getKmeliaBm().getAlias(
-                getSessionPublication().getDetail().getPK());
+        (List<Alias>) getKmeliaBm().getAlias(
+        getSessionPublication().getDetail().getPK());
 
     // add user's displayed name
     for (Alias object : aliases) {
@@ -4023,7 +4027,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     for (SpaceInstLight space : spaces) {
       String path = "";
       String[] componentIds = getOrganizationController().getAvailCompoIdsAtRoot(
-              space.getFullId(), getUserId());
+          space.getFullId(), getUserId());
       for (String componentId : componentIds) {
         instanceId = componentId;
 
@@ -4031,16 +4035,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
           String[] profiles =
               getOrganizationController().getUserProfiles(getUserId(), instanceId);
           String bestProfile = KmeliaHelper.getProfile(profiles);
-          if (SilverpeasRole.admin.isInRole(bestProfile) ||
-              SilverpeasRole.publisher.isInRole(bestProfile) ||
-              instanceId.equals(getComponentId())) {
+          if (SilverpeasRole.admin.isInRole(bestProfile) || SilverpeasRole.publisher.isInRole(
+              bestProfile) || instanceId.equals(getComponentId())) {
             instanceIds.add(instanceId);
             root.setComponentName(instanceId);
 
             if (instanceId.equals(getComponentId())) {
               tree = getKmeliaBm().getTreeview(root, "useless", false, false, getUserId(),
-                      false, StringUtil.getBooleanValue(getOrganizationController().
-                          getComponentParameterValue(instanceId, "rightsOnTopics")));
+                  false, StringUtil.getBooleanValue(getOrganizationController().
+                  getComponentParameterValue(instanceId, "rightsOnTopics")));
             }
 
             if (!StringUtil.isDefined(path)) {
@@ -4056,8 +4059,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
             }
 
             Treeview treeview = new Treeview(path + " > "
-                    + getOrganizationController().getComponentInstLight(instanceId).getLabel(),
-                    tree, instanceId);
+                + getOrganizationController().getComponentInstLight(instanceId).getLabel(),
+                tree, instanceId);
 
             treeview.setNbAliases(getNbAliasesInComponent(aliases, instanceId));
 
@@ -4085,8 +4088,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       NodePK root = new NodePK(NodePK.ROOT_NODE_ID, instanceId);
 
       tree = getKmeliaBm().getTreeview(root, "useless", false, false, getUserId(), false,
-              StringUtil.getBooleanValue(getOrganizationController().getComponentParameterValue(
-                  instanceId, "rightsOnTopics")));
+          StringUtil.getBooleanValue(getOrganizationController().getComponentParameterValue(
+          instanceId, "rightsOnTopics")));
     }
     return tree;
   }
@@ -4107,6 +4110,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Return the url to the first attached file for the current publication.
+   *
    * @return the url to the first attached file for the curent publication.
    * @throws RemoteException
    */
@@ -4121,13 +4125,13 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         DocumentVersion documentVersion = versioning.getLastPublicVersion(document.getPk());
         if (documentVersion != null) {
           url = URLManager.getApplicationURL() + versioning.getDocumentVersionURL(document.
-                  getInstanceId(), documentVersion.getLogicalName(), document.getPk().getId(),
-                  documentVersion.getPk().getId());
+              getInstanceId(), documentVersion.getLogicalName(), document.getPk().getId(),
+              documentVersion.getPk().getId());
         }
       }
     } else {
       List<AttachmentDetail> attachments = AttachmentController.searchAttachmentByPKAndContext(
-              pubPK, "Images");
+          pubPK, "Images");
       if (!attachments.isEmpty()) {
         AttachmentDetail attachment = attachments.get(0);
         url = URLManager.getApplicationURL() + attachment.getAttachmentURL();
@@ -4138,6 +4142,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Return the url to access the file
+   *
    * @param fileId the id of the file (attachment or document id).
    * @return the url to the file.
    * @throws RemoteException
@@ -4150,11 +4155,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       Document document = versioningUtil.getDocument(documentPk);
       DocumentVersion documentVersion = versioningUtil.getLastPublicVersion(documentPk);
       url = URLManager.getApplicationURL() + versioningUtil.getDocumentVersionURL(document.
-              getInstanceId(), documentVersion.getLogicalName(), document.getPk().getId(),
-              documentVersion.getPk().getId());
+          getInstanceId(), documentVersion.getLogicalName(), document.getPk().getId(),
+          documentVersion.getPk().getId());
     } else {
       AttachmentDetail attachment = AttachmentController.searchAttachmentByPK(new AttachmentPK(
-              fileId));
+          fileId));
       url = URLManager.getApplicationURL() + attachment.getAttachmentURL();
     }
     return url;
@@ -4225,7 +4230,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   private String getUpdateChainDescriptorFilename(String topicId) {
     return getSettings().getString("updateChainRepository") + getComponentId() + "_" + topicId
-            + ".xml";
+        + ".xml";
   }
 
   public synchronized List<NodeDetail> getSubTopics(String rootId) throws RemoteException {
@@ -4249,16 +4254,16 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public void initUpdateChainDescriptor() throws IOException, ClassNotFoundException,
-          ParserConfigurationException {
+      ParserConfigurationException {
     XStream xstream = new XStream(new DomDriver());
     xstream.alias("fieldDescriptor", FieldUpdateChainDescriptor.class);
     xstream.alias("updateChain", UpdateChainDescriptor.class);
     xstream.alias("parameter", FieldParameter.class);
 
     File descriptorFile =
-            new File(getUpdateChainDescriptorFilename(getSessionTopic().getNodePK().getId()));
+        new File(getUpdateChainDescriptorFilename(getSessionTopic().getNodePK().getId()));
     UpdateChainDescriptor updateChainDescriptor =
-            (UpdateChainDescriptor) xstream.fromXML(new FileReader(descriptorFile));
+        (UpdateChainDescriptor) xstream.fromXML(new FileReader(descriptorFile));
 
     String title = updateChainDescriptor.getTitle();
     String libelle = updateChainDescriptor.getLibelle();
@@ -4289,7 +4294,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public File exportPublication() {
     if (!isFormatSupported("zip")) {
       throw new KmeliaRuntimeException("KmeliaSessionController.exportPublication()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_EXPORT_FORMAT_NOT_SUPPORTED");
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_EXPORT_FORMAT_NOT_SUPPORTED");
     }
     PublicationPK pubPK = getSessionPublication().getDetail().getPK();
     File pdf = null;
@@ -4298,7 +4303,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       String subdir = "ExportPubli_" + pubPK.getId() + "_" + System.currentTimeMillis();
       String fileName = getPublicationExportFileName(getSessionPublication(), getLanguage());
       String subDirPath =
-              FileRepositoryManager.getTemporaryPath() + subdir + File.separator + fileName;
+          FileRepositoryManager.getTemporaryPath() + subdir + File.separator + fileName;
       FileFolderManager.createFolder(subDirPath);
       // generate from the publication a document in PDF
       if (isFormatSupported(DocumentFormat.pdf.name())) {
@@ -4316,7 +4321,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       return new File(zipFileName);
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaSessionController.exportPublication()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_CANT_EXPORT_PUBLICATION", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_CANT_EXPORT_PUBLICATION", e);
     } finally {
       if (pdf != null) {
         pdf.delete();
@@ -4360,14 +4365,14 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     List<NodeDetail> newPath = new ArrayList<NodeDetail>();
     try {
       List<NodeDetail> pathInReverse =
-              (List<NodeDetail>) getNodeBm().getPath(new NodePK(topicId, getComponentId()));
+          (List<NodeDetail>) getNodeBm().getPath(new NodePK(topicId, getComponentId()));
       // reverse the path from root to leaf
       for (int i = pathInReverse.size() - 1; i >= 0; i--) {
         newPath.add(pathInReverse.get(i));
       }
     } catch (Exception e) {
       throw new KmeliaRuntimeException("KmeliaBmEJB.getTopicPath()",
-              SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DAVOIR_LE_CHEMIN_COURANT", e);
+          SilverpeasRuntimeException.ERROR, "kmelia.EX_IMPOSSIBLE_DAVOIR_LE_CHEMIN_COURANT", e);
     }
     return newPath;
   }
@@ -4382,7 +4387,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       heightInt = getLengthFromProperties("vignetteHeight");
     }
 
-    return new int[] { widthInt, heightInt };
+    return new int[]{widthInt, heightInt};
   }
 
   private int getLengthFromProperties(String name) {
@@ -4392,8 +4397,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       length = Integer.parseInt(lengthFromProperties);
     } catch (NumberFormatException e) {
       SilverTrace.info("kmelia", "KmeliaSessionController.getLengthFromProperties()",
-              "root.MSG_GEN_PARAM_VALUE", "properties wrong parameter " + name + " = "
-                  + lengthFromProperties);
+          "root.MSG_GEN_PARAM_VALUE", "properties wrong parameter " + name + " = "
+          + lengthFromProperties);
     }
     return length;
   }
@@ -4406,8 +4411,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         length = Integer.parseInt(lengthFromXml);
       } catch (NumberFormatException e) {
         SilverTrace.info("kmelia", "KmeliaSessionController.getLengthFromXMLDescriptor()",
-                "root.MSG_GEN_PARAM_VALUE", "xml wrong parameter " + name + " = "
-                    + lengthFromXml);
+            "root.MSG_GEN_PARAM_VALUE", "xml wrong parameter " + name + " = "
+            + lengthFromXml);
       }
     }
     return length;
@@ -4416,6 +4421,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   /**
    * return the value of component parameter "axisIdGlossary". This paramater indicate the axis of
    * pdc to use to highlight word in publication content
+   *
    * @return an indentifier of Pdc axis
    */
   public String getAxisIdGlossary() {
@@ -4428,8 +4434,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     String[] compoIds = orgaController.getCompoId("gallery");
     for (String compoId : compoIds) {
       if (StringUtil.getBooleanValue(orgaController.getComponentParameterValue(
-              "gallery" + compoId,
-              "viewInWysiwyg"))) {
+          "gallery" + compoId,
+          "viewInWysiwyg"))) {
         if (galleries == null) {
           galleries = new ArrayList<ComponentInstLight>();
         }
@@ -4446,7 +4452,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       return getProfile();
     } catch (RemoteException ex) {
       throw new KmeliaRuntimeException("KmeliaBmEJB.getRole()",
-              SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", ex);
+          SilverpeasRuntimeException.ERROR, "kmelia.MSG_ERR_GENERAL", ex);
     }
   }
 
@@ -4469,8 +4475,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
             nodeName = nodeInPath.getName();
           }
           linkedPathString.append("<a href=\"javascript:onClick=topicGoTo('").append(
-                  nodeInPath.getNodePK().getId()).append("')\">").append(
-                  EncodeHelper.javaStringToHtmlString(nodeName)).append("</a>");
+              nodeInPath.getNodePK().getId()).append("')\">").append(
+              EncodeHelper.javaStringToHtmlString(nodeName)).append("</a>");
           pathString.append(EncodeHelper.javaStringToHtmlString(nodeName));
           if (iterator.hasNext()) {
             linkedPathString.append(" > ");
@@ -4496,6 +4502,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Is search in topics enabled
+   *
    * @return boolean
    */
   public boolean isSearchOnTopicsEnabled() {
@@ -4508,6 +4515,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Get publications and aliases of this topic and its subtopics answering to the query
+   *
    * @param query
    * @param sort
    * @return List of Kmelia publications
@@ -4521,17 +4529,17 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     String[] spacesIds = getOrganizationController().getAllSpaceIds(getUserDetail().getId());
     for (String spacesId : spacesIds) {
       String[] componentsIds =
-              getOrganizationController().getComponentIdsForUser(getUserDetail().getId(),
-                  this.getComponentName());
+          getOrganizationController().getComponentIdsForUser(getUserDetail().getId(),
+          this.getComponentName());
       for (String componentsId : componentsIds) {
         queryDescription.addSpaceComponentPair(spacesId, componentsId);
       }
     }
 
     try {
-  
+
       List<MatchingIndexEntry> results = SearchEngineFactory.getSearchEngine().search(
-        queryDescription).getEntries();
+          queryDescription).getEntries();
       PublicationDetail pubDetail = new PublicationDetail();
       pubDetail.setPk(new PublicationPK("unknown"));
       KmeliaPublication publication = KmeliaPublication.aKmeliaPublicationFromDetail(pubDetail);
@@ -4591,7 +4599,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       }
     } catch (Exception pe) {
       throw new KmeliaRuntimeException("KmeliaSessionController.search",
-              SilverpeasRuntimeException.ERROR, "root.EX_SEARCH_ENGINE_FAILED", pe);
+          SilverpeasRuntimeException.ERROR, "root.EX_SEARCH_ENGINE_FAILED", pe);
     }
     return userPublications;
   }
@@ -4606,6 +4614,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Gets an instance of PublicationTemplateManager.
+   *
    * @return an instance of PublicationTemplateManager.
    */
   private PublicationTemplateManager getPublicationTemplateManager() {
@@ -4614,6 +4623,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Is news manage
+   *
    * @return boolean
    */
   public boolean isNewsManage() {
@@ -4623,6 +4633,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   /**
    * Récupère une actualité déléguée dans le composant delegatednews correspondant à la publication
    * passée en paramètre
+   *
    * @param pubId : l'id de la publication de Theme Tracker
    * @return DelegatedNews : l'objet correspondant à l'actualité déléguée dans le composant
    * delegatednews ou null si elle n'existe pas
@@ -4636,6 +4647,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Ajout d'une actualité déléguée dans le composant delegatednews
+   *
    * @return String : pubId
    */
   public String addDelegatedNews() {
@@ -4649,7 +4661,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
     Date endDateAndHour = DateUtil.getDate(pubDetail.getEndDate(), pubDetail.getEndHour());
     DelegatedNewsService delegatedNewsService = ServicesFactory.getDelegatedNewsService();
     delegatedNewsService.addDelegatedNews(Integer.parseInt(pubId), instanceId, contributorId,
-            new Date(), beginDateAndHour, endDateAndHour);
+        new Date(), beginDateAndHour, endDateAndHour);
 
     // alerte l'équipe éditoriale du composant delegatednews
     String[] tabInstanceId = getOrganizationController().getCompoId("delegatednews");
@@ -4661,7 +4673,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
     delegatedNewsService.notifyDelegatedNewsToValidate(pubId,
         pubDetail.getName(this.getLanguage()), this.getUserId(), this.getUserDetail()
-            .getDisplayedName(), delegatednewsInstanceId);
+        .getDisplayedName(), delegatednewsInstanceId);
 
     return pubId;
   }
@@ -4691,7 +4703,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         }
       } catch (RemoteException ex) {
         SilverTrace.error("kmelia", getClass().getSimpleName() + ".getPublicationExportFileName()",
-                "root.EX_NO_MESSAGE", ex);
+            "root.EX_NO_MESSAGE", ex);
       }
     }
 
@@ -4714,6 +4726,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Gets all available export formats.
+   *
    * @return a list of export formats Silverpeas supports for export.
    */
   public List<String> getAvailableFormats() {
@@ -4724,6 +4737,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * Gets the export formats that are supported by the current Kmelia component instance. As some of
    * the export formats can be deactivated in the Kmelia settings file, this method returns all the
    * formats that are currently active.
+   *
    * @return a list of export formats.
    */
   public List<String> getSupportedFormats() {
@@ -4734,7 +4748,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       for (String exportFormat : exportFormats.trim().split(" ")) {
         if (!availableFormats.contains(exportFormat)) {
           throw new KmeliaRuntimeException("KmeliaSessionController.getSupportedFormats()",
-                  SilverTrace.TRACE_LEVEL_ERROR, "kmelia.EX_UNKNOWN_EXPORT_FORMAT");
+              SilverTrace.TRACE_LEVEL_ERROR, "kmelia.EX_UNKNOWN_EXPORT_FORMAT");
         }
         supportedFormats.add(exportFormat);
       }
@@ -4744,6 +4758,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Is the specified export format is supported by the Kmelia component instance?
+   *
    * @param format a recognized export format.
    * @return true if the specified format is currently supported for the publication export, false
    * otherwise.
@@ -4754,14 +4769,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
 
   /**
    * Is the specified publication classified on the PdC.
+   *
    * @param publication a publication;
    * @return true if the publication is classified, false otherwise.
    * @throws PdcException if an error occurs while verifying the publication is classified.
    */
   public boolean isClassifiedOnThePdC(final PublicationDetail publication) throws PdcException {
     List<ClassifyPosition> positions = getPdcBm().getPositions(
-            Integer.valueOf(publication.getSilverObjectId()),
-            publication.getComponentInstanceId());
+        Integer.valueOf(publication.getSilverObjectId()),
+        publication.getComponentInstanceId());
     return !positions.isEmpty();
   }
 
@@ -4770,6 +4786,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    * specified topic of the specified component instance can be modified during the
    * multi-publications import process? If no default classification is defined for the specified
    * topic (and for any of its parent topics), then false is returned.
+   *
    * @param topicId the unique identifier of the topic.
    * @param componentId the unique identifier of the component instance.
    * @return true if the default classification can be modified during the automatical
@@ -4777,9 +4794,9 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
    */
   public boolean isDefaultClassificationModifiable(String topicId, String componentId) {
     PdcClassificationService classificationService = PdcServiceFactory.getFactory().
-            getPdcClassificationService();
+        getPdcClassificationService();
     PdcClassification defaultClassification = classificationService.findAPreDefinedClassification(
-            topicId, componentId);
+        topicId, componentId);
     return defaultClassification != NONE_CLASSIFICATION && defaultClassification.isModifiable();
   }
 
@@ -4810,13 +4827,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   public List<String> getSelectedPublicationIds() {
     return selectedPublicationIds;
   }
-  
+
   public boolean isCustomPublicationTemplateUsed() {
     return customPublicationTemplateUsed;
   }
-  
+
   public String getCustomPublicationTemplateName() {
     return customPublicationTemplateName;
   }
-
 }

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/handlers/StatisticRequestHandler.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/handlers/StatisticRequestHandler.java
@@ -23,15 +23,6 @@
  */
 package com.stratelia.webactiv.kmelia.servlets.handlers;
 
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-
 import com.silverpeas.kmelia.model.StatsFilterVO;
 import com.silverpeas.kmelia.search.KmeliaSearchServiceFactory;
 import com.silverpeas.kmelia.stats.StatisticService;
@@ -48,6 +39,13 @@ import com.stratelia.webactiv.kmelia.control.ejb.KmeliaHelper;
 import com.stratelia.webactiv.kmelia.model.TopicDetail;
 import com.stratelia.webactiv.util.DateUtil;
 import com.stratelia.webactiv.util.GeneralPropertiesManager;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
 /**
  * This class aims to manage Kmelia statistic request.
  */
@@ -204,8 +202,6 @@ public class StatisticRequestHandler {
     profileNames.add(writerProfile.getName());
     sug.setProfileNames(profileNames);
 
-    sug.addProfileId(readerProfile.getId());
-    sug.addProfileId(writerProfile.getId());
     sel.setExtraParams(sug);
     
     return Selection.getSelectionURL(Selection.TYPE_USERS_GROUPS);


### PR DESCRIPTION
Update the initialization of the selection object used by the new user selection panel so that the use of the user role identifiers setting is now replaced by the set of both the role name and the topic they concern to.
