### PR TITLE
#3970 whitePages : Impossible d'afficher une fiche expert, résultat d'une recherche PDC

### DIFF
--- a/whitepages/whitepages-war/src/main/java/com/silverpeas/whitePages/servlets/WhitePagesRequestRouter.java
+++ b/whitepages/whitepages-war/src/main/java/com/silverpeas/whitePages/servlets/WhitePagesRequestRouter.java
@@ -415,7 +415,7 @@ public class WhitePagesRequestRouter extends ComponentRequestRouter<WhitePagesSe
         }
       }
 
-      else if (function.equals("searchResult") || function.equals("Consult")) {
+      else if (function.equals("searchResult") || function.equals("consultIdentity")) {
         request.setAttribute("userCardId", request.getParameter("Id"));
         destination = getDestination("consultCard", scc, request);
       }


### PR DESCRIPTION
J'ai oublié de mettre le "fix Bug #3970" dans mon message de commit.
