### PR TITLE
bug #4231 :  By setting the month before the day of month, when we are a...

### DIFF
--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
@@ -188,9 +188,9 @@
           // page is now ready, initialize the calendar...
 
           var currentDay = new Date();
+          currentDay.setDate(${currentDay.dayOfMonth});
           currentDay.setFullYear(${currentDay.year});
           currentDay.setMonth(${currentDay.month});
-          currentDay.setDate(${currentDay.dayOfMonth});
 
         // page is now ready, initialize the calendar...
         <c:if test='${not calendarView.viewType.nextEventsView}'>


### PR DESCRIPTION
...t the end of a month with 31 days and we want pass to the next month, instead we pass to two month after. In order to fix this bug, the day of month is set before setting the other date properties (month and year)
