### PR TITLE
Bug 4693 The settings parameter showTitle isn't correctly taken into account in the publication listing of a Kmelia topic

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -368,6 +368,12 @@ public class AjaxPublicationsListServlet extends HttpServlet {
               pubColor = "gray";
               pubState = resources.getString("PubStateDraft");
             }
+          } else if (pub.getStatus() != null && pub.isRefused()) {
+            if (admin.isInRole(profile) || publisher.isInRole(profile)
+                || currentUserId.equals(currentUser.getId())) {
+              pubColor = "red";
+              pubState = resources.getString("PublicationRefused");
+            }
           } else {
             if (admin.isInRole(profile) || publisher.isInRole(profile)
                 || currentUserId.equals(pub.getUpdaterId())


### PR DESCRIPTION
Now, the showTitle property defined in the kmeliaSettings.properties is correctly taken into account when displaying the publication listing of a folder (topic)
