### PR TITLE
Bug 4959 : fixing some bugs relative to i18n

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
@@ -3815,7 +3815,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
       if (!StringUtil.isDefined(currentId)) {
         currentId = getCurrentFolderId();
       }
-      return WysiwygController.load(getComponentId(), "Node_" + currentId, getLanguage());
+      return WysiwygController.load(getComponentId(), "Node_" + currentId, getCurrentLanguage());
     }
     return "";
   }

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
@@ -911,7 +911,8 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
             + topic.getName() + " > " + kmelia.getString("TopicWysiwyg"), CharEncoding.UTF_8);
 
         destination += "&ObjectId=Node_" + subTopicId;
-        destination += "&Language=fr";
+        destination += "&Language="+kmelia.getLanguage();
+        destination += "&ContentLanguage="+kmelia.getCurrentLanguage();
         destination += "&ReturnUrl=" + URLEncoder.encode(URLManager.getApplicationURL()
             + URLManager.getURL(kmelia.getSpaceId(), kmelia.getComponentId())
             + "FromTopicWysiwyg?Action=Search&Id=" + topicId + "&ChildId=" + subTopicId


### PR DESCRIPTION
If i18n is activated, WYSIWYG associated to folders was not correctly managed.
Content was always processed in the user's UI language (not current language selected in browse bar)

Don't forget to checkout PR on Silverpeas-Core...
