### PR TITLE
bug #4988 : the node names containing HTML text aren't correctly rendered as HTML

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -657,7 +657,7 @@ function spreadNbItems(children) {
 				child.attr['class'] = child.attr['status'];
 			<% } %>
 			if (child.attr['nbItems']) {
-				child.data = child.data + " ("+child.attr['nbItems']+")";
+				child.data = child.data + " ( "+child.attr['nbItems']+")";
 				spreadNbItems(child.children);
 			}
 		}
@@ -780,6 +780,7 @@ $(document).ready(
     	})
     	.jstree({
     	"core" : {
+        html_titles: true
     			//"load_open" : true
     	},
     	"ui" :{
@@ -805,7 +806,7 @@ $(document).ready(
 						} else {
 							if (n.data) {
 								// this is the root
-								n.data = "<%=EncodeHelper.javaStringToJsString(componentLabel)%>";
+								n.data = "<%=EncodeHelper.javaStringToHtmlString(componentLabel)%>";
 								if (n.attr['nbItems']) {
 									n.data = n.data + " ("+n.attr['nbItems']+")";
 								}


### PR DESCRIPTION
Inform the JQuery plugin jstree the name of the nodes are i...n HTML, so escaped HTML characters will be correctly rendered.

Don't forget to merge also the PR for bug-4988 on Silverpeas-Core.
