### PR TITLE
(nobranch,rebasingbug #5199) :  no online edition available for the attachments in toolbox

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/attachmentManager.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/attachmentManager.jsp
@@ -132,7 +132,7 @@ function topicGoTo(id) {
 		<br clear="all"/>
 <%	}
 	out.flush();
-	getServletConfig().getServletContext().getRequestDispatcher("/attachment/jsp/editAttachedFiles.jsp?Id="+pubId+"&ComponentId="+componentId+"&Context=attachment&IndexIt="+pIndexIt+"&Url="+url+"&UserId="+kmeliaScc.getUserId()+"&OpenUrl="+openUrl+"&Profile="+kmeliaScc.getProfile()+"&Language="+currentLang+"&XMLFormName="+URLEncoder.encode(xmlForm)).include(request, response);
+  getServletConfig().getServletContext().getRequestDispatcher("/attachment/jsp/displayAttachedFiles.jsp?Id="+pubId+"&ComponentId="+componentId+"&dnd=true&Context=attachment&IndexIt="+pIndexIt+"&Url="+url+"&UserId="+kmeliaScc.getUserId()+"&OpenUrl="+openUrl+"&Profile="+kmeliaScc.getProfile()+"&Language="+currentLang+"&XMLFormName="+URLEncoder.encode(xmlForm)).include(request, response);
 	out.flush();
 
 	if ("progress".equals(wizard) || "finish".equals(wizard)) {


### PR DESCRIPTION
Now toolbox delegates the attachments listing to the displayAttachedFiles.jsp instead of editAttachedFiles.jsp in order to profit of the online edition
