### PR TITLE
Feature #4843 : blocking the download of file attachments attached to publications

### DIFF
--- a/blog/blog-war/src/main/java/com/silverpeas/blog/access/BlogPostWriteAccessController.java
+++ b/blog/blog-war/src/main/java/com/silverpeas/blog/access/BlogPostWriteAccessController.java
@@ -23,7 +23,8 @@
  */
 package com.silverpeas.blog.access;
 
-import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AbstractAccessController;
+import com.silverpeas.accesscontrol.AccessControlContext;
 import com.silverpeas.accesscontrol.ComponentAccessController;
 import com.stratelia.webactiv.SilverpeasRole;
 import org.silverpeas.core.admin.OrganisationController;
@@ -37,10 +38,11 @@ import org.silverpeas.core.admin.OrganisationControllerFactory;
  *
  * @author mmoquillon
  */
-public class BlogPostWriteAccessController implements AccessController<String> {
+public class BlogPostWriteAccessController extends AbstractAccessController<String> {
 
   @Override
-  public boolean isUserAuthorized(String userId, String blogId) {
+  public boolean isUserAuthorized(String userId, String blogId,
+      final AccessControlContext context) {
     ComponentAccessController componentAccessController = new ComponentAccessController();
     OrganisationController organisationController = OrganisationControllerFactory.
         getOrganisationController();

--- a/kmelia/kmelia-config/src/main/config/properties/org/silverpeas/kmelia/settings/kmeliaIcons.properties
+++ b/kmelia/kmelia-config/src/main/config/properties/org/silverpeas/kmelia/settings/kmeliaIcons.properties
@@ -71,3 +71,4 @@ kmelia.operation.favorites = /util/icons/favoriteAdd.gif
 
 kmelia.file.preview = /util/icons/preview.png
 kmelia.file.view = /util/icons/view.png
+kmelia.file.forbidden-download = /util/icons/forbidden-download.png

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
@@ -55,7 +55,6 @@ import com.silverpeas.publicationTemplate.PublicationTemplateManager;
 import com.silverpeas.subscribe.service.NodeSubscriptionResource;
 import com.silverpeas.thumbnail.service.ThumbnailService;
 import com.silverpeas.thumbnail.service.ThumbnailServiceFactory;
-import com.silverpeas.thumbnail.service.ThumbnailServiceImpl;
 import com.silverpeas.util.EncodeHelper;
 import com.silverpeas.util.FileUtil;
 import com.silverpeas.util.ForeignPK;
@@ -3260,7 +3259,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
         FileRepositoryManager.copyFile(pdf.getPath(), subDirPath + File.separator + pdf.getName());
       }
       // copy files
-      new AttachmentImportExport().getAttachments(pubPK, subDirPath, "useless", null);
+      new AttachmentImportExport(getUserDetail())
+          .getAttachments(pubPK, subDirPath, "useless", null);
 
       String zipFileName = FileRepositoryManager.getTemporaryPath() + fileName + ".zip";
       // zip PDF and files

--- a/question-reply/question-reply-war/src/main/java/com/silverpeas/questionReply/control/QuestionReplyExport.java
+++ b/question-reply/question-reply-war/src/main/java/com/silverpeas/questionReply/control/QuestionReplyExport.java
@@ -23,7 +23,6 @@
  */
 package com.silverpeas.questionReply.control;
 
-import org.silverpeas.importExport.attachment.AttachmentImportExport;
 import com.silverpeas.questionReply.QuestionReplyException;
 import com.silverpeas.questionReply.model.Question;
 import com.silverpeas.questionReply.model.Reply;
@@ -33,6 +32,7 @@ import com.stratelia.webactiv.SilverpeasRole;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.FileRepositoryManager;
 import org.silverpeas.importExport.attachment.AttachmentDetail;
+import org.silverpeas.importExport.attachment.AttachmentImportExport;
 import org.silverpeas.util.UnitUtil;
 
 import java.io.File;
@@ -113,7 +113,7 @@ public class QuestionReplyExport {
       Reply reply = itR.next();
       if (isReplyVisible(question, reply, scc)) {
         reply.getPK().setComponentName(question.getInstanceId());
-        exportReply(reply, sb);
+        exportReply(scc, reply, sb);
       }
     }
     if (existe) {
@@ -126,8 +126,8 @@ public class QuestionReplyExport {
 
   }
 
-  protected void exportReply(Reply reply, StringBuilder sb) throws QuestionReplyException,
-      ParseException {
+  protected void exportReply(final QuestionReplySessionController qRSC, Reply reply,
+      StringBuilder sb) throws QuestionReplyException, ParseException {
     sb.append("<br>\n");
     sb.append("<center>\n");
     sb.append(
@@ -150,7 +150,7 @@ public class QuestionReplyExport {
     sb.append(reply.readCurrentWysiwygContent());
     sb.append("</td>\n");
     // récupération des fichiers joints : copie de ces fichiers dans le dossier "files"
-    AttachmentImportExport attachmentIE = new AttachmentImportExport();
+    AttachmentImportExport attachmentIE = new AttachmentImportExport(qRSC.getUserDetail());
     Collection<AttachmentDetail> attachments = null;
     try {
       String filePath = file.getParentFile().getPath() + File.separator + "files";

--- a/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
+++ b/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
@@ -137,7 +137,7 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
     try {
       if (versionNumber != WikiProvider.LATEST_VERSION) {
         List<SimpleDocument> versions = ((HistorisedDocument) AttachmentServiceFactory.
-            getAttachmentService().searchDocumentById(docPk, null)).getHistory();
+            getAttachmentService().searchDocumentById(docPk, null)).getFunctionalHistory();
         for (SimpleDocument version : versions) {
           if (versionNumber == version.getMajorVersion()) {
             return version;
@@ -157,7 +157,7 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
       ProviderException {
     try {
       return ((HistorisedDocument) AttachmentServiceFactory.getAttachmentService().
-          searchDocumentById(docPk, null)).getHistory();
+          searchDocumentById(docPk, null)).getFunctionalHistory();
     } catch (AttachmentException e) {
       ProviderException ex = new ProviderException(e.getMessage());
       ex.initCause(e);


### PR DESCRIPTION
- upgrading the access control mechanism to take in account the context in which the access is verified
- upgrading the document exporting in order to not include document forbidden to download
- upgrading the display of attachment according to the new forbidden download information
- refactoring some code

Don't forget to check :
- https://github.com/Silverpeas/Silverpeas-setup/pull/13
- https://github.com/Silverpeas/Silverpeas-Core/pull/459
