### PR TITLE
Feature #5189 FAQ permalink

### DIFF
--- a/question-reply/question-reply-war/src/main/webapp/questionReply/jsp/listQuestionsDHTML.jsp
+++ b/question-reply/question-reply-war/src/main/webapp/questionReply/jsp/listQuestionsDHTML.jsp
@@ -80,6 +80,7 @@ function bindQuestionsEvent() {
 						$.each(data, function(key, answer) {
 						  $('#a'+ id + ' > ul').append(displayAnswer(answer));
 						});
+						$('html, body').animate({scrollTop:$("#q" + id).parent().offset().top}, 500);
 					}
 				});
 


### PR DESCRIPTION
Automatic vertical scrolling to see directly at the top of the page a FAQ question related to some search results or updates on the FAQ application itself.
After so many attempts, still unable to remove old commit cec2073. Commits 187bfb2 and d4656b0 allow to undo it and only keep the changes corresponding to the present feature. Hope that it will be efficient.
