### PR TITLE
bug #5308 : Some HTML entities in some texts are encoded again for HTML

### DIFF
--- a/blog/blog-war/src/main/webapp/blog/jsp/accueil.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/accueil.jsp
@@ -272,7 +272,7 @@ function hideStyleSheetFile() {
 
           <div id="post<%=postId%>" class="<%=blocClass%>">
           <div class="titreTicket">
-            <a href="<%="ViewPost?PostId=" + postId%>"><%=post.getPublication().getName()%></a> <span class="status">(<%=status%>)</span>
+            <a href="<%="ViewPost?PostId=" + postId%>"><%=EncodeHelper.javaStringToHtmlString(post.getPublication().getName())%></a> <span class="status">(<%=status%>)</span>
                 <%  if ( link != null && !link.equals("")) {  %>
                   <span class="permalink"><a href="<%=link%>"><img src="<%=resource.getIcon("blog.link")%>" border="0" alt='<%=resource.getString("blog.CopyPostLink")%>' title='<%=resource.getString("blog.CopyPostLink")%>'/></a></span>
                 <%  } %>

--- a/blog/blog-war/src/main/webapp/blog/jsp/check.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/check.jsp
@@ -31,7 +31,7 @@ response.setDateHeader ("Expires",-1);          //prevents caching at the proxy 
 %>
 
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.*"%>
-<%@ page import="com.stratelia.webactiv.util.viewGenerator.html.Encode"%>
+<%@ page import="com.silverpeas.util.EncodeHelper"%>
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.window.Window"%>
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.operationPanes.OperationPane"%>
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.browseBars.BrowseBar"%>

--- a/blog/blog-war/src/main/webapp/blog/jsp/footer.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/footer.jsp
@@ -53,7 +53,7 @@ function closeWindows() {
 	<input type="hidden" name="SpaceId" value="<%=spaceId%>"/>
     <input type="hidden" name="SpaceName" value="<%=spaceLabel%>"/>
     <input type="hidden" name="ComponentId" value="<%=instanceId%>"/>
-    <input type="hidden" name="ComponentName" value="<%=Encode.javaStringToHtmlString(componentLabel)%>"/>
+    <input type="hidden" name="ComponentName" value="<%=EncodeHelper.javaStringToHtmlString(componentLabel)%>"/>
     <input type="hidden" name="ObjectId" value="<%=instanceId%>"/>
     <input type="hidden" name="Language" value="<%=resource.getLanguage()%>"/>
     <input type="hidden" name="ReturnUrl" value="<%=m_context+URLManager.getURL("blog", "useless", instanceId)%>Main"/>

--- a/blog/blog-war/src/main/webapp/blog/jsp/portlet.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/portlet.jsp
@@ -27,7 +27,6 @@
 <%@ include file="check.jsp" %>
 
 <% 
-// r�cup�ration des param�tres
 Collection	posts		= (Collection) request.getAttribute("Posts");
 %>
 

--- a/blog/blog-war/src/main/webapp/blog/jsp/toWysiwyg.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/toWysiwyg.jsp
@@ -30,7 +30,6 @@
 PublicationDetail 	pub			= (PublicationDetail) request.getAttribute("CurrentPublicationDetail");
 
 String 				pubId 		= pub.getPK().getId();
-String 				pubName 	= pub.getName();
 
 %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
@@ -60,7 +59,7 @@ function closeWindows() {
 	<input type="hidden" name="SpaceId" value="<%=spaceId%>"/>
     <input type="hidden" name="SpaceName" value="<%=spaceLabel%>"/>
     <input type="hidden" name="ComponentId" value="<%=instanceId%>"/>
-    <input type="hidden" name="ComponentName" value="<%=Encode.javaStringToHtmlString(componentLabel)%>"/>
+    <input type="hidden" name="ComponentName" value="<%=EncodeHelper.javaStringToHtmlString(componentLabel)%>"/>
     <input type="hidden" name="ObjectId" value="<%=pubId%>"/>
     <input type="hidden" name="Language" value="<%=resource.getLanguage()%>"/>
     <input type="hidden" name="ReturnUrl" value="<%=m_context+URLManager.getURL("blog", "useless", instanceId)%>FromWysiwyg?PostId=<%=pubId%>"/>

--- a/blog/blog-war/src/main/webapp/blog/jsp/viewCategory.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/viewCategory.jsp
@@ -212,7 +212,7 @@ function sortNode(updatedNodeJSON)
 		Icon updateIcon = iconPane.addIcon();
    		updateIcon.setProperties(resource.getIcon("blog.updateCategory"), resource.getString("blog.updateCategory"), "javaScript:editCategory('"+id+"')");
 		Icon deleteIcon = iconPane.addIcon();
-		deleteIcon.setProperties(resource.getIcon("blog.deleteCategory"), resource.getString("blog.deleteCategory"), "javaScript:deleteConfirm('"+id+"','"+Encode.javaStringToHtmlString(Encode.javaStringToJsString(nom))+"')");
+		deleteIcon.setProperties(resource.getIcon("blog.deleteCategory"), resource.getString("blog.deleteCategory"), "javaScript:deleteConfirm('"+id+"','"+EncodeHelper.javaStringToHtmlString(EncodeHelper.javaStringToJsString(nom))+"')");
 		iconPane.setSpacing("30");
 		ligne.addArrayCellIconPane(iconPane);
 	}	

--- a/blog/blog-war/src/main/webapp/blog/jsp/viewPost.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/viewPost.jsp
@@ -143,7 +143,7 @@ out.println(window.printBefore());
 		  </div>
 		 
 		  <div id="<%=blocClass%>">
-		   	<div class="titreTicket"><%=post.getPublication().getName()%> <span class="status">(<%=status%>)</span>
+        <div class="titreTicket"><%=EncodeHelper.javaStringToHtmlString(post.getPublication().getName())%> <span class="status">(<%=status%>)</span>
 			   	<%if (link != null && !link.equals("")) 
 			   	{	%>
 				  	<a href="<%=link%>"><img src="<%=resource.getIcon("blog.link")%>" border="0" alt='<%=resource.getString("blog.CopyPostLink")%>' title='<%=resource.getString("blog.CopyPostLink")%>' /></a>

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -70,6 +70,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.apache.commons.io.FilenameUtils;
+import org.owasp.encoder.Encode;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.component.kmelia.KmeliaPublicationHelper;
@@ -145,7 +146,8 @@ public class AjaxPublicationsListServlet extends HttpServlet {
 
       String selectedPublicationIds = req.getParameter("SelectedPubIds");
       String notSelectedPublicationIds = req.getParameter("NotSelectedPubIds");
-      List<PublicationPK> selectedIds = kmeliaSC.processSelectedPublicationIds(selectedPublicationIds,
+      List<PublicationPK> selectedIds = kmeliaSC.processSelectedPublicationIds(
+          selectedPublicationIds,
           notSelectedPublicationIds);
       boolean toPortlet = StringUtil.getBooleanValue(sToPortlet);
       boolean searchInProgress = StringUtil.isDefined(query);
@@ -542,8 +544,9 @@ public class AjaxPublicationsListServlet extends HttpServlet {
 
     template.setAttribute("publication", pub);
     template.setAttribute("link", "javascript:onClick=publicationGoTo('" + pub.getId() + "')");
-    template.setAttribute("name", name);
-    template.setAttribute("description", EncodeHelper.convertWhiteSpacesForHTMLDisplay(description));
+    template.setAttribute("name", Encode.forHtml(name));
+    template.setAttribute("description", EncodeHelper.convertWhiteSpacesForHTMLDisplay(Encode.
+        forHtml(description)));
     template.setAttribute("showDescription",
         StringUtil.isDefined(description) && !description.equals(name));
     template.setAttribute("importance", displayImportance(pub.getImportance(), resources));
@@ -574,7 +577,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     template.setAttribute("highlightClass", fragmentSettings.highlightClass);
     template
         .setAttribute("showRef", fragmentSettings.seeAlso && resources.getSetting(
-        "linkManagerShowPubId", false));
+                "linkManagerShowPubId", false));
     // Show topic name only in search in topic case
     if (fragmentSettings.toSearch && fragmentSettings.showTopicPathNameinSearchResult) {
       template.setAttribute("path", displayPublicationFullPath(kmeliaScc, pub));
@@ -587,7 +590,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     template.setAttribute("author", pub.getAuthor());
     template.setAttribute("files",
         displayFiles(pub, fragmentSettings.linkAttachment, fragmentSettings.seeAlso, userId,
-        topicId, kmeliaScc, resources));
+            topicId, kmeliaScc, resources));
 
     if (!pub.getInfoId().equals("0")) {
       template.setAttribute("formName", pub.getInfoId());
@@ -604,7 +607,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
       String userId, String topicId, KmeliaSessionController kmeliaScc, ResourcesWrapper resources,
       Writer out) throws IOException {
     PublicationDetail pub = aPub.getDetail();
-    String name = pub.getName(language);
+    String name = Encode.forHtml(pub.getName(language));
     out.write("<div class=\"line1\">");
     out.write("<span class=\"bullet\">&#8226;</span>");
     if (fragmentSettings.linksAllowed) {
@@ -719,7 +722,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     if (StringUtil.isDefined(description) && !description.equals(name)) {
       out.write("<div class=\"line3\">");
       out.write("<span class=\"description\">");
-      out.write(EncodeHelper.convertWhiteSpacesForHTMLDisplay(description));
+      out.write(EncodeHelper.convertWhiteSpacesForHTMLDisplay(Encode.forHtml(description)));
       out.write("</span>");
       out.write("</div>");
     }
@@ -821,7 +824,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
       throws IOException {
     out.
         write(
-        "<select name=\"sortBy\" id=\"sortingList\" onChange=\"javascript:sortGoTo(this.selectedIndex);\">");
+            "<select name=\"sortBy\" id=\"sortingList\" onChange=\"javascript:sortGoTo(this.selectedIndex);\">");
     out.write("<option>" + resources.getString("SortBy") + "</option>");
     out.write("<option>-------------------------------</option>");
     out.write("<option value=\"1\" id=\"sort1\" " + isSelectedSort(ksc, "1") + ">" + resources.
@@ -963,7 +966,8 @@ public class AjaxPublicationsListServlet extends HttpServlet {
         }
         boolean previewable = ViewerFactory.isPreviewable(attachment.getAttachmentPath());
         boolean viewable = ViewerFactory.isViewable(attachment.getAttachmentPath());
-        result.append(displayFile(url, title, attachment.getDescription(), icon, logicalName, size,
+        result.append(displayFile(url, title, Encode.forHtml(attachment.getDescription()), icon,
+            logicalName, size,
             downloadTime, attachment.getCreated(), permalink, resources, linkAttachment,
             previewable, viewable, attachment.getPk().getId()));
       }
@@ -1017,9 +1021,9 @@ public class AjaxPublicationsListServlet extends HttpServlet {
       if (StringUtil.isDefined(permalink)) {
         result.append("&#160;<a href=\"").append(permalink).append(
             "\" target=\"_blank\"><img src=\"").append(resources.getIcon("kmelia.link")).append(
-            "\" border=\"0\" valign=\"absmiddle\" alt=\"").append(
-            resources.getString("toolbox.CopyFileLink")).append("\" title=\"").append(
-            resources.getString("toolbox.CopyFileLink")).append("\"/></a>");
+                "\" border=\"0\" valign=\"absmiddle\" alt=\"").append(
+                resources.getString("toolbox.CopyFileLink")).append("\" title=\"").append(
+                resources.getString("toolbox.CopyFileLink")).append("\"/></a>");
       }
 
       result.append("<br/>");
@@ -1086,9 +1090,9 @@ public class AjaxPublicationsListServlet extends HttpServlet {
       if (StringUtil.isDefined(permalink)) {
         result.append("&#160;<a href=\"").append(permalink).append(
             "\" target=\"_blank\"><img src=\"").append(resources.getIcon("kmelia.link")).append(
-            "\" border=\"0\" valign=\"absmiddle\" alt=\"").append(
-            resources.getString("toolbox.CopyFileLink")).append("\" title=\"").append(
-            resources.getString("toolbox.CopyFileLink")).append("\"/></a>");
+                "\" border=\"0\" valign=\"absmiddle\" alt=\"").append(
+                resources.getString("toolbox.CopyFileLink")).append("\" title=\"").append(
+                resources.getString("toolbox.CopyFileLink")).append("\"/></a>");
       }
       result.append("<br/>");
       // displays extra information if parameter is true
@@ -1169,7 +1173,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
           writer.write("<td valign=\"top\" width=\"" + width + "%\">");
           writer.write("<p><b><a href=\"javascript:onClick=publicationGoToFromMain('"
               + pub.getPK().
-              getId() + "')\">" + pub.getName(language)
+              getId() + "')\">" + Encode.forHtml(pub.getName(language))
               + "</a>" + shortcut + "</b><br/>");
 
           if (kmeliaScc.showUserNameInList()) {
@@ -1180,11 +1184,12 @@ public class AjaxPublicationsListServlet extends HttpServlet {
             String link = URLManager.getSimpleURL(URLManager.URL_PUBLI, pub.getPK().getId());
             writer.write(" - <a href=\"" + link + "\"><img src=\"" + linkIcon
                 + "\" border=\"0\" align=\"absmiddle\" alt=\"" + resources.getString(
-                "kmelia.CopyPublicationLink") + "\" title=\"" + resources.getString(
-                "kmelia.CopyPublicationLink") + "\"></a>");
+                    "kmelia.CopyPublicationLink") + "\" title=\"" + resources.getString(
+                    "kmelia.CopyPublicationLink") + "\"></a>");
           }
           writer.write("<br/>");
-          writer.write(EncodeHelper.convertWhiteSpacesForHTMLDisplay(pub.getDescription(language)));
+          writer.write(EncodeHelper.convertWhiteSpacesForHTMLDisplay(Encode.forHtml(pub.
+              getDescription(language))));
           writer.write("</p>");
           writer.write("</td>");
           writer.write("<!-- Publication Body End -->");
@@ -1224,14 +1229,15 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     OrganisationController orga = kmelia.getOrganisationController();
     ComponentInstLight compoInstLight = orga.getComponentInstLight(pub.getInstanceId());
     String componentLabel = compoInstLight.getLabel(kmelia.getCurrentLanguage());
-    String spaceLabel = orga.getSpaceInstLightById(compoInstLight.getDomainFatherId()).getName(
-        kmelia.getCurrentLanguage());
+    String spaceLabel = Encode.forHtml(orga.
+        getSpaceInstLightById(compoInstLight.getDomainFatherId()).getName(
+            kmelia.getCurrentLanguage()));
     List<NodePK> nodesPK = (List<NodePK>) pub.getPublicationBm().getAllFatherPK(pub.getPK());
     if (nodesPK != null) {
       NodePK firstNodePK = nodesPK.get(0);
       String topicPathName = spaceLabel + " > " + componentLabel + " > "
           + kmelia.displayPath(kmelia.getKmeliaBm().getPath(firstNodePK.getId(),
-          firstNodePK.getInstanceId()), false, 3);
+                  firstNodePK.getInstanceId()), false, 3);
       return "<div class=\"publiPath\">" + topicPathName + "</div>";
     }
     return "";

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
@@ -99,15 +99,14 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.CharEncoding;
-import org.owasp.encoder.Encode;
 import org.silverpeas.importExport.versioning.DocumentVersion;
 import org.silverpeas.wysiwyg.control.WysiwygController;
 
 public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionController> {
 
   private static final long serialVersionUID = 1L;
-  private static final StatisticRequestHandler statisticRequestHandler =
-      new StatisticRequestHandler();
+  private static final StatisticRequestHandler statisticRequestHandler
+      = new StatisticRequestHandler();
 
   /**
    * This method creates a KmeliaSessionController instance
@@ -423,7 +422,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         NodeDetail node = kmelia.getSubTopicDetail(id);
         if (!SilverpeasRole.admin.isInRole(kmelia.getUserTopicProfile(id))
             && !SilverpeasRole.admin.isInRole(kmelia.getUserTopicProfile(node.getFatherPK().
-            getId()))) {
+                    getId()))) {
           destination = "/admin/jsp/accessForbidden.jsp";
         } else {
           request.setAttribute("NodeDetail", node);
@@ -508,7 +507,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         if (kmelia.isRightsOnTopicsEnabled()) {
           int rightsUsed = Integer.parseInt(request.getParameter("RightsUsed"));
           topic.setRightsDependsOn(rightsUsed);
-          
+
           // process destination
           NodeDetail oldTopic = kmelia.getNodeHeader(id);
           if (oldTopic.getRightsDependsOn() != rightsUsed) {
@@ -520,7 +519,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
           }
         }
         kmelia.updateTopicHeader(topic, alertType);
-        
+
         if (goToProfilesDefinition) {
           request.setAttribute("NodeId", id);
           destination = getDestination("ViewTopicProfiles", kmelia, request);
@@ -1267,7 +1266,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         } else {
           if (kmelia.getSessionClone() != null
               && id.equals(kmelia.getSessionClone().getDetail().getPK().
-              getId())) {
+                  getId())) {
             destination = getDestination("ViewClone", kmelia, request);
           } else {
             destination = getDestination("ViewPublication", kmelia, request);
@@ -1768,16 +1767,16 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
       KmeliaSessionController kmelia) throws Exception {
     String id = FileUploadUtil.getParameter(parameters, "PubId");
     String status = FileUploadUtil.getParameter(parameters, "Status");
-    String name = Encode.forHtml(FileUploadUtil.getParameter(parameters, "Name"));
-    String description = Encode.forHtml(FileUploadUtil.getParameter(parameters, "Description"));
-    String keywords = Encode.forHtml(FileUploadUtil.getParameter(parameters, "Keywords"));
+    String name = FileUploadUtil.getParameter(parameters, "Name");
+    String description = FileUploadUtil.getParameter(parameters, "Description");
+    String keywords = FileUploadUtil.getParameter(parameters, "Keywords");
     String beginDate = FileUploadUtil.getParameter(parameters, "BeginDate");
     String endDate = FileUploadUtil.getParameter(parameters, "EndDate");
     String version = FileUploadUtil.getParameter(parameters, "Version");
     String importance = FileUploadUtil.getParameter(parameters, "Importance");
     String beginHour = FileUploadUtil.getParameter(parameters, "BeginHour");
     String endHour = FileUploadUtil.getParameter(parameters, "EndHour");
-    String author = Encode.forHtml(FileUploadUtil.getParameter(parameters, "Author"));
+    String author = FileUploadUtil.getParameter(parameters, "Author");
     String targetValidatorId = FileUploadUtil.getParameter(parameters, "ValideurId");
     String tempId = FileUploadUtil.getParameter(parameters, "TempId");
     String infoId = FileUploadUtil.getParameter(parameters, "InfoId");
@@ -2108,9 +2107,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     String infoId = pubDetail.getInfoId();
     String pubId = pubDetail.getPK().getId();
     if (!StringUtil.isInteger(infoId)) {
-      PublicationTemplateImpl pubTemplate =
-          (PublicationTemplateImpl) getPublicationTemplateManager().getPublicationTemplate(
-          pubDetail.getPK().getInstanceId() + ":" + infoId);
+      PublicationTemplateImpl pubTemplate
+          = (PublicationTemplateImpl) getPublicationTemplateManager().getPublicationTemplate(
+              pubDetail.getPK().getInstanceId() + ":" + infoId);
 
       // RecordTemplate recordTemplate = pubTemplate.getRecordTemplate();
       Form formView = pubTemplate.getViewForm();
@@ -2593,7 +2592,4 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     return pks;
   }
 
-  private void setAttributesToPublicationHeader(KmeliaSessionController kmelia,
-      HttpServletRequest request) {
-  }
 }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -750,7 +750,7 @@
 				        /*********************************************************************************************************************/
 				        out.print("<h2 class=\"publiName\">");
 
-						   out.print(pubDetail.getName(language));
+						   out.print(EncodeHelper.javaStringToHtmlString(pubDetail.getName(language)));
 
 				     		   if (!"user".equals(profile)) {
 						          if (pubDetail.isValidationRequired()) {
@@ -767,7 +767,7 @@
 
 				        out.println("</h2>");
 
-				        String description = EncodeHelper.convertWhiteSpacesForHTMLDisplay(pubDetail.getDescription(language));
+				        String description = EncodeHelper.convertWhiteSpacesForHTMLDisplay(EncodeHelper.javaStringToHtmlString(pubDetail.getDescription(language)));
 				        if (StringUtil.isDefined(description)) {
 				        	out.println("<p class=\"publiDesc text2\">" + description + "</p>");
 				        }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
@@ -194,8 +194,8 @@
         }
       }
 
-      name = pubDetail.getName(language);
-      description = StringUtil.defaultIfBlank(pubDetail.getDescription(language), "");
+      name = EncodeHelper.javaStringToHtmlString(pubDetail.getName(language));
+      description = EncodeHelper.javaStringToHtmlString(StringUtil.defaultIfBlank(pubDetail.getDescription(language), ""));
       creationDate = resources.getOutputDate(pubDetail.getCreationDate());
       if (pubDetail.getBeginDate() != null) {
         beginDate = resources.getInputDate(pubDetail.getBeginDate());
@@ -667,12 +667,12 @@
             operationPane.addOperation(alertSrc, resources.getString("GML.notify"), "javaScript:alertUsers();");
           }
           String urlPublication = URLManager.getSimpleURL(URLManager.URL_PUBLI, pubDetail.getPK().getId());
-	      pathString = pubDetail.getName(language);
+	      pathString = EncodeHelper.javaStringToHtmlString(pubDetail.getName(language));
 	      String namePath = spaceLabel + " > " + componentLabel;
 	      if (!pathString.equals("")) {
 	      	namePath = namePath + " > " + pathString;
 	      }
-		  operationPane.addOperation(favoriteAddSrc, resources.getString("FavoritesAddPublication")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+EncodeHelper.javaStringToHtmlString(EncodeHelper.javaStringToJsString(namePath))+"','"+pubDetail.getDescription(language)+"','"+urlPublication+"')");
+		  operationPane.addOperation(favoriteAddSrc, resources.getString("FavoritesAddPublication")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+EncodeHelper.javaStringToHtmlString(EncodeHelper.javaStringToJsString(namePath))+"','"+EncodeHelper.javaStringToHtmlString(pubDetail.getDescription(language))+"','"+urlPublication+"')");
           operationPane.addLine();
 
           if (!"supervisor".equals(profile)) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
@@ -114,9 +114,9 @@ out.println(gef.getLookStyleSheet());
 %>
 	<table border="0" width="98%" align=center>
 		<tr>
-			<td align="left"><span class=txtnav><b><%=detail.getName(kmeliaScc.getCurrentLanguage())%></b></span><BR>
+			<td align="left"><span class=txtnav><b><%=EncodeHelper.javaStringToHtmlString(detail.getName(kmeliaScc.getCurrentLanguage()))%></b></span><BR>
 
-				<b><%=detail.getDescription(kmeliaScc.getCurrentLanguage())%><b>
+          <b><%=EncodeHelper.javaStringToHtmlString(detail.getDescription(kmeliaScc.getCurrentLanguage()))%><b>
 				<br />
 				<br /> 
 <%

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationsList.jsp.inc
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationsList.jsp.inc
@@ -119,7 +119,7 @@ void displaySameSubjectPublications(Collection pubs, String publicationLabel, Km
                       	if (checkboxAllowed)
                       		out.print("<td align=\"center\"><input type=\"checkbox\" name=\"PubIds\" value=\""+pub.getPK().getId()+"-"+pub.getPK().getInstanceId()+"\"></td>");
 						out.print("<td width=\"1\">&#149;&nbsp;</td><td nowrap>");
-						out.print("<a href=\""+URLManager.getSimpleURL(URLManager.URL_PUBLI, pub.getPK().getId(), pub.getPK().getInstanceId())+"\"><b>"+pub.getName(language)+"</b></a>");
+						out.print("<a href=\""+URLManager.getSimpleURL(URLManager.URL_PUBLI, pub.getPK().getId(), pub.getPK().getInstanceId())+"\"><b>"+EncodeHelper.javaStringToHtmlString(pub.getName(language))+"</b></a>");
 						out.print("&nbsp;</td><td width=\"100%\">");
 						if (showImportance)
 							out.print(displayImportance(new Integer(pub.getImportance()).intValue(), 5, resources, out));
@@ -132,7 +132,7 @@ void displaySameSubjectPublications(Collection pubs, String publicationLabel, Km
 							out.println("<td width=\"1\">&nbsp;</td>");
 						out.println("<td width=\"1\">&nbsp;</td>");
 						out.println("<td colspan=\"3\">"+getUserName(kmeliaPub, kmeliaScc)+" - "+resources.getOutputDate(pub.getUpdateDate())+"<br/>");
-						out.println(pub.getDescription(language)+"<br/><br/></td>");
+						out.println(EncodeHelper.javaStringToHtmlString(pub.getDescription(language))+"<br/><br/></td>");
 						out.println("</td></tr></table>");
 						out.println("</td>");
                       out.println("</tr>");


### PR DESCRIPTION
Remove the encoding for HTML rendering of the publications in Kmelia and in Blog. The encoding for HTML should be done at the HTML rendering and only for the data that were set by a user. (The encoding for HTML is to avoid XSS attacks.)

Don't forget to integrate also the branch bug-5308 in Silverpeas-Core and in Silverpeas-Setup.

The integration should be done also for 5.12.8-SNAPSHOT.
