### PR TITLE
Bug #5479 : JCR copy and move problems

### DIFF
--- a/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
+++ b/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
@@ -46,6 +46,7 @@ import java.util.*;
 import org.apache.commons.io.FileUtils;
 import org.silverpeas.attachment.model.HistorisedDocument;
 import org.silverpeas.attachment.model.SimpleAttachment;
+import org.silverpeas.attachment.model.SimpleDocumentVersion;
 import org.silverpeas.attachment.model.UnlockContext;
 
 import com.silverpeas.util.i18n.I18NHelper;
@@ -131,12 +132,11 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
     att.setAttribute(WikiPage.CHANGENOTE, currentVersion.getDescription());
   }
 
-  @SuppressWarnings("unchecked")
   protected SimpleDocument getDocumentVersion(SimpleDocumentPK docPk, int versionNumber) throws
       ProviderException {
     try {
       if (versionNumber != WikiProvider.LATEST_VERSION) {
-        List<SimpleDocument> versions = ((HistorisedDocument) AttachmentServiceFactory.
+        List<SimpleDocumentVersion> versions = ((HistorisedDocument) AttachmentServiceFactory.
             getAttachmentService().searchDocumentById(docPk, null)).getFunctionalHistory();
         for (SimpleDocument version : versions) {
           if (versionNumber == version.getMajorVersion()) {
@@ -152,11 +152,10 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
     }
   }
 
-  @SuppressWarnings("unchecked")
   protected List<SimpleDocument> getAllDocumentVersions(SimpleDocumentPK docPk) throws
       ProviderException {
     try {
-      return ((HistorisedDocument) AttachmentServiceFactory.getAttachmentService().
+      return (List)((HistorisedDocument) AttachmentServiceFactory.getAttachmentService().
           searchDocumentById(docPk, null)).getFunctionalHistory();
     } catch (AttachmentException e) {
       ProviderException ex = new ProviderException(e.getMessage());


### PR DESCRIPTION
- fixing the case of the copy that did not work too (history of versions was not respected, i18n was not supported, date of a version was not the one of the original but the date of the copy action !)
- fixing the case of the move
- upgrading the simple document access controller in order to take in account the versions of attachments
- improving the mechanism of universal link associated to attachments
- handling the language content for versioned attachments

Don't forget to check https://github.com/Silverpeas/Silverpeas-Core/pull/506
