### PR TITLE
Bug #5329 : multilingual - fixing the case of adding a first WYSIWYG content to a publication that the content language is not the same as the one selected at application level.

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
@@ -1271,7 +1271,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         }
         request.setAttribute("ObjectId", publication.getId());
         request.setAttribute("Language", kmelia.getLanguage());
-        request.setAttribute("ContentLanguage", kmelia.getCurrentLanguage());
+        request.setAttribute("ContentLanguage", checkLanguage(kmelia, publication));
         request.setAttribute("ReturnUrl", URLManager.getApplicationURL() + kmelia.getComponentUrl()
             + "FromWysiwyg?PubId=" + publication.getId());
         request.setAttribute("UserId", kmelia.getUserId());


### PR DESCRIPTION
The language of the WYSIWYG content used was the one selected at application level instead of the one of the publication ...

Please don't forget to check https://github.com/Silverpeas/Silverpeas-Core/pull/507 PR.
