### PR TITLE
Bug #5479 : work done for 5.14.x merged for 5.13.x

### DIFF
--- a/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
+++ b/wiki/wiki-jar/src/main/java/com/ecyrd/jspwiki/providers/WikiVersioningAttachmentProvider.java
@@ -46,6 +46,7 @@ import java.util.*;
 import org.apache.commons.io.FileUtils;
 import org.silverpeas.attachment.model.HistorisedDocument;
 import org.silverpeas.attachment.model.SimpleAttachment;
+import org.silverpeas.attachment.model.SimpleDocumentVersion;
 import org.silverpeas.attachment.model.UnlockContext;
 
 import com.silverpeas.util.i18n.I18NHelper;
@@ -131,13 +132,12 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
     att.setAttribute(WikiPage.CHANGENOTE, currentVersion.getDescription());
   }
 
-  @SuppressWarnings("unchecked")
   protected SimpleDocument getDocumentVersion(SimpleDocumentPK docPk, int versionNumber) throws
       ProviderException {
     try {
       if (versionNumber != WikiProvider.LATEST_VERSION) {
-        List<SimpleDocument> versions = ((HistorisedDocument) AttachmentServiceFactory.
-            getAttachmentService().searchDocumentById(docPk, null)).getHistory();
+        List<SimpleDocumentVersion> versions = ((HistorisedDocument) AttachmentServiceFactory.
+            getAttachmentService().searchDocumentById(docPk, null)).getFunctionalHistory();
         for (SimpleDocument version : versions) {
           if (versionNumber == version.getMajorVersion()) {
             return version;
@@ -152,12 +152,11 @@ public class WikiVersioningAttachmentProvider implements WikiAttachmentProvider 
     }
   }
 
-  @SuppressWarnings("unchecked")
   protected List<SimpleDocument> getAllDocumentVersions(SimpleDocumentPK docPk) throws
       ProviderException {
     try {
-      return ((HistorisedDocument) AttachmentServiceFactory.getAttachmentService().
-          searchDocumentById(docPk, null)).getHistory();
+      return (List)((HistorisedDocument) AttachmentServiceFactory.getAttachmentService().
+          searchDocumentById(docPk, null)).getFunctionalHistory();
     } catch (AttachmentException e) {
       ProviderException ex = new ProviderException(e.getMessage());
       ex.initCause(e);


### PR DESCRIPTION
 Cf. https://github.com/Silverpeas/Silverpeas-Components/pull/304

Also, taking into account a new detected problem around the copy of a versioned attachment that had several language contents before to be turned into versioned attachment.
The problem was that the result copy of this kind of attachment was keeping only one of the several language contents for its initial version.
