### PR TITLE
silverpeas file :  move file operations from SilverpeasFileProvider to SilverpeasFile

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
@@ -81,6 +81,9 @@ import com.stratelia.webactiv.util.publication.model.PublicationPK;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.CharEncoding;
+import org.silverpeas.file.SilverpeasFile;
+import org.silverpeas.file.SilverpeasFileDescriptor;
+import org.silverpeas.file.SilverpeasFileProvider;
 import org.silverpeas.importExport.versioning.DocumentVersion;
 import org.silverpeas.servlet.FileUploadUtil;
 import org.silverpeas.servlet.HttpRequest;
@@ -1867,7 +1870,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     return pubDetail;
   }
 
-  /**
+ /**
    * Process Form Upload for publications import
    *
    * @param kmeliaScc


### PR DESCRIPTION
Take into account the change of the Silverpeas File API (now some methods are moved from the SilverpeasFileProvider class to the SilverpeasFile class)

Don't forget to merge also Silvepreas Core: https://github.com/Silverpeas/Silverpeas-Core/pull/542
