### PR TITLE
Bug #6052

### DIFF
--- a/kmelia/kmelia-config/src/main/config/xmlcomponents/kmelia.xml
+++ b/kmelia/kmelia-config/src/main/config/xmlcomponents/kmelia.xml
@@ -349,9 +349,9 @@
       <type>checkbox</type>
       <updatable>always</updatable>
       <help>
-        <message lang="fr">Permet de gérer les versions des fichiers joints.</message>
-        <message lang="en">Attachments are versioned.</message>
-        <message lang="de">Anhänge werden versioniert.</message>
+        <message lang="fr">Permet de gérer les versions des fichiers joints. Ce paramètre est ignoré et considéré comme désactivé si celui "Publication toujours visible" est activé.</message>
+        <message lang="en">Attachments are versioned. This parameter is ignored and considered disabled if "Publication always visible" is enabled.</message>
+        <message lang="de">Anhänge werden versioniert. Dieser Parameter wird ignoriert und deaktiviert, wenn "Veröffentlichung immer Sichtbar" aktiviert ist.</message>
       </help>
     </parameter>
     <parameter>
@@ -667,9 +667,9 @@
       <type>checkbox</type>
       <updatable>always</updatable>
       <help>
-        <message lang="fr">La dernière version validée d'une publication est toujours visible même lorsqu'elle est en attente de validation.</message>
-        <message lang="en">The latest valid version of a publication is always visible even if it is waiting approval.</message>
-        <message lang="de">Die letztgültigen Fassung einer Veröffentlichung ist immer sichtbar, auch wenn es auf einer Genehmigung wartet.</message>
+        <message lang="fr">La dernière version validée d'une publication est toujours visible même lorsqu'elle est en attente de validation. Si activé, le paramètre "Fichiers joints versionnés" est ignoré et est considéré comme désactivé.</message>
+        <message lang="en">The latest valid version of a publication is always visible even if it is waiting approval. If enabled, "Versioned attachments" parameter is ignored and is considered deactivated.</message>
+        <message lang="de">Die letztgültigen Fassung einer Veröffentlichung ist immer sichtbar, auch wenn es auf einer Genehmigung wartet. Wenn aktiviert, die Parameter "Versionierte Anhänge" wird ignoriert, und gilt als deaktiviert.</message>
       </help>
     </parameter>
     <parameter>

--- a/kmelia/kmelia-ejb/src/main/java/com/stratelia/webactiv/kmelia/control/ejb/KmeliaBmEJB.java
+++ b/kmelia/kmelia-ejb/src/main/java/com/stratelia/webactiv/kmelia/control/ejb/KmeliaBmEJB.java
@@ -1391,7 +1391,7 @@ public class KmeliaBmEJB implements KmeliaBm {
         "root.MSG_GEN_ENTER_METHOD", "updateScope = " + updateScope);
     try {
       // if pubDetail is a clone
-      boolean isClone = isClone(pubDetail);
+      boolean isClone = pubDetail.isClone();
       SilverTrace.info("kmelia", "KmeliaBmEJB.updatePublication()", "root.MSG_GEN_PARAM_VALUE",
           "This publication is clone ? " + isClone);
       
@@ -1690,8 +1690,7 @@ public class KmeliaBmEJB implements KmeliaBm {
         return;
       }
 
-      boolean clone = isClone(pubDetail);
-      if (clone) {
+      if (pubDetail.isClone()) {
         pubDetail.setIndexOperation(IndexManager.NONE);
       }
 
@@ -1718,11 +1717,6 @@ public class KmeliaBmEJB implements KmeliaBm {
       // index all attached files to taking into account visibility period
       indexExternalElementsOfPublication(pubDetail);
     }
-  }
-
-  private boolean isClone(PublicationDetail publication) {
-    return isDefined(publication.getCloneId()) && !"-1".equals(publication.getCloneId())
-        && !isDefined(publication.getCloneStatus());
   }
 
   /**
@@ -2270,7 +2264,7 @@ public class KmeliaBmEJB implements KmeliaBm {
               "root.MSG_GEN_PARAM_VALUE", "Getting the publication");
           PublicationDetail publi = publicationBm.getDetail(pubPK);
           if (publi != null) {
-            boolean isClone = isClone(publi);
+            boolean isClone = publi.isClone();
             SilverTrace.info("kmelia", "KmeliaBmEJB.getPublicationFathers()",
                 "root.MSG_GEN_PARAM_VALUE", "This publication is clone ? " + isClone);
             if (isClone) {

--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/control/KmeliaSessionController.java
@@ -137,17 +137,8 @@ import com.stratelia.webactiv.util.statistic.model.HistoryObjectDetail;
 import com.stratelia.webactiv.util.statistic.model.StatisticRuntimeException;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.StringTokenizer;
 import org.apache.commons.io.FileUtils;
+import org.owasp.encoder.Encode;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.DocumentType;
 import org.silverpeas.attachment.model.SimpleDocument;
@@ -174,7 +165,7 @@ import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.rmi.RemoteException;
-import org.owasp.encoder.Encode;
+import java.util.*;
 
 import static com.silverpeas.kmelia.export.KmeliaPublicationExporter.*;
 import static com.silverpeas.pdc.model.PdcClassification.NONE_CLASSIFICATION;
@@ -1968,10 +1959,22 @@ public class KmeliaSessionController extends AbstractComponentSessionController 
   }
 
   public boolean isVersionControlled() {
+    if (isPublicationAlwaysVisibleEnabled()) {
+      // This mode is not compatible, for now, with the possibility to manage versioned
+      // attachments.
+      return false;
+    }
     return StringUtil.getBooleanValue(getComponentParameterValue(VERSION_MODE));
   }
 
   public boolean isVersionControlled(String anotherComponentId) {
+    String strPublicationAlwaysVisible = getOrganisationController()
+        .getComponentParameterValue(anotherComponentId, "publicationAlwaysVisible");
+    if (StringUtil.getBooleanValue(strPublicationAlwaysVisible)) {
+      // This mode is not compatible, for now, with the possibility to manage versioned
+      // attachments.
+      return false;
+    }
     String strVersionControlled = getOrganisationController().getComponentParameterValue(
         anotherComponentId, VERSION_MODE);
     return StringUtil.getBooleanValue(strVersionControlled);

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/kmelia/notification/ConfigurationChangeListener.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/kmelia/notification/ConfigurationChangeListener.java
@@ -23,21 +23,21 @@
  */
 package org.silverpeas.kmelia.notification;
 
-import javax.inject.Named;
-
-import org.silverpeas.attachment.AttachmentServiceFactory;
-import org.silverpeas.notification.jsondiff.Operation;
-
 import com.silverpeas.admin.notification.ComponentJsonPatch;
 import com.silverpeas.notification.DefaultNotificationSubscriber;
 import com.silverpeas.notification.NotificationTopic;
 import com.silverpeas.notification.SilverpeasNotification;
 import com.silverpeas.util.StringUtil;
+import org.silverpeas.attachment.AttachmentServiceFactory;
+import org.silverpeas.notification.jsondiff.Operation;
+
+import javax.inject.Named;
 
 import static com.silverpeas.notification.NotificationTopic.onTopic;
 import static com.silverpeas.notification.RegisteredTopics.ADMIN_COMPONENT_TOPIC;
 import static com.silverpeas.notification.RegisteredTopics.fromName;
 import static com.silverpeas.notification.SilverpeasNotificationCause.UPDATE;
+import static com.stratelia.webactiv.beans.admin.AdminReference.getAdminService;
 import static org.silverpeas.attachment.AttachmentService.VERSION_MODE;
 
 /**
@@ -64,9 +64,15 @@ public class ConfigurationChangeListener extends DefaultNotificationSubscriber {
       if ("kmelia".equalsIgnoreCase(patch.getComponentType())) {
         Operation operation = patch.getOperationByPath(VERSION_MODE);
         if (operation != null) {
-          AttachmentServiceFactory.getAttachmentService().switchComponentBehaviour(notification
-              .getSource().getComponentInstanceId(), StringUtil.getBooleanValue(operation
-              .getValue()));
+          boolean toVersionning = StringUtil.getBooleanValue(operation.getValue());
+          boolean alwaysVisible = StringUtil.getBooleanValue(getAdminService()
+              .getComponentParameterValue(notification.getSource().getComponentInstanceId(),
+                  "publicationAlwaysVisible"));
+          if (!alwaysVisible || !toVersionning) {
+            AttachmentServiceFactory.getAttachmentService()
+                .switchComponentBehaviour(notification.getSource().getComponentInstanceId(),
+                    toVersionning);
+          }
         }
       }
     }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/clone.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/clone.jsp
@@ -302,24 +302,13 @@ $(function() {
 		    out.println("<a name=\"attachments\"></a>");
 			try {
 				out.flush();
-				if (kmeliaScc.isVersionControlled()) {
-					getServletConfig().getServletContext().getRequestDispatcher(
-                "/attachment/jsp/displayAttachedFiles.jsp?Id=" + id + "&ComponentId=" + componentId
-                + "&Context=attachment&Language=" + resources.getLanguage()
-                    + "&AttachmentPosition="
-                + resources.getSetting("attachmentPosition") + "&ShowIcon=" + showIcon
-                + "&ShowTitle=" + showTitle + "&ShowFileSize=" + showFileSize
-                + "&ShowDownloadEstimation=" + showDownloadEstimation + "&ShowInfo=" + showInfo)
-                .include(request, response);
-				} else {
-					getServletConfig().getServletContext().getRequestDispatcher(
-                "/attachment/jsp/displayAttachedFiles.jsp?Id=" + id + "&ComponentId=" + componentId
-                + "&Context=attachment&AttachmentPosition=" + resources.getSetting(
-                "attachmentPosition") + "&ShowIcon=" + showIcon + "&ShowTitle=" + showTitle
-                      + "&ShowFileSize=" + showFileSize + "&ShowDownloadEstimation="
-                      + showDownloadEstimation + "&ShowInfo=" + showInfo + "&Profile=" + profile)
-                      .include(request, response);
-				}
+        getServletConfig().getServletContext().getRequestDispatcher(
+            "/attachment/jsp/displayAttachedFiles.jsp?Id=" + id + "&ComponentId=" + componentId +
+                "&Context=attachment&AttachmentPosition=" +
+                resources.getSetting("attachmentPosition") + "&ShowIcon=" + showIcon +
+                "&ShowTitle=" + showTitle + "&ShowFileSize=" + showFileSize +
+                "&ShowDownloadEstimation=" + showDownloadEstimation + "&ShowInfo=" + showInfo +
+                "&Profile=" + profile).include(request, response);
 			} catch (Exception e) {
 				throw new KmeliaException("JSPpublicationManager.displayUserModelAndAttachmentsView()",SilverpeasException.ERROR,"root.EX_DISPLAY_ATTACHMENTS_FAILED", e);
 			}

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -538,10 +538,6 @@
 
         InfoDetail infos = pubComplete.getInfoDetail();
         ModelDetail model = pubComplete.getModelDetail();
-        int type = 0;
-        if (kmeliaScc.isVersionControlled()) {
-          type = 1; // Versioning
-        }
         /*********************************************************************************************************************/
         /** Affichage des boutons de navigation (next / previous)															**/
         /*********************************************************************************************************************/
@@ -609,15 +605,9 @@
 			          try {
 			            out.flush();
 			            String attProfile = kmeliaScc.getProfile();
-			            if (kmeliaScc.isVersionControlled(componentId)) {
-			              if (!isUpdatable) {
-			                attProfile = "user";
-			              }
-			            } else {
-				              if (!attachmentsUpdatable) {
-				                attProfile = "user";
-				              }
-			            }
+                  if (!attachmentsUpdatable) {
+                    attProfile = "user";
+                  }
                   getServletConfig().getServletContext().getRequestDispatcher(
                       "/attachment/jsp/displayAttachedFiles.jsp?Id=" + id + "&ComponentId=" + componentId + "&Alias=" + alias + "&Context=attachment&AttachmentPosition=" + resources.
                           getSetting("attachmentPosition") + "&ShowIcon=" + showIcon + "&ShowTitle=" + showTitle + "&ShowFileSize=" + showFileSize + "&ShowDownloadEstimation=" + showDownloadEstimation + "&ShowInfo=" + showInfo +


### PR DESCRIPTION
- refactoring the way to get the information that a publication is a clone
- removing the management of 'Versionned attachments' component parameter in UI (this parameter must be used only for default behavior on new attachment adding)
- versionning ignored is publications are always visible parameter is enabled

Linked PR: https://github.com/Silverpeas/Silverpeas-Core/pull/586