### PR TITLE
Fix bug 6937 for 5.15

### DIFF
--- a/yellowpages/yellowpages-ejb/src/main/java/com/stratelia/webactiv/yellowpages/model/GroupDetail.java
+++ b/yellowpages/yellowpages-ejb/src/main/java/com/stratelia/webactiv/yellowpages/model/GroupDetail.java
@@ -32,7 +32,6 @@ public class GroupDetail extends Group implements java.io.Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private int totalUsers = 0;
   private List<UserDetail> users = new ArrayList<UserDetail>();
   private List<GroupDetail> subGroups = new ArrayList<GroupDetail>();
 
@@ -77,19 +76,14 @@ public class GroupDetail extends Group implements java.io.Serializable {
 
   @Override
   public int hashCode() {
-    int hash = 3;
-    hash = 47 * hash + this.totalUsers;
+    int hash = super.hashCode();
     hash = 47 * hash + (this.users != null ? this.users.hashCode() : 0);
     hash = 47 * hash + (this.subGroups != null ? this.subGroups.hashCode() : 0);
     return hash;
   }
 
   public int getTotalUsers() {
-    return totalUsers;
-  }
-
-  public void setTotalUsers(int totalUsers) {
-    this.totalUsers = totalUsers;
+    return super.getTotalNbUsers();
   }
 
 }

--- a/yellowpages/yellowpages-war/src/main/java/com/stratelia/webactiv/yellowpages/control/YellowpagesSessionController.java
+++ b/yellowpages/yellowpages-war/src/main/java/com/stratelia/webactiv/yellowpages/control/YellowpagesSessionController.java
@@ -225,8 +225,6 @@ public class YellowpagesSessionController extends AbstractComponentSessionContro
     for (Group subGroup1 : subGroups) {
       subGroup = subGroup1;
       subGroupDetail = new GroupDetail(subGroup);
-      subGroupDetail.setTotalUsers(getOrganisationController().
-          getAllSubUsersNumber(subGroup.getId()));
       groupDetail.addSubGroup(subGroupDetail);
     }
 


### PR DESCRIPTION
Doesn't set explicitly the direct number and the total number of users in a group as they are taken in charge by the Group class itself

The fix comes from cherry-picking the commits in 5.14.x