### PR TITLE
Suppression de styles qui n'ont rien à faire dans le code html

### DIFF
--- a/suggestion-box/suggestion-box-war/src/main/webapp/suggestionBox/jsp/suggestionEdit.jsp
+++ b/suggestion-box/suggestion-box-war/src/main/webapp/suggestionBox/jsp/suggestionEdit.jsp
@@ -140,14 +140,14 @@
                 <label for="title" class="txtlibform"><fmt:message key='GML.title'/>&nbsp;<img alt="mandatory" src="${mandatoryIcons}" width="5" height="5"/></label>
 
                 <div class="champs">
-                  <input id="title" type="text" name="title" size="70%" maxlength="2000" value="<c:out value='${suggestion.title}'/>" style="width: auto"/>
+                  <input id="title" type="text" name="title" maxlength="2000" value="<c:out value='${suggestion.title}'/>" />
                 </div>
               </div>
             </div>
           </fieldset>
         </div>
         <c:if test="${suggestion == null}">
-          <div style="width: 50%" class="cell">
+          <div class="cell">
             <view:fileUpload fieldset="true" jqueryFormSelector="form[name='suggestion']"/>
           </div>
         </c:if>


### PR DESCRIPTION
Des styles étaient en dur dans le code. Donc ça ne se fait pas, et en plus ça embête ensuite quand on veut faire les ajustements avec la css.

Lié au pull sur core : https://github.com/Silverpeas/Silverpeas-Core/pull/653