### PR TITLE
Feature #6071: skipping notification sending from attachment actions performed from publication page of kmelia application.

### DIFF
--- a/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/com/stratelia/webactiv/kmelia/servlets/KmeliaRequestRouter.java
@@ -718,6 +718,11 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
           request.setAttribute("PublicationSharingAllowed", kmelia.isPublicationSharingEnabled() &&
               kmeliaPublication.getDetail().isValid());
 
+          // Subscription management
+          setupRequestForSubscriptionNotificationSending(request,
+              highestSilverpeasUserRoleOnCurrentTopic, kmelia.getCurrentFolderPK(),
+              kmeliaPublication.getDetail());
+
           destination = rootDestination + "publication.jsp";
         }
       } else if (function.equals("PreviousPublication")) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -644,8 +644,6 @@
 			          /*********************************************************************************************************************/
 			          boolean showTitle = resources.getSetting("showTitle", true);
 			          boolean showFileSize = resources.getSetting("showFileSize", true);
-			          boolean showDownloadEstimation = resources.getSetting("showDownloadEstimation",
-			              true);
 			          boolean showInfo = resources.getSetting("showInfo", true);
 			          boolean showIcon = true;
 
@@ -657,23 +655,29 @@
 
 			            out.println("<a name=\"attachments\"></a>");
 			          }
-			          try {
-			            out.flush();
-			            String attProfile = kmeliaScc.getProfile();
-                  if (!attachmentsUpdatable) {
-                    attProfile = "user";
-                  }
-                  getServletConfig().getServletContext().getRequestDispatcher(
-                      "/attachment/jsp/displayAttachedFiles.jsp?Id=" + id + "&ComponentId=" + componentId + "&Alias=" + alias + "&Context=attachment&AttachmentPosition=" + resources.
-                          getSetting("attachmentPosition") + "&ShowIcon=" + showIcon + "&ShowTitle=" + showTitle + "&ShowFileSize=" + showFileSize + "&ShowDownloadEstimation=" + showDownloadEstimation + "&ShowInfo=" + showInfo +
-                          "&Language=" + language + "&Profile=" + attProfile + "&CallbackUrl=" + URLManager.
-                          getURL("useless", componentId) + "ViewPublication&IndexIt=" + indexIt + "&ShowMenuNotif=" + true).
-                      include(request, response);
-			          } catch (Exception e) {
-			            throw new KmeliaException(
-			                "JSPpublicationManager.displayUserModelAndAttachmentsView()",
-			                SilverpeasException.ERROR, "root.EX_DISPLAY_ATTACHMENTS_FAILED", e);
-			          }
+                out.flush();
+                String attProfile = kmeliaScc.getProfile();
+                if (!attachmentsUpdatable) {
+                  attProfile = "user";
+                }
+                %>
+        <c:set var="attachmentPosition"><%=resources.getSetting("attachmentPosition")%></c:set>
+        <c:set var="callbackUrl"><%=URLManager.getURL("useless", componentId) + "ViewPublication"%></c:set>
+        <viewTags:displayAttachments componentInstanceId="<%=componentId%>"
+                                     componentInstanceIdAlias="<%=alias%>"
+                                     resourceId="<%=id%>"
+                                     contentLanguage="<%=language%>"
+                                     greatestUserRole="<%=SilverpeasRole.from(attProfile)%>"
+                                     reloadCallbackUrl="${callbackUrl}"
+                                     hasToBeIndexed="<%=StringUtil.getBooleanValue(indexIt)%>"
+                                     attachmentPosition="${attachmentPosition}"
+                                     showIcon="<%=showIcon%>"
+                                     showTitle="<%=showTitle%>"
+                                     showDescription="<%=showInfo%>"
+                                     showFileSize="<%=showFileSize%>"
+                                     showMenuNotif="${true}"
+                                     subscriptionManagementContext="${requestScope.subscriptionManagementContext}"/>
+        <%
 
 			        }
 

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -24,6 +24,7 @@
 
 --%>
 <%@page import="org.silverpeas.components.quickinfo.model.News"%>
+<%@page import="com.stratelia.webactiv.SilverpeasRole" %>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
@@ -35,11 +36,16 @@
 <view:setBundle bundle="${requestScope.resources.multilangBundle}" />
 
 <c:set var="news" value="${requestScope['News']}"/>
+<jsp:useBean id="news" type="org.silverpeas.components.quickinfo.model.News"/>
 <c:set var="role" value="${requestScope['Role']}"/>
+<jsp:useBean id="role" type="java.lang.String"/>
+<c:set var="greatestUserRole" value="<%=SilverpeasRole.from(role)%>"/>
+<jsp:useBean id="greatestUserRole" type="com.stratelia.webactiv.SilverpeasRole"/>
 <c:set var="contributor" value="${role == 'admin' || role == 'publisher'}"/>
 <c:set var="userId" value="${sessionScope['SilverSessionController'].userId}"/>
 <c:set var="appSettings" value="${requestScope['AppSettings']}"/>
-<c:set var="viewOnly" value="${requestScope['ViewOnly']}"/>
+<c:set var="viewOnly" value="${not empty requestScope['ViewOnly'] ? requestScope['ViewOnly'] : false}"/>
+<jsp:useBean id="viewOnly" type="java.lang.Boolean"/>
 
 <%@ include file="checkQuickInfo.jsp" %>
 <%
@@ -133,13 +139,12 @@ function submitOnHomepage() {
 	</div>
 
   <%-- Attachments --%>
-  <c:import url="/attachment/jsp/displayAttachedFiles.jsp">
-    <c:param name="Id">${news.publicationId}</c:param>
-    <c:param name="Profile" value="${role eq 'user' ? 'user' : 'admin'}" />
-    <c:param name="ComponentId">${news.componentInstanceId}</c:param>
-    <c:param name="Context" value="${'attachment'}" />
-    <c:param name="addFileMenu" value="${'true'}" />
-  </c:import>
+  <c:set var="callbackUrl"><%=URLManager.getURL("useless", news.getComponentInstanceId()) + (viewOnly ? "ViewOnly" : "View") + "?Id=" + news.getId()%></c:set>
+  <c:set var="greatestUserRoleForAttachments" value="<%=greatestUserRole == SilverpeasRole.user ? SilverpeasRole.user : SilverpeasRole.admin%>"/>
+  <viewTags:displayAttachments componentInstanceId="${news.componentInstanceId}"
+                               resourceId="${news.publicationId}"
+                               greatestUserRole="${greatestUserRoleForAttachments}"
+                               reloadCallbackUrl="${callbackUrl}"/>
                           
   <viewTags:displayLastUserCRUD createDate="${news.createDate}" createdById="${news.createdBy}" updateDate="${news.updateDate}" updatedById="${news.updaterId}" publishDate="${news.onlineDate}" publishedById="${news.publishedBy}"/>
     


### PR DESCRIPTION
Using the new tag that handles the call of displayAttachedFiles.jsp (instead of calling it directly...) into publication display.

Fixing also a problem into quick info application, by using the new tag.
The problem occurred when adding an attachment just after the creation of a news: it was duplicating the news !

Linked to https://github.com/Silverpeas/Silverpeas-Core/pull/655