### PR TITLE
Feature 8046

### DIFF
--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
@@ -44,6 +44,8 @@
         <c:out value=".fc-event.${almanach.instanceId} { background-color: ${almanach.color}; border-color: ${almanach.color}; color: white; }"/>
       </c:forEach>
     </style>
+    <!-- Modifier l'appel de la css dans le plugin -->
+    <link rel='stylesheet' type='text/css' href="<c:url value='/util/styleSheets/fullcalendar-silverpeas.css'/>" />
     <view:includePlugin name="calendar"/>
     <script type="text/javascript">
       <!--

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
@@ -179,25 +179,18 @@
       </c:if>
 
         $(document).ready(function() {
-
-          // page is now ready, initialize the calendar...
-
-          var currentDay = new Date();
-          currentDay.setDate(${currentDay.dayOfMonth});
-          currentDay.setFullYear(${currentDay.year});
-          currentDay.setMonth(${currentDay.month});
-
         // page is now ready, initialize the calendar...
         <c:if test='${not calendarView.viewType.nextEventsView}'>
           $("#calendar").calendar({
             view: "${fn:toLowerCase(calendarView.viewType.name)}",
             weekends: ${calendarView.weekendVisible},
             firstDayOfWeek: ${calendarView.firstDayOfWeek},
-            currentDate: currentDay,
+            currentDate: moment({'year': ${currentDay.year}, 'month': ${currentDay.month},
+              'date': ${currentDay.dayOfMonth}}),
             events: <c:out value='${calendarView.eventsInJSON}' escapeXml='yes'/>,
             onday: clickDay,
             onevent: function(event) {
-              var eventDate = $.fullCalendar.formatDate(event.start, "yyyy/MM/dd");
+              var eventDate = event.start.format("YYYY/MM/DD");
               clickEvent(event.id, eventDate, event.instanceId);
             }
           });

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/calendar.jsp
@@ -44,8 +44,6 @@
         <c:out value=".fc-event.${almanach.instanceId} { background-color: ${almanach.color}; border-color: ${almanach.color}; color: white; }"/>
       </c:forEach>
     </style>
-    <!-- Modifier l'appel de la css dans le plugin -->
-    <link rel='stylesheet' type='text/css' href="<c:url value='/util/styleSheets/fullcalendar-silverpeas.css'/>" />
     <view:includePlugin name="calendar"/>
     <script type="text/javascript">
       <!--

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/listOfEvents.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/listOfEvents.jsp
@@ -161,37 +161,23 @@
          * Formats the specified date into a string according the pattern 'yyyy/MM/dd'.
          */
         function formatDate(date) {
-          var year = date.getFullYear(), month = date.getMonth()+1, day = date.getDate();
-          if (month < 10) month = "0" + month;
-          if (day < 10) day = "0" + day;
-          return year + "/" + month + "/" + day;
+          return date.format('YYYY/MM/DD');
         }
 
         function formatToLocaleDateString(date, lang) {
-          var year = date.getFullYear(), month = date.getMonth()+1, day = date.getDate();
-          if (month < 10) month = "0" + month;
-          if (day < 10) day = "0" + day;
-          var sep = getDateSeparator(lang);
-          if (lang === "en") {
-            return month + sep + day + sep + year;
-          }
-          return day + sep + month + sep + year;
+          return date.locale(lang).format('L');
         }
 
         /**
          * Formats the specified date and time into a string according the patterm 'HH:mm'.
          */
         function formatTime(time) {
-          var hours = time.getHours(), minutes = time.getMinutes();
-          if (hours < 10) hours = "0" + hours;
-          if (minutes < 10) minutes = "0" + minutes;
-          return hours + ":" + minutes;
+          return time.format('HH:mm');
         }
 
         function updateDate(dateTimeToUpdate, withDate) {
-          dateTimeToUpdate.setYear(withDate.getYear());
-          dateTimeToUpdate.setMonth(withDate.getMonth());
-          dateTimeToUpdate.setDate(withDate.getDate())
+          dateTimeToUpdate.set({'year': withDate.year(), 'month': withDate.month(),
+            'date': withDate.date()});
         }
 
         /**
@@ -226,19 +212,19 @@
          * The months and built by browsing the events and are remembered for month selection.
          */
         function buildCalendarView( events, monthsHavingEvents ) {
-          var currentMonth = -1, currentYear = -1, monthSection = null, today = new Date();
+          var currentMonth = -1, currentYear = -1, monthSection = null, today = moment();
           $("#calendar").children().remove();
           $("<ul>").attr("id", "eventList").appendTo("#calendar");
           $.each(events, function(index, event) {
-            var eventStartDate = $.fullCalendar.parseDate(event.start);
-            var startDate = $.fullCalendar.parseDate(event.start);
-            var endDate = $.fullCalendar.parseDate(event.end);
+            var eventStartDate = $.fullCalendar.moment(event.start);
+            var startDate = $.fullCalendar.moment(event.start);
+            var endDate = $.fullCalendar.moment(event.end);
       <c:if test="${calendarView.viewType.nextEventsView}">
-            if (startDate < today) startDate.setDate(today.getDate());
+            if (startDate.isBefore(today)) startDate.date(today.date());
       </c:if>
-            if (startDate.getMonth() != currentMonth || startDate.getFullYear() != currentYear) {
-              currentYear = startDate.getFullYear();
-              currentMonth = startDate.getMonth();
+            if (startDate.month() != currentMonth || startDate.year() != currentYear) {
+              currentYear = startDate.year();
+              currentMonth = startDate.month();
               monthSection = $("<ul>").addClass("eventList")
               .appendTo($("<li>").attr("id", MONTH_NAMES[currentMonth] + currentYear)
               .append($("<h3>").addClass("eventMonth").html(MONTH_NAMES[currentMonth] + ' ' + currentYear))
@@ -246,10 +232,10 @@
               monthsHavingEvents.push(MONTH_NAMES[currentMonth] + ' ' + currentYear);
             }
             var startTime = "", endTime = "";
-            if (eventStartDate.valueOf() == endDate.valueOf() && event.startTimeDefined && event.endTimeDefined) {
+            if (eventStartDate.isSame(endDate) && event.startTimeDefined && event.endTimeDefined) {
               startTime = "<fmt:message key='GML.at'/> " + formatTime(startDate);
             } else {
-              if (eventStartDate < startDate) {
+              if (eventStartDate.isBefore(startDate)) {
                 startTime = "<fmt:message key='GML.From'/> " + formatToLocaleDateString(eventStartDate, '${language}');
               }
               if (event.startTimeDefined) {
@@ -260,8 +246,7 @@
                 }
                 startTime = startTime + formatTime(startDate);
               }
-              if (endDate.getFullYear() > startDate.getFullYear() || endDate.getMonth() > startDate.getMonth() ||
-                endDate.getDate() > startDate.getDate()) {
+              if (endDate.isAfter(startDate)) {
                 endTime = "<fmt:message key='GML.to'/> " + formatToLocaleDateString(endDate, '${language}');
               }
               if (event.endTimeDefined) {
@@ -272,10 +257,10 @@
               viewEvent(event.id, formatDate(eventStartDate), event.instanceId);
             })
             .append($("<div>").addClass("eventBeginDate")
-            .append($("<span>").addClass("day").html(DAY_NAMES[startDate.getDay()]))
-            .append($("<span>").addClass("number").html(startDate.getDate()))
+            .append($("<span>").addClass("day").html(DAY_NAMES[startDate.day()]))
+            .append($("<span>").addClass("number").html(startDate.format('DD')))
             .append($("<span>").addClass("month").html(MONTH_NAMES[currentMonth]))
-            .append($("<span>").addClass("year").html(startDate.getFullYear())))
+            .append($("<span>").addClass("year").html(startDate.format('YYYY'))))
             .append($("<h2>").addClass("eventName")
             .append($("<a>").addClass(event.className.join(' ')).attr({
               "href": "javascript:viewEvent(" + event.id + ", '" + formatDate(startDate) + "' , '" + event.instanceId + "');",

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/portletCalendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/portletCalendar.jsp
@@ -71,37 +71,30 @@
        
         var events = <c:out value='${calendarView.eventsInJSON}' escapeXml='yes'/>;
         var slotCount = 0;
-        var now = new Date();
-        var nextday = new Date();
-        nextday.setDate(nextday.getDate() + 1);
-        
-        function inTwoDigits( t )
-        {
-          if (t < 10) t = "0" + t;
-          return t;
-        }
+        var now = moment();
+        var nextday = now.add(1, 'days');
         
         function computeIdFrom( date )
         {
-          var year = date.getFullYear(), month = inTwoDigits(date.getMonth()+1), day = inTwoDigits(date.getDate());
-          return year + "-" + month + "-" + day;
+          //var year = date.year(), month = inTwoDigits(date.month()+1), day = inTwoDigits(date.date());
+          return date.format('YYYY-MM-DD'); //year + "-" + month + "-" + day;
         }
-        
+
         function formatDate( date )
         {
-          var year = date.getFullYear(), month = inTwoDigits(date.getMonth()+1), day = inTwoDigits(date.getDate());
-          return year + "/" + month + "/" + day;
+          //var year = date.year(), month = inTwoDigits(date.month()+1), day = inTwoDigits(date.date());
+          return date.format('YYYY/MM/DD'); //year + "/" + month + "/" + day;
         }
         
         function areDateEquals( date1, date2 ) {        	
-          return date1.getFullYear() == date2.getFullYear() && date1.getMonth() == date2.getMonth() && date1.getDate() == date2.getDate();
+          return date1.isSame(date2);
         }
         
         function startTimeOf( event ) {
           if (event.startTimeDefined)
           {
-            var hours = inTwoDigits(startDate.getHours()), minutes = inTwoDigits(startDate.getMinutes());
-            var startTime =  " <fmt:message key='GML.at'/> " + hours + ":" + minutes;
+            //var hours = inTwoDigits(startDate.getHours()), minutes = inTwoDigits(startDate.getMinutes());
+            var startTime =  " <fmt:message key='GML.at'/> " + startDate.format('HH:mm'); // hours + ":" + minutes;
             return $("<span>").addClass("eventBeginHours").html(startTime);
           }
           return "";
@@ -121,7 +114,7 @@
       
         function shortFormatOf( date )
         {
-          var month = inTwoDigits(date.getMonth()+1), day = inTwoDigits(date.getDate());
+          var month = date.format('MM'), day = date.format('DD');
           return $("<div>").addClass("eventShortDate").
             append($("<span>").addClass("number").append(day)).
             append("/").
@@ -136,10 +129,10 @@
             return $("<div>").addClass("eventLongDate").append(TOMORROW);
           else
             return $("<div>").addClass("eventLongDate").
-              append($("<span>").addClass("day").html(DAY_NAMES[date.getDay()] + " ")).
-              append($("<span>").addClass("number").html(inTwoDigits(date.getDate()) + " ")).
-              append($("<span>").addClass("month").html(MONTH_NAMES[date.getMonth()] + " ")).
-              append($("<span>").addClass("year").html(date.getFullYear()));
+              append($("<span>").addClass("day").html(DAY_NAMES[date.day()] + " ")).
+              append($("<span>").addClass("number").html(date.format('DD') + " ")).
+              append($("<span>").addClass("month").html(MONTH_NAMES[date.month()] + " ")).
+              append($("<span>").addClass("year").html(date.format('YYYY')));
         }
         
         function daySlotOf( event )
@@ -164,8 +157,9 @@
         for (var i = 0; i < events.length && slotCount < SLOTS_MAX; i++) {
           var event = events[i];
           var eventCss = event.className.join(' ');
-          var startDate = $.fullCalendar.parseDate(event.start);
-          if (Date.today().compareTo(startDate) == 1) {
+          var startDate = moment(event.start);
+
+          if (now.isAfter(startDate)) {
             startDate = now;
           }
           

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/portletCalendar.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/portletCalendar.jsp
@@ -48,7 +48,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <view:looknfeel />
     <link rel='stylesheet' type='text/css' href="<c:url value='/almanach/jsp/styleSheets/almanach.css'/>" />
-    <script type="text/javascript" src="<c:url value='/util/javaScript/date.js'/>"></script>
     <view:includePlugin name="calendar"/>
     <script type="text/javascript">
       function viewEvent( id, date, componentId )

--- a/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/accueil.jsp
+++ b/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/accueil.jsp
@@ -61,7 +61,7 @@ function sendData() {
 
 function viewClassifieds(fieldNumber, fieldValue) {
 	var id = $("#searchForm select").get(fieldNumber).id;
-	$("#searchForm #"+id+" option[value='"+fieldValue+"']").attr('selected','selected');
+	$("#searchForm #"+id+" option[value='"+fieldValue+"']").prop('selected',true);
 	sendData();
 }
 </script>

--- a/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/accueilNotCategorized.jsp
+++ b/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/accueilNotCategorized.jsp
@@ -72,7 +72,7 @@ function sendData() {
 
 function viewClassifieds(fieldNumber, fieldValue) {
 	var id = $("#searchForm select").get(fieldNumber).id;
-	$("#searchForm #"+id+" option[value='"+fieldValue+"']").attr('selected','selected');
+	$("#searchForm #"+id+" option[value='"+fieldValue+"']").prop('selected', true);
 	sendData();
 }
 </script>

--- a/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/classifiedsResult.jsp
+++ b/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/classifiedsResult.jsp
@@ -69,7 +69,7 @@ function sendData() {
 
 function viewClassifieds(fieldNumber, fieldValue) {
 	var id = $("#searchForm select").get(fieldNumber).id;
-	$("#searchForm #"+id+" option[value='"+fieldValue+"']").attr('selected','selected');
+	$("#searchForm #"+id+" option[value='"+fieldValue+"']").prop('selected',true);
 	sendData();
 }
 </script>

--- a/gallery/gallery-war/src/main/webapp/gallery/jsp/javaScript/silverpeas-gallery-slider.js
+++ b/gallery/gallery-war/src/main/webapp/gallery/jsp/javaScript/silverpeas-gallery-slider.js
@@ -377,7 +377,7 @@
   function __buildDialogContainer($sliderContainer) {
     var $base = $("#slideshow");
     var $fullscreenSwitcher = $("#slideshow_fullscreenSwitcher");
-    if ($base.size() == 0) {
+    if ($base.length == 0) {
       $base = $("<div>").attr('id', 'slideshow').css('display', 'block').css('border',
           '0px').css('padding', '0px').css('margin', '0px auto').css('text-align',
           'center').css('background-color', 'white');

--- a/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/multilang/kmeliaBundle.properties
+++ b/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/multilang/kmeliaBundle.properties
@@ -322,7 +322,7 @@ kmelia.ImportMode2=Cr\u00e9ation d'une publication avec une pi\u00e8ce jointe pa
 kmelia.help.rightclick.title = AIDE - Gestion des dossiers
 kmelia.help.rightclick.buttons.ok = J'ai compris
 kmelia.help.rightclick.buttons.remind = Me le rappeler
-kmelia.help.rightclick.content = En tant que <b>gestionnaire</b>, vous pouvez g\u00e9rer les dossiers comme bon vous semble.<br/><br/>Dans l'explorateur de dossiers, un <b>clic droit</b> sur le nom d'un dossier fait apparaitre un menu contextuel. Il vous permet d'acc\u00e9der \u00e0 toutes les actions possibles sur ce dossier.<br/><br/><u>Exemple</u> : Pour ajouter un dossier \u00e0 la racine, faites un clic droit sur le dossier <b>{0}</b> puis cliquez sur l'action <b>Cr\u00e9er un dossier</b>.<br/><br/>Vous pouvez \u00e9galement acc\u00e9der \u00e0 cette action via le menu <b>Que voulez-vous faire ?</b>.
+kmelia.help.rightclick.content = En tant que <b>gestionnaire</b>, vous pouvez g\u00e9rer les dossiers comme bon vous semble.<br/><br/>Dans l''explorateur de dossiers, un <b>clic droit</b> sur le nom d'un dossier fait apparaitre un menu contextuel. Il vous permet d'acc\u00e9der \u00e0 toutes les actions possibles sur ce dossier.<br/><br/><u>Exemple</u> : Pour ajouter un dossier \u00e0 la racine, faites un clic droit sur le dossier <b>{0}</b> puis cliquez sur l'action <b>Cr\u00e9er un dossier</b>.<br/><br/>Vous pouvez \u00e9galement acc\u00e9der \u00e0 cette action via le menu <b>Que voulez-vous faire ?</b>.
 
 kmelia.ExportPublication = Exporter...
 kmelia.export = Exporter

--- a/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/multilang/kmeliaBundle_fr.properties
+++ b/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/multilang/kmeliaBundle_fr.properties
@@ -322,7 +322,7 @@ kmelia.ImportMode2=Cr\u00e9ation d'une publication avec une pi\u00e8ce jointe pa
 kmelia.help.rightclick.title = AIDE - Gestion des dossiers
 kmelia.help.rightclick.buttons.ok = J'ai compris
 kmelia.help.rightclick.buttons.remind = Me le rappeler
-kmelia.help.rightclick.content = En tant que <b>gestionnaire</b>, vous pouvez g\u00e9rer les dossiers comme bon vous semble.<br/><br/>Dans l'explorateur de dossiers, un <b>clic droit</b> sur le nom d'un dossier fait apparaitre un menu contextuel. Il vous permet d'acc\u00e9der \u00e0 toutes les actions possibles sur ce dossier.<br/><br/><u>Exemple</u> : Pour ajouter un dossier \u00e0 la racine, faites un clic droit sur le dossier <b>{0}</b> puis cliquez sur l'action <b>Cr\u00e9er un dossier</b>.<br/><br/>Vous pouvez \u00e9galement acc\u00e9der \u00e0 cette action via le menu <b>Que voulez-vous faire ?</b>.
+kmelia.help.rightclick.content = En tant que <b>gestionnaire</b>, vous pouvez g\u00e9rer les dossiers comme bon vous semble.<br/><br/>Dans l''explorateur de dossiers, un <b>clic droit</b> sur le nom d'un dossier fait apparaitre un menu contextuel. Il vous permet d'acc\u00e9der \u00e0 toutes les actions possibles sur ce dossier.<br/><br/><u>Exemple</u> : Pour ajouter un dossier \u00e0 la racine, faites un clic droit sur le dossier <b>{0}</b> puis cliquez sur l'action <b>Cr\u00e9er un dossier</b>.<br/><br/>Vous pouvez \u00e9galement acc\u00e9der \u00e0 cette action via le menu <b>Que voulez-vous faire ?</b>.
 
 kmelia.ExportPublication = Exporter...
 kmelia.export = Exporter

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/FolderResource.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/FolderResource.java
@@ -35,6 +35,7 @@ import org.silverpeas.core.webapi.node.NodeEntity;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.webapi.node.NodeType;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -203,7 +204,7 @@ public class FolderResource extends RESTWebService {
     String parentNodeId = getNodeIdFromURI(path);
     NodePK nodePK = getNodePK(parentNodeId);
 
-    String nodeName = nodeEntity.getData();
+    String nodeName = nodeEntity.getText();
     if (StringUtils.isEmpty(nodeName)) {
       throw new WebApplicationException(Status.NO_CONTENT);
     }
@@ -245,8 +246,8 @@ public class FolderResource extends RESTWebService {
   }
 
   private void decorateRoot(NodeEntity root, String lang) {
-    root.setState("open");
-    root.getAttr().setRel("root");
+    root.getState().setOpened(true);
+    root.setType(NodeType.ROOT);
     decorateRootChildren(root.getChildren(), lang);
   }
 
@@ -256,14 +257,14 @@ public class FolderResource extends RESTWebService {
         ResourceLocator.getLocalizationBundle("org.silverpeas.kmelia.multilang.kmeliaBundle", lang);
     for (NodeEntity child : children) {
       if (child.getAttr().getId().equalsIgnoreCase("tovalidate")) {
-        child.getAttr().setRel("tovalidate");
-        child.setState("");
-        child.setData(Encode.forHtml(messages.getString("ToValidateShort")));
+        child.setType(NodeType.TO_VALIDATE);
+        child.getState().opened(false).setSelected(false);
+        child.setText(Encode.forHtml(messages.getString("ToValidateShort")));
         child.getAttr().setDescription(messages.getString("kmelia.tovalidate.desc"));
       } else if (child.getAttr().getId().equalsIgnoreCase("1")) {
-        child.getAttr().setRel("bin");
-        child.setState("");
-        child.setData(Encode.forHtml(messages.getString("kmelia.basket")));
+        child.setType(NodeType.BIN);
+        child.getState().opened(false).setSelected(false);
+        child.setText(Encode.forHtml(messages.getString("kmelia.basket")));
         child.getAttr().setDescription(messages.getString("kmelia.basket.desc"));
       }
     }
@@ -305,7 +306,7 @@ public class FolderResource extends RESTWebService {
   private void setOpenState(NodeEntity[] children, List<NodeDetail> path) {
     for (NodeEntity child : children) {
       if (isInPath(child, path)) {
-        child.setState("open");
+        child.getState().setOpened(true);
         setOpenState(child.getChildren(), path);
       }
     }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/glossaryHighlight.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/glossaryHighlight.js
@@ -1,21 +1,20 @@
 //manage the tooltip displaying in publication
 //the displaying personalization must be done here
 $(document).ready(function() {
-	$('.highlight-silver').each(function(){
-		   $(this).qtip({
-			content: {
-				text: false // Use each elements title attribute
-			},
-			style: {
-				tip: true,
-				classes: "qtip-shadow qtip-green"
-			},
-			position: {
-				adjust: {
-					method: "flip flip"
-				},
-				viewport: $(window)
-			}
-		   });
-		});
+  $('.highlight-silver').each(function() {
+    $(this).qtip({
+      content : {
+        text : false // Use each elements title attribute
+      },
+      style : {
+        tip : true, classes : "qtip-shadow qtip-green"
+      },
+      position : {
+        adjust : {
+          method : "flip flip"
+        },
+        viewport : $(window)
+      }
+    });
+  });
 });

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -139,8 +139,8 @@ function displayPath(id) {
     //remove topic breadcrumb
     removeBreadCrumbElements();
     $(data).each(function(i, topic) {
-      if (topic.attr["id"] != 0) {
-        addBreadCrumbElement("javascript:topicGoTo(" + topic.attr["id"] + ")", topic.data);
+      if (topic.id !== '0') {
+        addBreadCrumbElement("javascript:topicGoTo(" + topic.id + ")", topic.text);
       }
     });
   });
@@ -563,7 +563,7 @@ function displayTopicInformation(id) {
     $("#footer").css({'visibility': 'visible'});
     var url = getWebContext() + "/services/folders/" + getComponentId() + "/" + id;
     $.getJSON(url, function(topic) {
-      var name = topic.data;
+      var name = topic.text;
       var desc = topic.attr["description"];
       var date = $.datepicker.formatDate(getDateFormat(), new Date(topic.attr["creationDate"]));
       ;
@@ -647,8 +647,8 @@ function topicAdd(topicId, isLinked) {
       //remove topic breadcrumb
       $("#addOrUpdateNode #path").html("");
       $(data).each(function(i, topic) {
-        var item = " > " + topic.data;
-        if (topic.attr["id"] == 0) {
+        var item = " > " + topic.text;
+        if (topic.id == 0) {
           item = getComponentLabel();
         }
         $("#addOrUpdateNode #path").html($("#addOrUpdateNode #path").html() + item);
@@ -697,8 +697,8 @@ function topicUpdate(id) {
       //remove topic breadcrumb
       $("#addOrUpdateNode #path").html("");
       $(data).each(function(i, topic) {
-        var item = " > " + topic.data;
-        if (topic.attr["id"] == 0) {
+        var item = " > " + topic.text;
+        if (topic.id == 0) {
           item = getComponentLabel();
         } else {
           if (i === data.length - 1) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -80,7 +80,6 @@ boolean userCanManageTopics = rightsOnTopics.booleanValue() || "admin".equalsIgn
   <title></title>
   <view:looknfeel withCheckFormScript="true"/>
 <view:script src="/util/javaScript/browseBarComplete.js"/>
-<view:script src="/util/javaScript/jquery/jquery-migrate-1.4.1.min.js"/>
 <view:script src="/util/javaScript/jquery/jstree.min.js"/>
 <view:script src="/util/javaScript/jquery/jquery.cookie.js"/>
   <view:link href="/util/javaScript/jquery/themes/default/style.min.css"/>

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -23,8 +23,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
-<%@page import="org.silverpeas.components.kmelia.SearchContext"%>
 <%@page import="org.silverpeas.components.kmelia.KmeliaPublicationHelper"%>
+<%@page import="org.silverpeas.components.kmelia.SearchContext"%>
 <%@page import="org.silverpeas.core.admin.user.model.SilverpeasRole"%>
 <%@ page import="org.silverpeas.core.i18n.I18NHelper" %>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
@@ -80,9 +80,10 @@ boolean userCanManageTopics = rightsOnTopics.booleanValue() || "admin".equalsIgn
   <title></title>
   <view:looknfeel withCheckFormScript="true"/>
 <view:script src="/util/javaScript/browseBarComplete.js"/>
-<view:script src="/util/javaScript/jquery/jquery-migrate-1.2.1.min.js"/>
-<view:script src="/util/javaScript/jquery/jquery.jstree.js"/>
+<view:script src="/util/javaScript/jquery/jquery-migrate-1.4.1.min.js"/>
+<view:script src="/util/javaScript/jquery/jstree.min.js"/>
 <view:script src="/util/javaScript/jquery/jquery.cookie.js"/>
+  <view:link href="/util/javaScript/jquery/themes/default/style.min.css"/>
 
 <view:includePlugin name="popup"/>
 <view:includePlugin name="preview"/>
@@ -96,7 +97,8 @@ function topicGoTo(id) {
     closeWindows();
     displayTopicContent(id);
     getTreeview().deselect_all();
-    getTreeview().select_node($('#'+id));
+    var node = getTreeview().get_node('#'+id);
+    getTreeview().select_node(node);
 }
 
 function getCurrentUserId() {
@@ -130,6 +132,14 @@ function getTranslation() {
 
 function getToValidateFolderId() {
 	return "<%=KmeliaHelper.SPECIALFOLDER_TOVALIDATE%>";
+}
+
+function getCurrentFolderId() {
+  return "<%=id%>";
+}
+
+function arePublicationsOnRootAllowed() {
+  return <%=KmeliaPublicationHelper.isPublicationsOnRootAllowed(componentId)%>;
 }
 
 var icons = new Object();
@@ -225,8 +235,10 @@ function getComponentPermalink() {
 	return "<%=URLUtil.getSimpleURL(URLUtil.URL_COMPONENT, componentId, false)%>";
 }
 
-function deleteNode(nodeId, nodeLabel) {
+function deleteNode(nodeId) {
 	// removing nb items displayed in nodeLabel
+  var node = getTreeview().get_node('#' + nodeId);
+  var nodeLabel = node.text;
 	if (params["nbPublisDisplayed"]) {
 		var idx = nodeLabel.lastIndexOf('(');
 		if (idx > 1) {
@@ -263,7 +275,7 @@ function nodeDeleted(nodeId) {
 	if (params["nbPublisDisplayed"]) {
 		// change nb publications on each parent of deleted node (except root)
 		var nbPublisRemoved = getNbPublis(nodeId);
-		var path = getTreeview().get_path("#"+nodeId, true);
+		var path = getTreeview().get_path("#"+nodeId, false, true);
 		for (i=0; i<path.length; i++) {
 			var elementId = path[i];
 			if (elementId != "0" && elementId != nodeId) {
@@ -321,21 +333,20 @@ function cutCurrentNode() {
 
 function changeCurrentTopicStatus() {
 	var node = getTreeview()._get_node("#"+getCurrentNodeId());
-	changeStatus(getCurrentNodeId(), node.attr("status"));
+	changeStatus(getCurrentNodeId(), node.original.attr["status"]);
 }
 
 function updateUIStatus(nodeId, newStatus, recursive) {
 	// updating data stored in treeview
-	var node = getTreeview()._get_node("#"+nodeId);
-	node.attr("status", newStatus);
+	var node = getTreeview().get_node("#"+nodeId);
+	node.original.attr["status"] = newStatus;
 
 	//changing label style according to topic's new status
-	node.removeClass("Visible Invisible");
-	node.addClass(newStatus);
+	$('#' + nodeId).removeClass("Visible Invisible").addClass(newStatus);
 
 	//
 	if (recursive == "1") {
-		var children = getTreeview()._get_children("#"+nodeId);
+		var children = node.children;
 		for (var i=0; i<children.length; i++) {
 			try {
 				updateUIStatus(children[i].id, newStatus, recursive);
@@ -374,8 +385,8 @@ function displayTopicContent(id) {
 			displayPublicationPromise = displayPublications(id);
 
 			//update breadcrumb
-            removeBreadCrumbElements();
-            addBreadCrumbElement("#", "<%=resources.getString("ToValidate")%>");
+      removeBreadCrumbElements();
+      addBreadCrumbElement("#", "<%=resources.getString("ToValidate")%>");
 		} else {
 			displayOperations(id);
 			displayPublicationPromise = displayPublications(id);
@@ -428,7 +439,7 @@ function showRightClickHelp() {
 }
 
 function getTreeview() {
-	return $.jstree._reference("#treeDiv1");
+	return $.jstree.reference("#treeDiv1");
 }
 
 function customMenu(node) {
@@ -437,10 +448,10 @@ function customMenu(node) {
 		return false;
 	<% } %>
 
-	var nodeType = node.attr("rel");
+	var nodeType = node.type;
   var userRole = '<%=profile%>';
 	if (params["rightsOnTopic"]) {
-		userRole = node.attr("role");
+		userRole = node.original.attr["role"];
 	}
 	if (nodeType == getToValidateFolderId()) {
     	return false;
@@ -461,36 +472,40 @@ function customMenu(node) {
     	addItem: {
         	label: "<%=resources.getString("CreerSousTheme")%>",
             action: function (obj) {
-            	topicAdd(obj.attr("id"), false);
+              var node = getTreeview().get_node(obj.reference);
+            	topicAdd(node.id, false);
             }
         },
     	editItem: {
             label: "<%=resources.getString("ModifierSousTheme")%>",
             action: function (obj) {
-            	var url = getWebContext()+"/services/folders/"+getComponentId()+"/"+obj.attr("id");
+              var node = getTreeview().get_node(obj.reference);
+            	var url = getWebContext()+"/services/folders/"+getComponentId()+"/"+node.id;
         		$.getJSON(url, function(topic){
-        					var name = topic.data;
+        					var name = topic.text;
         					var desc = topic.attr["description"];
         					if (params["i18n"]) {
         						storeTranslations(topic.translations);
         					} else {
                     setDataInFolderDialog(name, desc);
         					}
-        					topicUpdate(topic.attr["id"]);
+        					topicUpdate(topic.id);
         				});
             }
         },
         deleteItem: {
             label: "<%=resources.getString("SupprimerSousTheme")%>",
             action: function (obj) {
-            	deleteNode(obj.attr("id"), getTreeview().get_text(obj));
+              var node = getTreeview().get_node(obj.reference);
+            	deleteNode(node.id);
             }
         },
         sortItem: {
             label: "<%=resources.getString("kmelia.SortTopics")%>",
             action: function (obj) {
+              var node = getTreeview().get_node(obj.reference);
             	closeWindows();
-        		SP_openWindow("ToOrderTopics?Id="+obj.attr("id"), "topicAddWindow", "600", "500", "directories=0,menubar=0,toolbar=0,scrollbars=1,alwaysRaised,resizable");
+        		SP_openWindow("ToOrderTopics?Id="+node.id, "topicAddWindow", "600", "500", "directories=0,menubar=0,toolbar=0,scrollbars=1,alwaysRaised,resizable");
             },
         	"separator_after" : true
         },
@@ -498,7 +513,8 @@ function customMenu(node) {
         pdcItem: {
         	label: "<%=resources.getString("GML.PDCPredefinePositions")%>",
             action: function (obj) {
-            	openPredefinedPdCClassification(obj.attr("id"));
+              var node = getTreeview().get_node(obj.reference);
+            	openPredefinedPdCClassification(node.id);
             },
         	"separator_after" : true
         },
@@ -506,19 +522,22 @@ function customMenu(node) {
         copyItem: {
             label: "<%=resources.getString("GML.copy")%>",
             action: function (obj) {
-            	copyNode(obj.attr("id"));
+              var node = getTreeview().get_node(obj.reference);
+            	copyNode(node.id);
             }
         },
         cutItem: {
             label: "<%=resources.getString("GML.cut")%>",
             action: function (obj) {
-            	cutNode(obj.attr("id"));
+              var node = getTreeview().get_node(obj.reference);
+            	cutNode(node.id);
             }
         },
         pasteItem: {
             label: "<%=resources.getString("GML.paste")%>",
             action: function (obj) {
-            	pasteNode(obj.attr("id"));
+              var node = getTreeview().get_node(obj.reference);
+            	pasteNode(node.id);
             },
         	"separator_after" : true
         }
@@ -527,7 +546,8 @@ function customMenu(node) {
         wysiwygItem: {
             label: "<%=resources.getString("TopicWysiwyg")%>",
             action: function (obj) {
-            	updateTopicWysiwyg(obj.attr("id"));
+              var node = getTreeview().get_node(obj.reference);
+            	updateTopicWysiwyg(node.id);
             }
         }
         <% } %>
@@ -536,7 +556,8 @@ function customMenu(node) {
         statusItem: {
             label: "<%=resources.getString("TopicVisible2Invisible")%>",
             action: function (obj) {
-            	changeStatus(obj.attr("id"), obj.attr("status"));
+              var node = getTreeview().get_node(obj.reference);
+            	changeStatus(node.id, node.original.attr["status"]);
             }
         }
     	<% } %>
@@ -555,7 +576,7 @@ function customMenu(node) {
     }
 
     if (items.statusItem) {
-    	if (node.attr("status") == "Invisible") {
+    	if (node.original.attr["status"] == "Invisible") {
     		items.statusItem.label = "<%=resources.getString("TopicInvisible2Visible")%>";
     	}
     }
@@ -577,7 +598,7 @@ function customMenu(node) {
 	  } else {
       var isTopicManagementDelegated = <%=kmeliaScc.isTopicManagementDelegated()%>;
       var userId = "<%=kmeliaScc.getUserId()%>";
-      var creatorId = node.attr("creatorId");
+      var creatorId = node.original.attr["creatorId"];
       if (isTopicManagementDelegated && userRole != "admin") {
         if (creatorId != userId) {
           //do not show the menu
@@ -629,14 +650,18 @@ function spreadNbItems(children) {
 			var child = children[i];
 			child.attr['title'] = child.attr['description'].unescapeHTML();
 			<% if (kmeliaScc.isOrientedWebContent()) { %>
-				child.attr['class'] = child.attr['status'];
+      child.li_attr = { class: child.attr['status'] };
 			<% } %>
-			if (child.attr['nbItems']) {
-				child.data = child.data + " ("+child.attr['nbItems']+")";
-				spreadNbItems(child.children);
+			if (child.attr['nbItems'] >= 0) {
+				child.text = child.text + " ("+child.attr['nbItems']+")";
+        if (child.children && child.children.length > 0) {
+          spreadNbItems(child.children);
+        } else {
+          child.children = true;
+        }
 			}
-		}
-	}
+    }
+  }
 }
 
 function getUserProfile(id) {
@@ -672,13 +697,23 @@ function extractPublicationId(id) {
 	return id.substring(4, id.length);
 }
 
+function extractFolderId(id) {
+  if (id) {
+    var idx = id.indexOf('_');
+    if (idx > 0) {
+      id = id.substr(0, idx);
+    }
+  }
+  return id;
+}
+
 function publicationMovedSuccessfully(id, targetId) {
 	var pubName = getPublicationName(id);
   notySuccess("<%=resources.getString("kmelia.drag.publication.success1")%>" + pubName + "<%=resources.getString("kmelia.drag.publication.success2")%>");
 
 	if (params["nbPublisDisplayed"]) {
 		// add one publi to target node and its parents
-		var path = getTreeview().get_path("#"+targetId, true);
+		var path = getTreeview().get_path("#"+targetId, false, true);
 		for (i=0; i<path.length; i++) {
 			var elementId = path[i];
 			if (elementId != "0") {
@@ -687,7 +722,7 @@ function publicationMovedSuccessfully(id, targetId) {
 		}
 
 		// remove one publi to current node and its parents
-		var path = getTreeview().get_path("#"+getCurrentNodeId(), true);
+		var path = getTreeview().get_path("#"+getCurrentNodeId(), false, true);
 		for (i=0; i<path.length; i++) {
 			var elementId = path[i];
 			if (elementId != "0") {
@@ -726,7 +761,7 @@ function publicationsRemovedSuccessfully(nb) {
 		} else {
 			// publications goes to trash
 			// remove nb publi to current node and its parents except root
-			var path = getTreeview().get_path("#"+getCurrentNodeId(), true);
+			var path = getTreeview().get_path("#"+getCurrentNodeId(), false, true);
 			for (i=0; i<path.length; i++) {
 				var elementId = path[i];
 				if (elementId != "0") {
@@ -766,181 +801,117 @@ function resizePart(idPart) {
     $(idPart).css("height",hauteur);
 }
 
-$(document).ready(
-	function () {
-		//build the tree
-		$("#treeDiv1").bind("loaded.jstree", function (event, data) {
-			//alert("TREE IS LOADED");
-		}).bind("select_node.jstree", function (e, data) {
-    		// data.inst is the instance which triggered this event
-    		var nodeId = $(data.rslt.obj).attr('id');
-
-    		// open topic in treeview
-    		var idSelector = "#"+nodeId;
-    		$.jstree._reference(idSelector).open_node(idSelector);
-
-		// display topic content in right panel
-    		displayTopicContent(nodeId);
-    	})
-    	.jstree({
-    	"core" : {
-        html_titles: true
-    			//"load_open" : true
-    	},
-    	"ui" :{
-            "select_limit" : 1,
-          	"initially_select" : "#<%=id%>",
-          	"select_prev_on_delete" : false
+$(document).ready(function() {
+  //build the tree
+  $("#treeDiv1").jstree({
+    "core" : {
+      force_text : false,
+      "data" : {
+        "url" : function (node) {
+          var url = getWebContext() + "/services/folders/" + getComponentId() + "/" +
+              getCurrentFolderId() + "/treeview?lang=" + getTranslation() + "&IEFix=" +
+              new Date().getTime();
+          if (node && node.id !== '#') {
+            url = getWebContext() + "/services/folders/" + getComponentId() + "/" + node.id +
+                "/children?lang=" + getTranslation() + "&IEFix=" + new Date().getTime();
+          }
+          return url;
         },
-	"json_data" : {
-			"ajax" : {
-				"url": function (node) {
-					var nodeId = "";
-					var url = "<%=m_context%>/services/folders/<%=componentId%>/<%=id%>/treeview?lang="+getTranslation()+"&IEFix="+new Date().getTime();
-					if (node != -1) {
-						url = "<%=m_context%>/services/folders/<%=componentId%>/"+node.attr("id")+"/children?lang="+getTranslation()+"&IEFix="+new Date().getTime();
-					}
-					return url;
-				},
-				success: function(n) {
-					if (n) {
-						if (n.length) {
-							// this is subfolders
-							spreadNbItems(n);
-						} else {
-							if (n.data) {
-								// this is the root
-								n.data = "<%=EncodeHelper.javaStringToHtmlString(componentLabel)%>";
-								if (n.attr['nbItems']) {
-									n.data = n.data + " ("+n.attr['nbItems']+")";
-								}
-								<% if (kmeliaScc.isOrientedWebContent()) { %>
-									n.attr['class'] = n.attr['status'];
-								<% } %>
-								spreadNbItems(n.children);
-							}
-						}
-					}
-				    return n;
-				}
-			}
-		},
-		// Using types - most of the time this is an overkill
-		// read the docs carefully to decide whether you need types
-		"types" : {
-			// I set both options to -2, as I do not need depth and children count checking
-			// Those two checks may slow jstree a lot, so use only when needed
-			"max_depth" : -2,
-			"max_children" : -2,
-			// I want only `drive` nodes to be root nodes
-			// This will prevent moving or creating any other type as a root node
-			"valid_children" : [ "root" ],
-			"types" : {
-				// The `root` node
-				"root" : {
-					"valid_children" : [ "bin", getToValidateFolderId() ],
-					// those prevent the functions with the same name to be used on `root` nodes
-					// internally the `before` event is used
-					"start_drag" : false,
-					"move_node" : false,
-					"delete_node" : false,
-					"remove" : false
-				},
-				// The `bin` node
-				"bin" : {
-					// can have files and folders inside, but NOT other `drive` nodes
-					"valid_children" : "none",
-					"icon" : {
-						"image" : "icons/treeview/basket.jpg"
-					},
-					// those prevent the functions with the same name to be used on `bin` nodes
-					// internally the `before` event is used
-					"start_drag" : false,
-					"move_node" : false,
-					"delete_node" : false,
-					"remove" : false
-				},
-				// The `to validate` node
-				"<%=KmeliaHelper.SPECIALFOLDER_TOVALIDATE%>" : {
-					// can have files and folders inside, but NOT other `drive` nodes
-					"valid_children" : "none",
-					"icon" : {
-						"image" : "<%=m_context%>/util/icons/ok_alpha.gif"
-					},
-					// those prevent the functions with the same name to be used on `tovalidate` nodes
-					// internally the `before` event is used
-					"start_drag" : false,
-					"move_node" : false,
-					"delete_node" : false,
-					"remove" : false
-				},
-				"folder" : {
-					"valid_children" : [ "folder" ],
-					// those prevent the functions with the same name to be used on `root` nodes
-					// internally the `before` event is used
-					"start_drag" : false,
-					"move_node" : false,
-					"delete_node" : false,
-					"remove" : false
-				}
-			}
-		},
-		"themes" : {
-			"theme" : "default",
-			"dots" : false,
-			"icons" : true
-		},
-		"contextmenu" : {
-			"show_at_node" : false,
-			"items" : customMenu
-		},
-		"dnd" : {
-			"drop_finish" : function () {
-				alert("drop_finish");
-			},
-			"drag_check" : function (data) {
-				var targetId = data.r.attr("id");
-				var targetType = data.r.attr("rel");
-				if (targetId == getCurrentNodeId()) {
-					return false;
-				} else if (targetType == getToValidateFolderId()) {
-					return false;
-				} else if (targetType == "root") {
-					if (<%=KmeliaPublicationHelper.isPublicationsOnRootAllowed(componentId)%>) {
-						var profile = getUserProfile(targetId);
-						//writeInConsole("drag_check : current user is "+profile+" in root");
-						if (profile != "<%=SilverpeasRole.user.toString()%>") {
-							return {
-								after : false,
-								before : false,
-								inside : true
-							};
-						}
-					}
-				} else if (targetId != "treeDiv1"){
-					var profile = getUserProfile(targetId);
-					//writeInConsole("drag_check : current user is "+profile+" in folder #"+targetId);
-					if (profile != "<%=SilverpeasRole.user.toString()%>") {
-						return {
-							after : false,
-							before : false,
-							inside : true
-						};
-					}
-				}
-				return false;
-			},
-			"drag_finish" : function (data) {
-				var pubId = extractPublicationId(data.o.id);
-				var targetId = data.r.attr("id");
+        "success" : function(node) {
+          if (node) {
+            if (node.length) {
+              // this is subfolders
+              spreadNbItems(node);
+            } else {
+              if (node.text) {
+                // this is the root
+                node.text = "<%=EncodeHelper.javaStringToHtmlString(componentLabel)%>";
+                if (node.attr['nbItems'] >= 0) {
+                  node.text = node.text + " ("+node.attr['nbItems']+")";
+                }
+                <% if (kmeliaScc.isOrientedWebContent()) { %>
+                node.li_attr = {class: node.attr['status']};
+                <% } %>
+                spreadNbItems(node.children);
+              }
+            }
+          }
+          return node;
+        }
+      },
+      "check_callback" : true,
+      "themes" : {
+        "dots" : false,
+        "icons" : true
+      },
+      "multiple" : false
+    },
+    // Using types - most of the time this is an overkill
+    // read the docs carefully to decide whether you need types
+    "types" : {
+      "#" : {
+        // I set both options to -2, as I do not need depth and children count checking
+        // Those two checks may slow jstree a lot, so use only when needed
+        "max_depth" : -2, // I want only `drive` nodes to be root nodes
+        "max_children" : -2, // This will prevent moving or creating any other type as a root node
+        "valid_children" : ["root"],
+      },
+      // The `root` node
+      "root" : {
+        // those prevent the functions with the same name to be used on `root` nodes
+        "valid_children" : ["bin", getToValidateFolderId()]
+      },
+      // The `bin` node
+      "bin" : {
+        // can have files and folders inside, but NOT other `drive` nodes
+        "valid_children" : -1,
+        "icon" : getWebContext() + "/util/icons/treeview/basket.jpg"
+      },
+      // The `to validate` node
+      "<%=KmeliaHelper.SPECIALFOLDER_TOVALIDATE%>" : {
+        // can have files and folders inside, but NOT other `drive` nodes
+        "valid_children" : -1,
+        "icon" : getWebContext() + "/util/icons/ok_alpha.gif"
+      },
+      "folder" : {
+        // those prevent the functions with the same name to be used on `root` nodes
+        "valid_children" : ["folder"]
+      }
+    },
+    "contextmenu" : {
+      "show_at_node" : false,
+      "items" : customMenu
+    },
+    "dnd" : {
+      "is_draggable" : false
+      //"check_while_dragging": true,
+      //"use_html5" : false
+    },
+    // the `plugins` array allows you to configure the active plugins on this instance
+    "plugins" : ["types", "contextmenu", "dnd"]
+  }).on("loaded.jstree", function(event, data) {
+    console.info('jstree loaded');
+  }).on("ready.jstree", function(event, data) {
+    var node = data.instance.get_node('#' + getCurrentFolderId());
+    data.instance.select_node(node);
+  }).on("select_node.jstree", function(e, data) {
+    // data.inst is the instance which triggered this event
+    var nodeId = data.node.id;
 
-				// store new parent of publication
-				movePublication(pubId, getCurrentNodeId(), targetId);
-			}
-		},
-		// the `plugins` array allows you to configure the active plugins on this instance
-		"plugins" : ["themes","json_data","ui","types","crrm","contextmenu","dnd"]
-    });
+    // open topic in treeview
+    if (nodeId >= 0) {
+      data.instance.open_node(data.node);
+    }
+
+    // display topic content in right panel
+    displayTopicContent(nodeId);
+  }).on("move_node.jstree", function(e, data) {
+    var pubId = extractPublicationId(data.node.id);
+    var targetId = data.parent;
+
+    // store new parent of publication
+    movePublication(pubId, getCurrentNodeId(), targetId);
+  });
 
     // init splitter
     $(".resizable1").resizable({
@@ -987,6 +958,56 @@ $(document).ready(
 	<% } %>
 	}
 );
+
+// starts the dragging when a publication is holden to be dragged off
+$(document).on('mousedown', '.jstree-draggable', function(e) {
+  return $.vakata.dnd.start(e,
+      {
+        'jstree' : true, 'obj' : $(this),
+        'nodes' : [{id : $(this).attr('id'), text : $(this).text()}]
+      },
+      '<div id="jstree-dnd" class="jstree-default"><i class="jstree-icon jstree-er"></i>' +
+        $(this).text() + '</div>');
+});
+
+$(document).on("dnd_stop.vakata", function(event, data) {
+  var treeview = getTreeview();
+  if (!treeview.settings.dnd.check_while_dragging) {
+    var target = $(data.event.target);
+    var targetId = extractFolderId(target.attr('id'));
+    var pubId = extractPublicationId(data.data.nodes[0].id);
+    // store new parent of publication
+    movePublication(pubId, getCurrentNodeId(), targetId);
+  }
+}).on("dnd_move.vakata", function(event, data) {
+  var target = $(data.event.target);
+  var canBeDropped = false;
+  var treeview = getTreeview();
+  if (target.closest('#treeDiv1').length) {
+    var targetId = extractFolderId(target.attr('id'));
+    if (targetId) {
+      target = treeview.get_node('#' + targetId);
+      if (targetId == getToValidateFolderId() || targetId == getCurrentNodeId()) {
+        canBeDropped = false;
+      } else if (target.type === 'root' && arePublicationsOnRootAllowed()) {
+        var profile = getUserProfile(targetId);
+        if (profile != "<%=SilverpeasRole.user.toString()%>") {
+          canBeDropped = true;
+        }
+      } else {
+        var profile = getUserProfile(targetId);
+        if (profile != "<%=SilverpeasRole.user.toString()%>") {
+          canBeDropped = true;
+        }
+      }
+    }
+  }
+  if (canBeDropped) {
+    treeview.settings.dnd.check_while_dragging = false;
+  } else {
+    treeview.settings.dnd.check_while_dragging = true;
+  }
+});
 </script>
 </div>
 <div id="visibleInvisible-message" style="display: none;">

--- a/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/almanach.jsp
+++ b/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/almanach.jsp
@@ -173,7 +173,7 @@
       weeklyView : ${viewContext.viewType.weeklyView},
       language : '${language}',
       objectView : '${objectView}',
-      currentDay : new Date().setDay(${refDay.year}, ${refDay.month}, ${refDay.dayOfMonth}),
+      currentDay : moment({'year': ${refDay.year}, 'month': ${refDay.month}, 'date': ${refDay.dayOfMonth}}),
       planningOfUser : ${not empty viewContext.selectedUserId}
     };
 

--- a/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/portlet.jsp
+++ b/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/portlet.jsp
@@ -166,7 +166,7 @@
       weeklyView : ${viewContext.viewType.weeklyView},
       language : '${language}',
       objectView : '${objectView}',
-      currentDay : new Date().setDay(${refDay.year}, ${refDay.month}, ${refDay.dayOfMonth}),
+      currentDay : moment({'year': ${refDay.year}, 'month': ${refDay.month}, 'date': ${refDay.dayOfMonth}}),
       planningOfUser : ${not empty viewContext.selectedUserId}
     };
 

--- a/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/styleSheets/resourcesManager.css
+++ b/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/styleSheets/resourcesManager.css
@@ -21,6 +21,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#navigation {
+  background-color:#EAEAEA;
+  padding: 5px;
+  width:99%;
+  min-height:24px;
+  position:relative;
+}
 
 .titrePanier {
   margin: 3px;

--- a/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/styleSheets/resourcesManager.css
+++ b/resourcesManager/resourcesManager-war/src/main/webapp/resourcesManager/jsp/styleSheets/resourcesManager.css
@@ -138,12 +138,14 @@ div.selected {
   background-position:center center;
   background-repeat:	no-repeat;
 }
-.sousNavBulle .list-mode.active  {
+.sousNavBulle .list-mode.active, 
+.sousNavBulle .list-mode:hover {
   background-image: url(../icons/list-mode-active.png) ;
   background-position:center center;
   background-repeat:	no-repeat;
 }
-.sousNavBulle .calendar-mode.active   {
+.sousNavBulle .calendar-mode.active,
+.sousNavBulle .calendar-mode:hover   {
   background-image: url(../icons/calendar-mode-active.png)  ;
   background-position:center center;
   background-repeat:	no-repeat;

--- a/rssAggregator/rssAggregator-war/src/main/webapp/rssAgregator/jsp/displayRSS.jsp
+++ b/rssAggregator/rssAggregator-war/src/main/webapp/rssAgregator/jsp/displayRSS.jsp
@@ -167,7 +167,6 @@ function deleteChannel(id) {
 function loadChannelsItem() {
   $.ajax({
     url: '<c:out value="${ctxPath}/services/rss/${componentId}"/>',
-    async: false,
     data: { agregate: 'yes'},
     success: function(data){
       alert('loadChannelsItem succeeded on application id : <%=componentId%>');

--- a/rssAggregator/rssAggregator-war/src/main/webapp/rssAgregator/jsp/rssPortletView.jsp
+++ b/rssAggregator/rssAggregator-war/src/main/webapp/rssAgregator/jsp/rssPortletView.jsp
@@ -95,7 +95,6 @@ function deleteChannel(id) {
 function loadChannelsItem() {
   $.ajax({
     url: '<c:out value="${ctxPath}/services/rss/${componentId}"/>',
-    async: false,
     data: { agregate: 'yes'},
     success: function(data){
       alert('loadChannelsItem succeeded on application id : <%=componentId%>');

--- a/yellowpages/yellowpages-war/src/main/webapp/yellowpages/jsp/topicManager.jsp
+++ b/yellowpages/yellowpages-war/src/main/webapp/yellowpages/jsp/topicManager.jsp
@@ -182,25 +182,30 @@ function toAddOrUpdateFolder(action, id) {
     dialogTitle = '<%=EncodeHelper.javaStringToJsString(resources.getString("TopicUpdateTitle"))%>';
   }
 
-	$.ajax({
-		url: webContext+'<%=URLUtil.getURL("yellowpages", null, componentId)%>'+action+'?Id='+id,
-		async: false,
-		type: "GET",
-		dataType: "html",
-		success: function(data) {
-			  $('#folderDialog').html(data);
-		}
-	});
-
-	$('#folderDialog').popup('validation', {
+  new Promise(function(resolve, reject) {
+    $.ajax({
+      url: webContext+'<%=URLUtil.getURL("yellowpages", null, componentId)%>'+action+'?Id='+id,
+      type: "GET",
+      dataType: "html",
+      success: function(data) {
+        $('#folderDialog').html(data);
+        resolve();
+      },
+      error: function() {
+        resolve();
+      }
+    });
+  }).then(function() {
+    $('#folderDialog').popup('validation', {
       title : dialogTitle,
-	    callback : function() {
-	      if (isCorrectForm()) {
-			  window.document.AddAndUpdateFolderForm.submit();
-		  }
-	      return true;
-	    }
-	});
+      callback : function() {
+        if (isCorrectForm()) {
+          window.document.AddAndUpdateFolderForm.submit();
+        }
+        return true;
+      }
+    });
+  });
 }
 
 </script>


### PR DESCRIPTION
The following Javascript libraries/plugins are updated (with their CSS):
* JQuery,
* JQuery-UI,
* QTip,
* Noty,
* RateIt,
* JSTree,
* FullCalendar,
* CKEditor,
* AngularJS.

Warning: jquery-migrate-1.4.1.min.js isn't really minified. It is distributed under this name in order to avoid the build system to minify it. Keep it non-minified lets us to have warnings from it on detected deprecated uses of JQuery. But, this lib should be remove before the release of Silverpeas 6.0 (it would be nice to remove it for the release of 6.0-alpha2)

Don't forget to merge also the PR [#748](https://github.com/Silverpeas/Silverpeas-Core/pull/749) in Silverpeas-Core.