### PR TITLE
Feature #8017: user calendar

### DIFF
--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/model/EventOccurrence.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/model/EventOccurrence.java
@@ -149,7 +149,7 @@ public class EventOccurrence implements Comparable<EventOccurrence> {
   /**
    * Does this occurrence occur all the day defined?
    * An occurrence occurs all the day if its start or its end date is a single date instead of a
-   * date time.
+   * datetime.
    * @return true if the event is occurring all the day.
    */
   public boolean isAllDay() {
@@ -157,18 +157,18 @@ public class EventOccurrence implements Comparable<EventOccurrence> {
   }
 
   /**
-   * Gets the start date and time of this event in the ISO 8601 format (with minute precision).
+   * Gets the start datetime of this event in the ISO 8601 format (with minute precision).
    * For example: 2010-01-01T14:30.
-   * @return the ISO 8601 format of the start date and time of this event.
+   * @return the ISO 8601 format of the start datetime of this event.
    */
   public String getStartDateTimeInISO() {
     return startDate.toShortISO8601();
   }
 
   /**
-   * Gets the end date and time of this event in the ISO 8601 format (with minute precision).
+   * Gets the end datetime of this event in the ISO 8601 format (with minute precision).
    * For example: 2010-01-01T14:30.
-   * @return the ISO 8601 format of the end date and time of this event.
+   * @return the ISO 8601 format of the end datetime of this event.
    */
   public String getEndDateTimeInISO() {
     return endDate.toShortISO8601();

--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
@@ -158,7 +158,7 @@ public class CalendarEventEncoder {
           .toInstant()
           .atZone(TimeZone.getDefault().toZoneId())
           .toOffsetDateTime();
-      recurrence.upTo(endDateTime);
+      recurrence.until(endDateTime);
     }
 
     return recurrence;

--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
@@ -92,14 +92,14 @@ public class CalendarEventEncoder {
           .withDescription(eventDetail.getWysiwyg())
           .withPriority(Priority.valueOf(eventDetail.getPriority()));
       if (isDefined(eventDetail.getPlace())) {
-        event.getAttributes().add("location", eventDetail.getPlace());
+        event.getAttributes().set("location", eventDetail.getPlace());
       }
       String url = eventDetail.getEventUrl();
       if (isDefined(url)) {
         if (!StringUtil.startsWithIgnoreCase(url, "http")) {
           url = "http://" + url;
         }
-        event.getAttributes().add("url", url);
+        event.getAttributes().set("url", url);
       }
       if (eventDetail.getPeriodicity() != null) {
         event.recur(withTheRecurrenceRuleOf(eventDetail));
@@ -149,7 +149,10 @@ public class CalendarEventEncoder {
         timeUnit = TimeUnit.DAY;
         break;
     }
-    Recurrence recurrence = every(periodicity.getFrequency(), timeUnit).on(daysOfWeek);
+    Recurrence recurrence = every(periodicity.getFrequency(), timeUnit);
+    if (timeUnit != TimeUnit.DAY) {
+      recurrence.on(daysOfWeek);
+    }
     if (periodicity.getUntilDatePeriod() != null) {
       OffsetDateTime endDateTime = periodicity.getUntilDatePeriod()
           .toInstant()

--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/service/CalendarEventEncoder.java
@@ -27,7 +27,7 @@ import net.fortuna.ical4j.model.TimeZoneRegistry;
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
 import org.silverpeas.components.almanach.model.EventDetail;
 import org.silverpeas.components.almanach.model.Periodicity;
-import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.calendar.Priority;
 import org.silverpeas.core.calendar.Recurrence;
 import org.silverpeas.core.calendar.DayOfWeekOccurrence;

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachCalendarView.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachCalendarView.java
@@ -27,6 +27,7 @@ import org.silverpeas.core.web.calendar.CalendarDay;
 import org.silverpeas.core.web.calendar.CalendarTimeWindowViewContext;
 import org.silverpeas.core.web.calendar.CalendarViewType;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -47,16 +48,16 @@ public class AlmanachCalendarView {
   /**
    * Constructs a new calendar view of the specified almanach. By default, the week-end days are
    * displayed.
-   *
-   * @param almanach the DTO carrying information about the almanach instance this view is about.
+   *  @param almanach the DTO carrying information about the almanach instance this view is about.
    * @param currentDay the current day in this calendar view.
    * @param viewType the type of view the calendar should be rendered.
    * @param locale the locale to take into account (fr for the french locale (fr_FR) for example).
+   * @param zoneId the zoneId to take into account (ZoneId.of("Europe/Paris") for example).
    */
   public AlmanachCalendarView(final AlmanachDTO almanach, final Date currentDay,
-      final CalendarViewType viewType, final String locale) {
+      final CalendarViewType viewType, final String locale, final ZoneId zoneId) {
     this.almanach = almanach;
-    viewContext = new CalendarTimeWindowViewContext(null, locale);
+    viewContext = new CalendarTimeWindowViewContext(null, locale, zoneId);
     viewContext.setReferenceDay(currentDay);
     viewContext.setViewType(viewType);
     if (!CalendarViewType.NEXT_EVENTS.equals(viewContext.getViewType())) {

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachCalendarView.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachCalendarView.java
@@ -24,7 +24,7 @@
 package org.silverpeas.components.almanach.control;
 
 import org.silverpeas.core.web.calendar.CalendarDay;
-import org.silverpeas.core.web.calendar.CalendarViewContext;
+import org.silverpeas.core.web.calendar.CalendarTimeWindowViewContext;
 import org.silverpeas.core.web.calendar.CalendarViewType;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class AlmanachCalendarView {
 
-  private CalendarViewContext viewContext;
+  private CalendarTimeWindowViewContext viewContext;
   private AlmanachDTO almanach;
   private List<DisplayableEventOccurrence> events = new ArrayList<>();
   private String label = "";
@@ -56,7 +56,7 @@ public class AlmanachCalendarView {
   public AlmanachCalendarView(final AlmanachDTO almanach, final Date currentDay,
       final CalendarViewType viewType, final String locale) {
     this.almanach = almanach;
-    viewContext = new CalendarViewContext(null, locale);
+    viewContext = new CalendarTimeWindowViewContext(null, locale);
     viewContext.setReferenceDay(currentDay);
     viewContext.setViewType(viewType);
     if (!CalendarViewType.NEXT_EVENTS.equals(viewContext.getViewType())) {

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
@@ -48,7 +48,7 @@ import org.silverpeas.core.date.period.PeriodType;
 import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.importexport.ExportException;
 import org.silverpeas.core.importexport.Exporter;
-import org.silverpeas.core.importexport.ExporterProvider;
+import org.silverpeas.core.importexport.ical.ICalExporterProvider;
 import org.silverpeas.core.importexport.ical.ExportableCalendar;
 import org.silverpeas.core.io.upload.UploadedFile;
 import org.silverpeas.core.notification.user.client.NotificationMetaData;
@@ -953,10 +953,10 @@ public class AlmanachSessionController extends AbstractComponentSessionControlle
           "almanach.EXE_GET_ALL_EVENTS_FAIL", ex);
       throw new ExportException(ex.getMessage(), ex);
     }
-    Exporter<ExportableCalendar> iCalExporter = ExporterProvider.getICalExporter();
+    Exporter<ExportableCalendar> iCalExporter = ICalExporterProvider.getICalExporter();
     FileWriter fileWriter = new FileWriter(icsFilePath);
     try {
-      iCalExporter.export(withWriter(fileWriter), ExportableCalendar.with(eventsToExport));
+      iCalExporter.exports(withWriter(fileWriter), () -> ExportableCalendar.with(eventsToExport));
     } catch (ExportException ex) {
       File fileToDelete = new File(icsFilePath);
       if (fileToDelete.exists()) {

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
@@ -23,30 +23,7 @@
  */
 package org.silverpeas.components.almanach.control;
 
-import org.silverpeas.core.calendar.event.CalendarEvent;
-import org.silverpeas.core.importexport.ExportException;
-import org.silverpeas.core.importexport.Exporter;
-import org.silverpeas.core.importexport.ExporterProvider;
-import org.silverpeas.core.importexport.ical.ExportableCalendar;
-import org.silverpeas.core.pdc.pdc.model.PdcClassification;
-import org.silverpeas.core.pdc.pdc.model.PdcPosition;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.webapi.pdc.PdcClassificationEntity;
-import org.silverpeas.core.ui.DisplayI18NHelper;
-import org.silverpeas.core.web.mvc.util.AlertUser;
-import org.silverpeas.core.notification.user.client.NotificationMetaData;
-import org.silverpeas.core.notification.user.client.NotificationParameters;
-import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
-import org.silverpeas.core.web.mvc.controller.ComponentContext;
-import org.silverpeas.core.web.mvc.controller.MainSessionController;
-import org.silverpeas.core.silvertrace.SilverTrace;
-import org.silverpeas.core.admin.component.model.ComponentInstLight;
-import org.silverpeas.core.admin.space.SpaceInstLight;
 import org.apache.commons.io.FileUtils;
-import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.web.calendar.CalendarViewType;
 import org.silverpeas.components.almanach.model.EventDetail;
 import org.silverpeas.components.almanach.model.EventOccurrence;
 import org.silverpeas.components.almanach.model.EventPK;
@@ -57,20 +34,43 @@ import org.silverpeas.components.almanach.service.AlmanachNoSuchFindEventExcepti
 import org.silverpeas.components.almanach.service.AlmanachRuntimeException;
 import org.silverpeas.components.almanach.service.AlmanachService;
 import org.silverpeas.components.almanach.service.CalendarEventEncoder;
+import org.silverpeas.core.ForeignPK;
+import org.silverpeas.core.admin.component.model.ComponentInstLight;
+import org.silverpeas.core.admin.space.SpaceInstLight;
+import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
+import org.silverpeas.core.contribution.content.wysiwyg.WysiwygException;
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController;
 import org.silverpeas.core.date.period.Period;
 import org.silverpeas.core.date.period.PeriodType;
+import org.silverpeas.core.exception.SilverpeasException;
+import org.silverpeas.core.importexport.ExportException;
+import org.silverpeas.core.importexport.Exporter;
+import org.silverpeas.core.importexport.ExporterProvider;
+import org.silverpeas.core.importexport.ical.ExportableCalendar;
 import org.silverpeas.core.io.upload.UploadedFile;
-import org.silverpeas.core.util.file.FileRepositoryManager;
-import org.silverpeas.core.util.file.FileServerUtils;
-import org.silverpeas.core.ForeignPK;
+import org.silverpeas.core.notification.user.client.NotificationMetaData;
+import org.silverpeas.core.notification.user.client.NotificationParameters;
+import org.silverpeas.core.pdc.pdc.model.PdcClassification;
+import org.silverpeas.core.pdc.pdc.model.PdcPosition;
+import org.silverpeas.core.silvertrace.SilverTrace;
+import org.silverpeas.core.ui.DisplayI18NHelper;
 import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.exception.SilverpeasException;
-import org.silverpeas.core.contribution.content.wysiwyg.WysiwygException;
-import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.util.file.FileRepositoryManager;
+import org.silverpeas.core.util.file.FileServerUtils;
+import org.silverpeas.core.web.calendar.CalendarViewType;
+import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
+import org.silverpeas.core.web.mvc.controller.ComponentContext;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
+import org.silverpeas.core.web.mvc.util.AlertUser;
+import org.silverpeas.core.webapi.pdc.PdcClassificationEntity;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -85,14 +85,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.silverpeas.core.cache.service.VolatileCacheServiceProvider
+    .getSessionVolatileResourceCacheService;
 import static org.silverpeas.core.importexport.ExportDescriptor.withWriter;
 import static org.silverpeas.core.pdc.pdc.model.PdcClassification.NONE_CLASSIFICATION;
 import static org.silverpeas.core.pdc.pdc.model.PdcClassification.aPdcClassificationOfContent;
-import static org.silverpeas.core.cache.service.VolatileCacheServiceProvider
-    .getSessionVolatileResourceCacheService;
-import static org.silverpeas.core.web.calendar.CalendarViewType.*;
 import static org.silverpeas.core.util.DateUtil.parse;
 import static org.silverpeas.core.util.StringUtil.isDefined;
+import static org.silverpeas.core.web.calendar.CalendarViewType.*;
 
 /**
  * The AlmanachSessionController provides features to handle almanachs and theirs events. A such
@@ -840,7 +840,8 @@ public class AlmanachSessionController extends AbstractComponentSessionControlle
       throws AlmanachException, AlmanachNoSuchFindEventException {
     AlmanachDTO almanachDTO = getAlmanachDTO(isAgregationUsed());
     AlmanachCalendarView view =
-        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), YEARLY, getLanguage());
+        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), YEARLY, getLanguage(),
+            getPersonalization().getZoneId());
     if (isWeekendNotVisible()) {
       view.unsetWeekendVisible();
     }
@@ -860,7 +861,8 @@ public class AlmanachSessionController extends AbstractComponentSessionControlle
 
     AlmanachDTO almanachDTO = getAlmanachDTO(isAgregationUsed());
     AlmanachCalendarView view =
-        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), MONTHLY, getLanguage());
+        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), MONTHLY, getLanguage(),
+            getPersonalization().getZoneId());
     if (isWeekendNotVisible()) {
       view.unsetWeekendVisible();
     }
@@ -880,7 +882,8 @@ public class AlmanachSessionController extends AbstractComponentSessionControlle
 
     AlmanachDTO almanachDTO = getAlmanachDTO(isAgregationUsed());
     AlmanachCalendarView view =
-        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), WEEKLY, getLanguage());
+        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), WEEKLY, getLanguage(),
+            getPersonalization().getZoneId());
     if (isWeekendNotVisible()) {
       view.unsetWeekendVisible();
     }
@@ -902,7 +905,8 @@ public class AlmanachSessionController extends AbstractComponentSessionControlle
       throws AlmanachException, AlmanachNoSuchFindEventException {
     AlmanachDTO almanachDTO = getAlmanachDTO(aggregated);
     AlmanachCalendarView view =
-        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), NEXT_EVENTS, getLanguage());
+        new AlmanachCalendarView(almanachDTO, currentDay.getTime(), NEXT_EVENTS, getLanguage(),
+            getPersonalization().getZoneId());
 
     if (isWeekendNotVisible()) {
       view.unsetWeekendVisible();

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/control/AlmanachSessionController.java
@@ -37,7 +37,7 @@ import org.silverpeas.components.almanach.service.CalendarEventEncoder;
 import org.silverpeas.core.ForeignPK;
 import org.silverpeas.core.admin.component.model.ComponentInstLight;
 import org.silverpeas.core.admin.space.SpaceInstLight;
-import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/servlets/AlmanachICSProducer.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/servlets/AlmanachICSProducer.java
@@ -27,7 +27,7 @@ import org.silverpeas.core.annotation.RequestScoped;
 import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.importexport.Exporter;
-import org.silverpeas.core.importexport.ExporterProvider;
+import org.silverpeas.core.importexport.ical.ICalExporterProvider;
 import org.silverpeas.core.importexport.ical.ExportableCalendar;
 import org.silverpeas.core.admin.service.AdminController;
 import org.silverpeas.core.admin.user.model.UserFull;
@@ -94,8 +94,8 @@ public class AlmanachICSProducer {
         List<EventDetail> allEventDetails = getAllEvents(almanachId);
         List<CalendarEvent> allEvents = encoder.encode(allEventDetails);
 
-        Exporter<ExportableCalendar> iCalExporter = ExporterProvider.getICalExporter();
-        iCalExporter.export(withWriter(writer), ExportableCalendar.with(allEvents));
+        Exporter<ExportableCalendar> iCalExporter = ICalExporterProvider.getICalExporter();
+        iCalExporter.exports(withWriter(writer), () -> ExportableCalendar.with(allEvents));
       } catch (Exception ex) {
         throw new WebApplicationException(ex, Status.SERVICE_UNAVAILABLE);
       }

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/servlets/AlmanachICSProducer.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/servlets/AlmanachICSProducer.java
@@ -25,7 +25,7 @@ package org.silverpeas.components.almanach.servlets;
 
 import org.silverpeas.core.annotation.RequestScoped;
 import org.silverpeas.core.annotation.Service;
-import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.importexport.Exporter;
 import org.silverpeas.core.importexport.ExporterProvider;
 import org.silverpeas.core.importexport.ical.ExportableCalendar;

--- a/forums/forums-war/src/main/java/org/silverpeas/components/forums/control/helpers/ForumHelper.java
+++ b/forums/forums-war/src/main/java/org/silverpeas/components/forums/control/helpers/ForumHelper.java
@@ -238,10 +238,9 @@ public class ForumHelper {
           out.println("</span></td>");
 
           // Notation
-          SilverpeasRole greaterUserRole =
-              SilverpeasRole.getGreaterFrom(SilverpeasRole.from(fsc.getUserRoles()));
+          SilverpeasRole highestUserRole = fsc.getHighestSilverpeasUserRole();
           boolean canUserRating =
-              greaterUserRole != null && greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.user);
+              highestUserRole != null && highestUserRole.isGreaterThanOrEquals(SilverpeasRole.user);
           RaterRatingEntity raterRatingEntity = RaterRatingEntity.fromRateable(message);
           out.print("<td  align=\"center\">");
           out.write(raterRatingEntity

--- a/forums/forums-war/src/main/java/org/silverpeas/components/forums/control/helpers/ForumListHelper.java
+++ b/forums/forums-war/src/main/java/org/silverpeas/components/forums/control/helpers/ForumListHelper.java
@@ -148,10 +148,9 @@ public class ForumListHelper {
       out.println("</span></td>");
 
       // 6ème colonne : notation
-      SilverpeasRole greaterUserRole =
-          SilverpeasRole.getGreaterFrom(SilverpeasRole.from(fsc.getUserRoles()));
+      SilverpeasRole highestUserRole = fsc.getHighestSilverpeasUserRole();
       boolean canUserRating =
-          greaterUserRole != null && greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.user);
+          highestUserRole != null && highestUserRole.isGreaterThanOrEquals(SilverpeasRole.user);
       RaterRatingEntity raterRatingEntity = RaterRatingEntity.fromRateable(forum);
       out.print("<td class=\"ArrayCell\">");
       out.write(raterRatingEntity

--- a/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/model/Media.java
+++ b/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/model/Media.java
@@ -249,8 +249,8 @@ public abstract class Media implements SilverpeasContent, SilverContentInterface
     AccessController<String> accessController = AccessControllerProvider
         .getAccessController(ComponentAccessControl.class);
     return accessController.isUserAuthorized(user.getId(), getComponentInstanceId()) &&
-        (isVisible(DateUtil.getDate()) || (user.isAccessAdmin() || getGreatestUserRole(user)
-            .isGreaterThanOrEquals(SilverpeasRole.publisher) || (getGreatestUserRole(user)
+        (isVisible(DateUtil.getDate()) || (user.isAccessAdmin() || getHighestUserRole(user)
+            .isGreaterThanOrEquals(SilverpeasRole.publisher) || (getHighestUserRole(user)
             .isGreaterThanOrEquals(SilverpeasRole.writer) && user.getId().equals(getCreatorId()))));
   }
 
@@ -502,14 +502,14 @@ public abstract class Media implements SilverpeasContent, SilverContentInterface
   }
 
   /**
-   * Retrieve greatest user role
+   * Retrieve highest user role
    * @param user the current user detail
-   * @return the greatest user role
+   * @return the highest user role
    */
-  protected SilverpeasRole getGreatestUserRole(final User user) {
+  protected SilverpeasRole getHighestUserRole(final User user) {
     Set<SilverpeasRole> userRoles =
         SilverpeasRole.from(OrganizationControllerProvider.getOrganisationController()
             .getUserProfiles(user.getId(), getComponentInstanceId()));
-    return SilverpeasRole.getGreatestFrom(userRoles);
+    return SilverpeasRole.getHighestFrom(userRoles);
   }
 }

--- a/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/model/MediaCriteria.java
+++ b/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/model/MediaCriteria.java
@@ -297,7 +297,7 @@ public class MediaCriteria {
       Set<SilverpeasRole> requesterRoles = SilverpeasRole.from(
           OrganizationControllerProvider.getOrganisationController()
               .getUserProfiles(getRequester().getId(), getComponentInstanceId()));
-      componentHighestRequesterRole = SilverpeasRole.getGreaterFrom(requesterRoles);
+      componentHighestRequesterRole = SilverpeasRole.getHighestFrom(requesterRoles);
     }
     return componentHighestRequesterRole;
   }

--- a/gallery/gallery-library/src/test/java/org/silverpeas/components/gallery/model/MediaTest.java
+++ b/gallery/gallery-library/src/test/java/org/silverpeas/components/gallery/model/MediaTest.java
@@ -330,7 +330,7 @@ public class MediaTest {
     }
 
     @Override
-    protected SilverpeasRole getGreatestUserRole(final User user) {
+    protected SilverpeasRole getHighestUserRole(final User user) {
       return SilverpeasRole.reader;
     }
 

--- a/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/servlets/GalleryRequestRouter.java
+++ b/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/servlets/GalleryRequestRouter.java
@@ -125,7 +125,7 @@ public class GalleryRequestRouter extends ComponentRequestRouter<GallerySessionC
     String userId = gallerySC.getUserId();
 
     request.setAttribute("Profile", highestUserRole.getName());
-    request.setAttribute("greaterUserRole", highestUserRole);
+    request.setAttribute("highestUserRole", highestUserRole);
     request.setAttribute("UserId", userId);
     request.setAttribute("IsGuest", gallerySC.isGuest());
     request.setAttribute("IsExportEnable", gallerySC.isExportEnable());

--- a/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/listSubAlbums.tag
+++ b/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/listSubAlbums.tag
@@ -26,8 +26,8 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
 
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
-<jsp:useBean id="greaterUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
+<jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 
 <view:setConstant var="adminRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.admin"/>
 
@@ -40,7 +40,7 @@
 
 <script type="text/javascript">
 
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(adminRole)}">
   $(document).ready(function() {
     $("#albumList").sortable({opacity : 0.4, cursor : 'move'});
 

--- a/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/viewMediaLayout.tag
+++ b/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/viewMediaLayout.tag
@@ -75,7 +75,7 @@
               description="Fragment to put additional bloc of metadata" %>
 
 <%-- Request attributes --%>
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
 <c:set var="media" value="${requestScope.Media}" scope="request"/>
 <jsp:useBean id="media" type="org.silverpeas.components.gallery.model.Media" scope="request"/>
 <c:set var="internalMedia" value="${media.internalMedia}"/>
@@ -137,7 +137,7 @@
     }
     </c:if>
 
-    <c:if test="${greaterUserRole eq adminRole}">
+    <c:if test="${highestUserRole eq adminRole}">
     function clipboardCopy() {
       top.IdleFrame.location.href =
           '<c:url value="${silfn:componentURL(componentId)}"/>copy?Object=Image&Id=${mediaId}';
@@ -175,7 +175,7 @@
     <view:operation altText="${manageLocationLabel}" action="javaScript:manageLocations()"/>
     <view:operation altText="${deleteLabel}" action="javaScript:deleteConfirm()" icon="${deleteIcon}"/>
   </c:if>
-  <c:if test="${greaterUserRole eq adminRole}">
+  <c:if test="${highestUserRole eq adminRole}">
     <fmt:message key="GML.copy" var="copyLabel"/>
     <fmt:message key="gallery.copy" var="copyIcon" bundle="${icons}"/>
     <c:url var="copyIcon" value="${copyIcon}"/>
@@ -193,7 +193,7 @@
     <c:url var="diapoIcon" value="${diapoIcon}"/>
     <view:operation altText="${diapoLabel}" action="javascript:startSlideshow('${mediaId}')" icon="${diapoIcon}"/>
   </c:if>
-  <c:if test="${media.type.photo and greaterUserRole eq userRole and requestScope.IsBasket}">
+  <c:if test="${media.type.photo and highestUserRole eq userRole and requestScope.IsBasket}">
     <view:operationSeparator/>
     <fmt:message var="addBasketLabel" key="gallery.addMediaToBasket"/>
     <fmt:message var="addBasketIcon" key="gallery.addMediaToBasket" bundle="${icons}"/>

--- a/gallery/gallery-war/src/main/webapp/gallery/jsp/viewAlbum.jsp
+++ b/gallery/gallery-war/src/main/webapp/gallery/jsp/viewAlbum.jsp
@@ -43,8 +43,8 @@
 <view:setConstant var="writerRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
 <view:setConstant var="userRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.user"/>
 
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
-<jsp:useBean id="greaterUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
+<jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 
 <c:set var="componentId" value="${requestScope.browseContext[3]}"/>
 
@@ -142,8 +142,8 @@
 <c:set var="isBasket" value="${requestScope.IsBasket}"/>
 <c:set var="isGuest" value="${requestScope.IsGuest}"/>
 <c:set var="isExportEnable" value="${requestScope.IsExportEnable}"/>
-<c:set var="basketOperationsAllowed" value="${greaterUserRole eq userRole and isBasket}"/>
-<c:set var="isMediaSelectable" value="${basketOperationsAllowed or isExportEnable or greaterUserRole.isGreaterThanOrEquals(publisherRole)}"/>
+<c:set var="basketOperationsAllowed" value="${highestUserRole eq userRole and isBasket}"/>
+<c:set var="isMediaSelectable" value="${basketOperationsAllowed or isExportEnable or highestUserRole.isGreaterThanOrEquals(publisherRole)}"/>
 
 <view:setConstant var="PREVIEW_RESOLUTION" constant="org.silverpeas.components.gallery.constant.MediaResolution.PREVIEW"/>
 <view:setConstant var="ORIGINAL_RESOLUTION" constant="org.silverpeas.components.gallery.constant.MediaResolution.ORIGINAL"/>
@@ -171,7 +171,7 @@ function addFavorite(name, description, url) {
   postNewLink(name, url, description);
 }
 
-<c:if test="${greaterUserRole eq adminRole or userId eq currentAlbum.creatorId}">
+<c:if test="${highestUserRole eq adminRole or userId eq currentAlbum.creatorId}">
 function deleteConfirm(id, nom) {
   // confirmation de suppression de l'album
   var label = "<fmt:message key="gallery.confirmDeleteAlbum"/> '" + $('<span>').html(nom).text() + "' ?";
@@ -184,14 +184,14 @@ function deleteConfirm(id, nom) {
 }
 </c:if>
 
-<c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+<c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
   <c:if test="${dragAndDropEnable}">
 function uploadCompleted(s) {
   location.href =
       "<c:url value="${silfn:componentURL(componentId)}ViewAlbum?Id=${currentAlbum.id}"/>&deselectAll=true";
 }
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
 
 function sendData() {
   // envoi des photos selectionnees pour la modif par lot
@@ -249,7 +249,7 @@ function sendToBasket() {
   }
 }
 
-<c:if test="${greaterUserRole eq adminRole}">
+<c:if test="${highestUserRole eq adminRole}">
 function sendDataForAddPath() {
   // envoi des photos selectionnees pour le placement par lot
   var selectedPhotos = getMediaIds(true);
@@ -350,17 +350,17 @@ function CutSelectedMedia() {
 <body>
 <gallery:browseBar albumPath="${path}"/>
 <view:operationPane>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
     <%-- Actions on album --%>
     <view:operationOfCreation action="javaScript:openGalleryEditor()" altText="${addAlbumLabel}" icon="${addAlbumIcon}"/>
-    <c:if test="${greaterUserRole eq adminRole or userId eq currentAlbum.creatorId}">
+    <c:if test="${highestUserRole eq adminRole or userId eq currentAlbum.creatorId}">
       <view:operation action="javaScript:openGalleryEditor(currentGallery)" altText="${updateAlbumLabel}" icon="${updateAlbumIcon}"/>
       <c:set var="tmpLabel"><c:out value="${currentAlbum.name}"/></c:set>
       <view:operation action="javaScript:deleteConfirm('${currentAlbum.id}','${silfn:escapeHtml(silfn:escapeJs(tmpLabel))}')" altText="${deleteAlbumLabel}" icon="${deleteAlbumIcon}"/>
     </c:if>
     <view:operationSeparator/>
     <%-- Copy/Cut of albums --%>
-    <c:if test="${greaterUserRole eq adminRole}">
+    <c:if test="${highestUserRole eq adminRole}">
       <view:operation action="javascript:onClick=clipboardCopy()" altText="${copyAlbumLabel}" icon="${copyAlbumIcon}"/>
       <view:operation action="javascript:onClick=clipboardCut()" altText="${cutAlbumLabel}" icon="${cutAlbumIcon}"/>
       <view:operationSeparator/>
@@ -371,24 +371,24 @@ function CutSelectedMedia() {
     </c:if>
   </c:if>
   <%-- Manage media by massively way --%>
-  <c:if test="${not (greaterUserRole eq userRole and not isBasket)}">
+  <c:if test="${not (highestUserRole eq userRole and not isBasket)}">
     <view:operation action="AllSelected" altText="${allSelectMediaLabel}" icon="${allSelectMediaIcon}"/>
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
     <view:operation action="javascript:onClick=sendData()" altText="${updateSelectedMediaLabel}" icon="${updateSelectedMediaIcon}"/>
     <view:operation action="javascript:onClick=sendDataDelete()" altText="${deleteSelectedMediaLabel}" icon="${deleteSelectedMediaIcon}"/>
     <c:if test="${isPdcUsed}">
       <view:operation action="javascript:onClick=sendDataCategorize()" altText="${categorizedSelectedMediaLabel}" icon="${categorizedSelectedMediaIcon}"/>
     </c:if>
   </c:if>
-  <c:if test="${greaterUserRole eq adminRole}">
+  <c:if test="${highestUserRole eq adminRole}">
     <view:operation action="javascript:onClick=sendDataForAddPath()" altText="${addPathForSelectedMediaLabel}" icon="${addPathForSelectedMediaIcon}"/>
     <view:operation action="javascript:onClick=CopySelectedMedia()" altText="${copySelectedMediaLabel}" icon="${copySelectedMediaIcon}"/>
     <view:operation action="javascript:onClick=CutSelectedMedia()" altText="${cutSelectedMediaLabel}" icon="${cutSelectedMediaIcon}"/>
     <view:operation action="javascript:onClick=clipboardPaste()" altText="${pasteSelectedMediaLabel}" icon="${pasteSelectedMediaIcon}"/>
   </c:if>
   <%-- Manage one media --%>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
     <view:operationSeparator/>
     <view:operationOfCreation action="${addPhotoAction}" altText="${addPhotoLabel}" icon="${addPhotoIcon}"/>
     <view:operationOfCreation action="${addVideoAction}" altText="${addVideoLabel}" icon="${addVideoIcon}"/>
@@ -438,13 +438,13 @@ function CutSelectedMedia() {
                                  isViewList="${isViewList}"
                                  selectable="${isMediaSelectable}"/>
     <c:choose>
-      <c:when test="${empty currentAlbum.media and empty albums and greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+      <c:when test="${empty currentAlbum.media and empty albums and highestUserRole.isGreaterThanOrEquals(publisherRole)}">
         <c:set var="templateUserRole" value="${publisherRole}"/>
       </c:when>
-      <c:when test="${empty currentAlbum.media and greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:when test="${empty currentAlbum.media and highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <c:set var="templateUserRole" value="${writerRole}"/>
       </c:when>
-      <c:when test="${empty currentAlbum.media and greaterUserRole.isGreaterThanOrEquals(userRole)}">
+      <c:when test="${empty currentAlbum.media and highestUserRole.isGreaterThanOrEquals(userRole)}">
         <c:set var="templateUserRole" value="${userRole}"/>
       </c:when>
     </c:choose>
@@ -492,7 +492,7 @@ function CutSelectedMedia() {
   <input type="hidden" name="Id"/>
 </form>
 <view:progressMessage/>
-<c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole) and dragAndDropEnable}">
+<c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole) and dragAndDropEnable}">
   <c:url var="uploadCompletedUrl" value="/RgalleryDragAndDrop/jsp/Drop">
     <c:param name="ComponentId" value="${componentId}"/>
     <c:param name="AlbumId" value="${currentAlbum.id}"/>

--- a/gallery/gallery-war/src/main/webapp/gallery/jsp/viewRestrictedMediaList.jsp
+++ b/gallery/gallery-war/src/main/webapp/gallery/jsp/viewRestrictedMediaList.jsp
@@ -39,8 +39,8 @@
 <view:setConstant var="publisherRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
 <view:setConstant var="userRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.user"/>
 
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
-<jsp:useBean id="greaterUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
+<jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 
 <fmt:message key="gallery.updateSelectedMedia" var="updateSelectedMediaLabel"/>
 <fmt:message key="gallery.updateSelectedMedia" var="updateSelectedMediaIcon" bundle="${icons}"/>
@@ -67,7 +67,7 @@
 <c:set var="isViewNotVisible" value="${requestScope.ViewNotVisible}"/>
 <c:set var="isBasket" value="${requestScope.IsBasket}"/>
 <c:set var="isExportEnable" value="${requestScope.IsExportEnable}"/>
-<c:set var="isMediaSelectable" value="${greaterUserRole eq userRole and isBasket or isExportEnable}"/>
+<c:set var="isMediaSelectable" value="${highestUserRole eq userRole and isBasket or isExportEnable}"/>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -97,7 +97,7 @@ function sendToBasket() {
 <body>
 <gallery:browseBar isViewNotVisible="${isViewNotVisible}" searchKeyword="${searchKeyWord}"/>
 <view:operationPane>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
     <view:operation action="AllSelected" altText="${allSelectMediaLabel}" icon="${allSelectMediaIcon}"/>
     <view:operation action="javascript:onClick=sendData()" altText="${updateSelectedMediaLabel}" icon="${updateSelectedMediaIcon}"/>
   </c:if>

--- a/gallery/gallery-war/src/main/webapp/gallery/jsp/welcome.jsp
+++ b/gallery/gallery-war/src/main/webapp/gallery/jsp/welcome.jsp
@@ -42,8 +42,8 @@
 <view:setConstant var="SMALL_RESOLUTION" constant="org.silverpeas.components.gallery.constant.MediaResolution.SMALL"/>
 <view:setConstant var="PREVIEW_RESOLUTION" constant="org.silverpeas.components.gallery.constant.MediaResolution.PREVIEW"/>
 
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
-<jsp:useBean id="greaterUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
+<jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 <c:set var="isPdcUsed" value="${requestScope.IsUsePdc}"/>
 <c:set var="isPrivateSearch" value="${requestScope.IsPrivateSearch}"/>
 <c:set var="isBasket" value="${requestScope.IsBasket}"/>
@@ -94,7 +94,7 @@
   <script type="text/javascript" src="<c:url value="/util/javaScript/lucene/luceneQueryValidator.js"/>"></script>
   <script type="text/javascript" src="<c:url value="/util/javaScript/jquery/jquery.cookie.js"/>"></script>
   <script type="text/javascript">
-<c:if test="${greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+<c:if test="${highestUserRole.isGreaterThanOrEquals(adminRole)}">
 $(document).ready(function() {
   showAlbumsHelp();
 });
@@ -187,29 +187,29 @@ function checkLuceneQuery(query) {
 </head>
 <body>
 <view:operationPane>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(adminRole) and isPdcUsed}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(adminRole) and isPdcUsed}">
     <c:url value="/RpdcUtilization/jsp/Main?ComponentId=${componentId}" var="tmpUrl"/>
     <view:operation action="javascript:onClick=openSPWindow('${tmpUrl}','utilizationPdc1')" altText="${pdcLabel}" icon="${pdcIcon}"/>
     <view:operationSeparator/>
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
     <view:operationOfCreation action="javaScript:openGalleryEditor()" altText="${addAlbumLabel}" icon="${addAlbumIcon}"/>
     <view:operationSeparator/>
     <view:operation action="ViewNotVisible" altText="${viewNotVisibleLabel}" icon="${viewNotVisibleIcon}"/>
     <view:operationSeparator/>
   </c:if>
 
-  <c:if test="${greaterUserRole eq userRole and isBasket or (greaterUserRole.isGreaterThanOrEquals(publisherRole) and isExportEnable)}">
+  <c:if test="${highestUserRole eq userRole and isBasket or (highestUserRole.isGreaterThanOrEquals(publisherRole) and isExportEnable)}">
     <view:operation action="BasketView" altText="${viewBasketLabel}" icon="${viewBasketIcon}"/>
   </c:if>
-  <c:if test="${(greaterUserRole eq adminRole or greaterUserRole eq userRole) and isOrder}">
+  <c:if test="${(highestUserRole eq adminRole or highestUserRole eq userRole) and isOrder}">
     <view:operation action="OrderViewList" altText="${viewOrderListLabel}" icon="${viewOrderListIcon}"/>
   </c:if>
-  <c:if test="${greaterUserRole != adminRole and not isGuest}">
+  <c:if test="${highestUserRole != adminRole and not isGuest}">
     <view:operationOfCreation action="javaScript:askMedia()" altText="${askMediaLabel}" icon="${askMediaIcon}"/>
     <view:operationSeparator/>
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(adminRole)}">
     <view:operation action="javascript:onClick=clipboardPaste()" altText="${pasteLabel}" icon="${pasteIcon}"/>
     <view:operationSeparator/>
   </c:if>

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -622,8 +622,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
             withParameter(EXPORT_FOR_USER, getUserDetail()).
             withParameter(EXPORT_LANGUAGE, getLanguage()).
             withParameter(EXPORT_TOPIC, getCurrentFolderId()).
-            inFormat(inFormat.name());
-        aKmeliaPublicationExporter().export(descriptor, publication);
+            inMimeType(inFormat.name());
+        aKmeliaPublicationExporter().exports(descriptor, () -> publication);
       } catch (Exception ex) {
         SilverLogger.getLogger(this).error("Publication export failure", ex);
         if (document != null) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -3651,7 +3651,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
    * @return true if current user has admin access on topic given in parameter
    */
   public boolean isTopicAdmin(final String nodeId) {
-    return SilverpeasRole.getGreatestFrom(SilverpeasRole.from(getUserTopicProfile(nodeId)))
+    return SilverpeasRole.getHighestFrom(SilverpeasRole.from(getUserTopicProfile(nodeId)))
         .isGreaterThanOrEquals(SilverpeasRole.admin);
   }
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/export/KmeliaPublicationExporter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/export/KmeliaPublicationExporter.java
@@ -22,22 +22,23 @@
  */
 package org.silverpeas.components.kmelia.export;
 
+import org.apache.commons.io.FileUtils;
+import org.silverpeas.components.kmelia.model.KmeliaPublication;
+import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.converter.DocumentFormat;
 import org.silverpeas.core.contribution.converter.DocumentFormatConverterProvider;
 import org.silverpeas.core.contribution.converter.ODTConverter;
 import org.silverpeas.core.importexport.ExportDescriptor;
 import org.silverpeas.core.importexport.ExportException;
 import org.silverpeas.core.importexport.Exporter;
-import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.components.kmelia.model.KmeliaPublication;
 import org.silverpeas.core.util.file.FileRepositoryManager;
-import org.apache.commons.io.FileUtils;
 
 import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.silverpeas.core.contribution.converter.DocumentFormat.inFormat;
 import static org.silverpeas.core.contribution.converter.DocumentFormat.odt;
@@ -75,18 +76,19 @@ public class KmeliaPublicationExporter implements Exporter<KmeliaPublication> {
    * @param descriptor the descriptor providing enough information about the export to perform
    * (document name, user for which the export is, the language in which the export has to be done,
    * ...)
-   * @param publication the publication to export. If several publications are passed as parameter,
-   * only the first one is taken.
+   * @param supplier a supplier of the publication to export. If several publications are passed as
+   * parameter, only the first one is taken.
    * @throws ExportException if an error occurs while exporting the publication.
    */
   @Override
-  public void export(ExportDescriptor descriptor, KmeliaPublication publication) throws
+  public void exports(ExportDescriptor descriptor, Supplier<KmeliaPublication> supplier) throws
           ExportException {
     OutputStream output = descriptor.getOutputStream();
     UserDetail user = descriptor.getParameter(EXPORT_FOR_USER);
     String language = descriptor.getParameter(EXPORT_LANGUAGE);
     String folderId = descriptor.getParameter(EXPORT_TOPIC);
-    DocumentFormat targetFormat = DocumentFormat.inFormat(descriptor.getFormat());
+    DocumentFormat targetFormat = DocumentFormat.inFormat(descriptor.getMimeType());
+    KmeliaPublication publication = supplier.get();
     String documentPath = getTemporaryExportFilePathFor(publication);
     File odtDocument = null, exportFile = null;
     try {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -1035,15 +1035,15 @@ public class AjaxPublicationsListServlet extends HttpServlet {
         result.append(" <img onclick=\"javascript:previewFile(this, '").append(id)
             .append("');\" class=\"preview-file\" src=\"")
             .append(resources.getIcon("kmelia.file.preview")).append("\" alt=\"")
-            .append(resources.getString("GML.preview")).append("\" title=\"")
-            .append(resources.getString("GML.preview")).append("\"/>");
+            .append(resources.getString("GML.preview.file")).append("\" title=\"")
+            .append(resources.getString("GML.preview.file")).append("\"/>");
       }
       if (viewable) {
         result.append(" <img onclick=\"javascript:viewFile(this, '").append(id)
             .append("');\" class=\"view-file\" src=\"")
             .append(resources.getIcon("kmelia.file.view")).append("\" alt=\"")
-            .append(resources.getString("GML.view")).append("\" title=\"")
-            .append(resources.getString("GML.view")).append("\"/>");
+            .append(resources.getString("GML.view.file")).append("\" title=\"")
+            .append(resources.getString("GML.view.file")).append("\"/>");
       }
       if (!isDownloadAllowedForReaders) {
         String forbiddenDownloadHelp =

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -149,7 +149,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     boolean profileError = false;
     boolean kmaxMode = false;
     boolean toolboxMode;
-    SilverpeasRole highestSilverpeasUserRoleOnCurrentTopic = SilverpeasRole.getGreaterFrom(
+    SilverpeasRole highestSilverpeasUserRoleOnCurrentTopic = SilverpeasRole.getHighestFrom(
         SilverpeasRole.from(kmelia.getUserTopicProfile(kmelia.getCurrentFolderId())));
     try {
       if ("kmax".equals(kmelia.getComponentRootName())) {

--- a/kmelia/kmelia-war/src/main/webapp/WEB-INF/tags/silverpeas/kmelia/dragAndDrop.tag
+++ b/kmelia/kmelia-war/src/main/webapp/WEB-INF/tags/silverpeas/kmelia/dragAndDrop.tag
@@ -34,9 +34,9 @@
 <view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
 <view:setBundle basename="org.silverpeas.util.attachment.multilang.attachment" var="attachment"/>
 
-<%@ attribute name="greatestUserRole" required="true"
+<%@ attribute name="highestUserRole" required="true"
               type="org.silverpeas.core.admin.user.model.SilverpeasRole"
-              description="The greatest role the user has" %>
+              description="The highest role the user has" %>
 <%@ attribute name="componentInstanceId" required="true"
               type="java.lang.String"
               description="The component instance id associated to the drag and drop" %>
@@ -55,7 +55,7 @@
 
   <view:setConstant var="writerRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
   <jsp:useBean id="writerRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
-  <c:if test="${greatestUserRole.isGreaterThanOrEquals(writerRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
 
     <c:set var="_ddIsI18n" value="${silfn:isI18n() && silfn:isDefined(contentLanguage)}"/>
 
@@ -65,7 +65,7 @@
     <c:set var="isVersionActive" value="${not isPublicationAlwaysVisible and silfn:booleanValue(isComponentVersioned)}"/>
 
     <c:set var="targetValidationEnabled" value="${kmeliaCtrl.targetValidationEnable || kmeliaCtrl.targetMultiValidationEnable}"/>
-    <c:set var="validationMandatory" value="${targetValidationEnabled && greatestUserRole.equals(writerRole)}"/>
+    <c:set var="validationMandatory" value="${targetValidationEnabled && highestUserRole.equals(writerRole)}"/>
     <fmt:message var="ValidatorLabel" key="kmelia.Valideur"/>
 
     <view:includePlugin name="dragAndDropUpload"/>
@@ -73,7 +73,7 @@
     <view:setConstant var="adminRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.admin"/>
     <jsp:useBean id="adminRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 
-    <c:set var="ignoreFolders" value="${not greatestUserRole.isGreaterThanOrEquals(adminRole) or (forceIgnoreFolder != null and forceIgnoreFolder)}"/>
+    <c:set var="ignoreFolders" value="${not highestUserRole.isGreaterThanOrEquals(adminRole) or (forceIgnoreFolder != null and forceIgnoreFolder)}"/>
     <c:set var="draftEnabled" value="${kmeliaCtrl.draftEnabled}"/>
     <c:set var="onlyDraftMode" value="${draftEnabled and kmeliaCtrl.pdcUsed and kmeliaCtrl.PDCClassifyingMandatory}"/>
     <c:set var="publicationStateConfirmation" value="${draftEnabled and not onlyDraftMode}"/>

--- a/kmelia/kmelia-war/src/main/webapp/WEB-INF/tags/silverpeas/kmelia/paste.tag
+++ b/kmelia/kmelia-war/src/main/webapp/WEB-INF/tags/silverpeas/kmelia/paste.tag
@@ -33,9 +33,9 @@
 <fmt:setLocale value="${userLanguage}"/>
 <view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
 
-<%@ attribute name="greatestUserRole" required="true"
+<%@ attribute name="highestUserRole" required="true"
               type="org.silverpeas.core.admin.user.model.SilverpeasRole"
-              description="The greatest role the user has" %>
+              description="The highest role the user has" %>
 <%@ attribute name="componentInstanceId" required="true"
               type="java.lang.String"
               description="The component instance id associated to the drag and drop" %>
@@ -45,10 +45,10 @@
 
 <view:setConstant var="writerRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
 <jsp:useBean id="writerRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
-<c:if test="${greatestUserRole.isGreaterThanOrEquals(writerRole)}">
+<c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
 
   <c:set var="targetValidationEnabled" value="${kmeliaCtrl.targetValidationEnable || kmeliaCtrl.targetMultiValidationEnable}"/>
-  <c:set var="validationMandatory" value="${targetValidationEnabled && greatestUserRole.equals(writerRole)}"/>
+  <c:set var="validationMandatory" value="${targetValidationEnabled && highestUserRole.equals(writerRole)}"/>
   <c:set var="draftEnabled" value="${kmeliaCtrl.draftEnabled}"/>
   <fmt:message var="ValidatorLabel" key="kmelia.Valideur"/>
 

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/oneLevel.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/oneLevel.jsp
@@ -42,7 +42,7 @@
 <fmt:setLocale value="${sessionScope[sessionController].language}" />
 <view:setBundle bundle="${requestScope.resources.multilangBundle}" />
 
-<c:set var='greatestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
+<c:set var='highestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
 
 <%
 String		rootId				= "0";
@@ -415,8 +415,8 @@ function getString(key) {
 
 <%@ include file="../../sharing/jsp/createTicketPopin.jsp" %>
 <view:progressMessage/>
-<kmelia:paste greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" />
-<kmelia:dragAndDrop greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" contentLanguage="<%=translation%>" />
+<kmelia:paste highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" />
+<kmelia:dragAndDrop highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" contentLanguage="<%=translation%>" />
 <script type="text/javascript">
 /* declare the module myapp and its dependencies (here in the silverpeas module) */
 var myapp = angular.module('silverpeas.kmelia', ['silverpeas.services', 'silverpeas.directives']);

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -621,7 +621,7 @@
                                      componentInstanceIdAlias="<%=alias%>"
                                      resourceId="<%=id%>"
                                      contentLanguage="<%=language%>"
-                                     greatestUserRole="<%=SilverpeasRole.from(attProfile)%>"
+                                     highestUserRole="<%=SilverpeasRole.from(attProfile)%>"
                                      reloadCallbackUrl="${callbackUrl}"
                                      hasToBeIndexed="<%=StringUtil.getBooleanValue(indexIt)%>"
                                      attachmentPosition="${attachmentPosition}"

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
@@ -36,7 +36,7 @@
 <%@ page import="org.silverpeas.core.web.util.viewgenerator.html.browsebars.BrowseBar" %>
 <%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
 
-<c:set var='greatestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
+<c:set var='highestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
 
 <%
 String id = "0";
@@ -285,8 +285,8 @@ $(document).ready(function() {
 
 <%@ include file="../../sharing/jsp/createTicketPopin.jsp" %>
 <view:progressMessage/>
-<kmelia:paste greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" />
-<kmelia:dragAndDrop greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" forceIgnoreFolder="true" contentLanguage="<%=translation%>" />
+<kmelia:paste highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" />
+<kmelia:dragAndDrop highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" forceIgnoreFolder="true" contentLanguage="<%=translation%>" />
 <script type="text/javascript">
 /* declare the module myapp and its dependencies (here in the silverpeas module) */
 var myapp = angular.module('silverpeas.kmelia', ['silverpeas.services', 'silverpeas.directives']);

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -39,7 +39,7 @@
 <fmt:setLocale value="${sessionScope[sessionController].language}" />
 <view:setBundle bundle="${requestScope.resources.multilangBundle}" />
 
-<c:set var='greatestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
+<c:set var='highestUserRole' value='<%=SilverpeasRole.from((String) request.getAttribute("Profile"))%>'/>
 
 <%
 String		rootId				= "0";
@@ -1059,8 +1059,8 @@ $(document).on("dnd_stop.vakata", function(event, data) {
 
 <%@ include file="../../sharing/jsp/createTicketPopin.jsp" %>
 <view:progressMessage/>
-<kmelia:paste greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" />
-<kmelia:dragAndDrop greatestUserRole="${greatestUserRole}" componentInstanceId="<%=componentId%>" contentLanguage="<%=translation%>" />
+<kmelia:paste highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" />
+<kmelia:dragAndDrop highestUserRole="${highestUserRole}" componentInstanceId="<%=componentId%>" contentLanguage="<%=translation%>" />
 <script type="text/javascript">
 /* declare the module myapp and its dependencies (here in the silverpeas module) */
 var myapp = angular.module('silverpeas.kmelia', ['silverpeas.services', 'silverpeas.directives']);

--- a/mailinglist/mailinglist-library/src/integration-test/resources/org/silverpeas/components/mailinglist/service/model/create-database.sql
+++ b/mailinglist/mailinglist-library/src/integration-test/resources/org/silverpeas/components/mailinglist/service/model/create-database.sql
@@ -84,6 +84,7 @@ UNIQUE (mailId, componentId);
 CREATE TABLE Personalization (
   id                  VARCHAR(100) NOT NULL,
   languages           VARCHAR(100) NULL,
+  zoneId              VARCHAR(100) NULL,
   look                VARCHAR(50)  NULL,
   personalWSpace      VARCHAR(50)  NULL,
   thesaurusStatus     INT          NOT NULL,

--- a/mailinglist/mailinglist-library/src/integration-test/resources/org/silverpeas/components/mailinglist/service/model/dao/create-database.sql
+++ b/mailinglist/mailinglist-library/src/integration-test/resources/org/silverpeas/components/mailinglist/service/model/dao/create-database.sql
@@ -84,6 +84,7 @@ UNIQUE (mailId, componentId);
 CREATE TABLE Personalization (
   id                  VARCHAR(100) NOT NULL,
   languages           VARCHAR(100) NULL,
+  zoneId              VARCHAR(100) NULL,
   look                VARCHAR(50)  NULL,
   personalWSpace      VARCHAR(50)  NULL,
   thesaurusStatus     INT          NOT NULL,

--- a/mailinglist/mailinglist-war/src/test-awaiting/resources/create-database.sql
+++ b/mailinglist/mailinglist-war/src/test-awaiting/resources/create-database.sql
@@ -89,6 +89,7 @@ CREATE TABLE UniqueId (
 CREATE TABLE Personalization (
 	id varchar(100) NOT NULL ,
 	languages varchar(100) NULL,
+	zoneId VARCHAR(100) NULL,
 	look varchar(50) NULL,
 	personalWSpace varchar(50) NULL,
 	thesaurusStatus int NOT NULL,

--- a/questionReply/questionReply-war/src/main/java/org/silverpeas/components/questionreply/control/QuestionReplySessionController.java
+++ b/questionReply/questionReply-war/src/main/java/org/silverpeas/components/questionreply/control/QuestionReplySessionController.java
@@ -462,7 +462,7 @@ public class QuestionReplySessionController extends AbstractComponentSessionCont
 
   @Override
   public SilverpeasRole getHighestSilverpeasUserRole() {
-    SilverpeasRole highestUserRole = SilverpeasRole.getGreatestFrom(getSilverpeasUserRoles());
+    SilverpeasRole highestUserRole = SilverpeasRole.getHighestFrom(getSilverpeasUserRoles());
     if (highestUserRole == null || SilverpeasRole.user.isGreaterThanOrEquals(highestUserRole)) {
       highestUserRole = SilverpeasRole.user;
     }

--- a/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/web/NewsResource.java
+++ b/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/web/NewsResource.java
@@ -89,7 +89,7 @@ public class NewsResource extends AbstractNewsResource {
   }
 
   private boolean isContributor() {
-    return getGreaterUserRole().isGreaterThanOrEquals(SilverpeasRole.publisher);
+    return getHighestUserRole().isGreaterThanOrEquals(SilverpeasRole.publisher);
   }
 
 }

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -41,8 +41,8 @@
 <c:set var="index" value="${requestScope['Index']}"/>
 <c:set var="role" value="${requestScope['Role']}"/>
 <jsp:useBean id="role" type="java.lang.String"/>
-<c:set var="greatestUserRole" value="<%=SilverpeasRole.from(role)%>"/>
-<jsp:useBean id="greatestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
+<c:set var="highestUserRole" value="<%=SilverpeasRole.from(role)%>"/>
+<jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 <c:set var="contributor" value="${role == 'admin' || role == 'publisher'}"/>
 <c:set var="userId" value="${sessionScope['SilverSessionController'].userId}"/>
 <c:set var="appSettings" value="${requestScope['AppSettings']}"/>
@@ -167,10 +167,10 @@ function onDelete(id) {
   <%-- Attachments --%>
   <c:set var="callbackUrl"><%=
 	URLUtil.getURL("useless", news.getComponentInstanceId()) + (viewOnly ? "ViewOnly" : "View") + "?Id=" + news.getId()%></c:set>
-  <c:set var="greatestUserRoleForAttachments" value="<%=greatestUserRole == SilverpeasRole.user ? SilverpeasRole.user : SilverpeasRole.admin%>"/>
+  <c:set var="highestUserRoleForAttachments" value="<%=highestUserRole == SilverpeasRole.user ? SilverpeasRole.user : SilverpeasRole.admin%>"/>
   <viewTags:displayAttachments componentInstanceId="${news.componentInstanceId}"
                                resourceId="${news.publicationId}"
-                               greatestUserRole="${greatestUserRoleForAttachments}"
+                               highestUserRole="${highestUserRoleForAttachments}"
                                reloadCallbackUrl="${callbackUrl}"/>
                           
   <viewTags:displayLastUserCRUD createDate="${news.createDate}" createdById="${news.createdBy}" updateDate="${news.updateDate}" updatedById="${news.updaterId}" publishDate="${news.onlineDate}" publishedById="${news.publishedBy}"/>

--- a/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
+++ b/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.components.resourcesmanager.control;
 
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.web.calendar.CalendarTimeWindowViewContext;
 import org.silverpeas.components.resourcesmanager.web.ResourceManagerResourceURIs;
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.web.calendar.CalendarTimeWindowViewContext;
+
+import java.time.ZoneId;
 
 /**
  * User: Yohann Chastagnier
@@ -43,12 +45,13 @@ public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewCont
 
   /**
    * Default constructor.
-   * @param componentInstanceId
-   * @param language
+   * @param componentInstanceId the component instance identifier
+   * @param language the language to take into account (fr for the french locale (fr_FR) for example).
+   * @param zoneId the zoneId to take into account (ZoneId.of("Europe/Paris") for example).
    */
   public ReservationTimeWindowViewContext(final String componentInstanceId, final UserDetail currentUser,
-      final String language) {
-    super(componentInstanceId, language);
+      final String language, final ZoneId zoneId) {
+    super(componentInstanceId, language, zoneId);
     this.currentUser = currentUser;
   }
 

--- a/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
+++ b/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
@@ -36,6 +36,7 @@ import java.time.ZoneId;
  */
 public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewContext {
 
+  private static final String SERVICES_PATH_PART = "/services/";
   private ResourceManagerDataViewType dataViewType = ResourceManagerDataViewType.reservations;
   private UserDetail currentUser = null;
   private String selectedUserId = null;
@@ -126,7 +127,7 @@ public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewCont
    */
   public String getReservationEventUrl() {
     StringBuilder uri = new StringBuilder(URLUtil.getApplicationURL());
-    uri.append("/services/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
+    uri.append(SERVICES_PATH_PART).append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
     uri.append("/").append(getComponentInstanceId());
     uri.append("/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_RESERVATIONS_URI_PART);
     uri.append("/").append(getViewType().getPeriodeType().getName());
@@ -160,7 +161,7 @@ public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewCont
       return "";
     }
     StringBuilder uri = new StringBuilder(URLUtil.getApplicationURL());
-    uri.append("/services/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
+    uri.append(SERVICES_PATH_PART).append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
     uri.append("/").append(getComponentInstanceId());
     uri.append("/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_RESOURCES_URI_PART);
     uri.append("/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_CATEGORIES_URI_PART);
@@ -176,7 +177,7 @@ public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewCont
       return "";
     }
     StringBuilder uri = new StringBuilder(URLUtil.getApplicationURL());
-    uri.append("/services/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
+    uri.append(SERVICES_PATH_PART).append(ResourceManagerResourceURIs.RESOURCE_MANAGER_BASE_URI);
     uri.append("/").append(getComponentInstanceId());
     uri.append("/").append(ResourceManagerResourceURIs.RESOURCE_MANAGER_RESOURCES_URI_PART);
     uri.append("/").append(resourceId);

--- a/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
+++ b/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ReservationTimeWindowViewContext.java
@@ -25,14 +25,14 @@ package org.silverpeas.components.resourcesmanager.control;
 
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.web.calendar.CalendarViewContext;
+import org.silverpeas.core.web.calendar.CalendarTimeWindowViewContext;
 import org.silverpeas.components.resourcesmanager.web.ResourceManagerResourceURIs;
 
 /**
  * User: Yohann Chastagnier
  * Date: 17/04/13
  */
-public class ReservationViewContext extends CalendarViewContext {
+public class ReservationTimeWindowViewContext extends CalendarTimeWindowViewContext {
 
   private ResourceManagerDataViewType dataViewType = ResourceManagerDataViewType.reservations;
   private UserDetail currentUser = null;
@@ -46,7 +46,7 @@ public class ReservationViewContext extends CalendarViewContext {
    * @param componentInstanceId
    * @param language
    */
-  public ReservationViewContext(final String componentInstanceId, final UserDetail currentUser,
+  public ReservationTimeWindowViewContext(final String componentInstanceId, final UserDetail currentUser,
       final String language) {
     super(componentInstanceId, language);
     this.currentUser = currentUser;
@@ -56,7 +56,7 @@ public class ReservationViewContext extends CalendarViewContext {
    * Reset to null all filters.
    */
   @Override
-  public ReservationViewContext resetFilters() {
+  public ReservationTimeWindowViewContext resetFilters() {
     super.resetFilters();
     dataViewType = ResourceManagerDataViewType.reservations;
     selectedUserId = null;

--- a/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ResourcesManagerSessionController.java
+++ b/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ResourcesManagerSessionController.java
@@ -24,20 +24,6 @@
 package org.silverpeas.components.resourcesmanager.control;
 
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
-import org.silverpeas.core.notification.user.client.NotificationManagerException;
-import org.silverpeas.core.notification.user.client.NotificationMetaData;
-import org.silverpeas.core.notification.user.client.NotificationParameters;
-import org.silverpeas.core.notification.user.client.NotificationSender;
-import org.silverpeas.core.notification.user.client.UserRecipient;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
-import org.silverpeas.core.web.mvc.controller.ComponentContext;
-import org.silverpeas.core.web.mvc.controller.MainSessionController;
-import org.silverpeas.core.web.selection.Selection;
-import org.silverpeas.core.web.selection.SelectionUsersGroups;
-import org.silverpeas.core.admin.user.model.SilverpeasRole;
-import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.components.resourcesmanager.ResourcesManagerProvider;
 import org.silverpeas.components.resourcesmanager.model.Category;
 import org.silverpeas.components.resourcesmanager.model.Reservation;
@@ -47,13 +33,27 @@ import org.silverpeas.components.resourcesmanager.model.ResourceValidator;
 import org.silverpeas.components.resourcesmanager.service.ResourcesManagerRuntimeException;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.exception.SilverpeasRuntimeException;
+import org.silverpeas.core.notification.user.client.NotificationManagerException;
+import org.silverpeas.core.notification.user.client.NotificationMetaData;
+import org.silverpeas.core.notification.user.client.NotificationParameters;
+import org.silverpeas.core.notification.user.client.NotificationSender;
+import org.silverpeas.core.notification.user.client.UserRecipient;
+import org.silverpeas.core.ui.DisplayI18NHelper;
 import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.MultiSilverpeasBundle;
 import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
+import org.silverpeas.core.web.mvc.controller.ComponentContext;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
+import org.silverpeas.core.web.selection.Selection;
+import org.silverpeas.core.web.selection.SelectionUsersGroups;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,7 +79,9 @@ public class ResourcesManagerSessionController extends AbstractComponentSessionC
   public ReservationTimeWindowViewContext getViewContext() {
     if (viewContext == null) {
       // Initialization
-      viewContext = new ReservationTimeWindowViewContext(getComponentId(), getUserDetail(), getLanguage());
+      viewContext =
+          new ReservationTimeWindowViewContext(getComponentId(), getUserDetail(), getLanguage(),
+              getPersonalization().getZoneId());
     }
     return viewContext;
   }

--- a/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ResourcesManagerSessionController.java
+++ b/resourcesManager/resourcesManager-war/src/main/java/org/silverpeas/components/resourcesmanager/control/ResourcesManagerSessionController.java
@@ -62,7 +62,7 @@ import java.util.List;
 
 public class ResourcesManagerSessionController extends AbstractComponentSessionController {
 
-  private ReservationViewContext viewContext = null;
+  private ReservationTimeWindowViewContext viewContext = null;
 
   private Reservation reservationCourante;
   private Date beginDateReservation;
@@ -76,10 +76,10 @@ public class ResourcesManagerSessionController extends AbstractComponentSessionC
   private NotificationSender notifSender;
   private MultiSilverpeasBundle resources;
 
-  public ReservationViewContext getViewContext() {
+  public ReservationTimeWindowViewContext getViewContext() {
     if (viewContext == null) {
       // Initialization
-      viewContext = new ReservationViewContext(getComponentId(), getUserDetail(), getLanguage());
+      viewContext = new ReservationTimeWindowViewContext(getComponentId(), getUserDetail(), getLanguage());
     }
     return viewContext;
   }

--- a/scheduleEvent/scheduleEvent-library/src/main/java/org/silverpeas/components/scheduleevent/service/CalendarEventEncoder.java
+++ b/scheduleEvent/scheduleEvent-library/src/main/java/org/silverpeas/components/scheduleevent/service/CalendarEventEncoder.java
@@ -27,7 +27,7 @@ import org.silverpeas.components.scheduleevent.service.model.ScheduleEventStatus
 import org.silverpeas.components.scheduleevent.service.model.beans.DateOption;
 import org.silverpeas.components.scheduleevent.service.model.beans.Response;
 import org.silverpeas.components.scheduleevent.service.model.beans.ScheduleEvent;
-import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.date.Period;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;

--- a/scheduleEvent/scheduleEvent-war/src/main/java/org/silverpeas/components/scheduleevent/control/ScheduleEventSessionController.java
+++ b/scheduleEvent/scheduleEvent-war/src/main/java/org/silverpeas/components/scheduleevent/control/ScheduleEventSessionController.java
@@ -23,7 +23,7 @@ package org.silverpeas.components.scheduleevent.control;
 import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.importexport.ExportException;
 import org.silverpeas.core.importexport.Exporter;
-import org.silverpeas.core.importexport.ExporterProvider;
+import org.silverpeas.core.importexport.ical.ICalExporterProvider;
 import org.silverpeas.core.importexport.ical.ExportableCalendar;
 import org.silverpeas.components.scheduleevent.notification.ScheduleEventUserCallAgainNotification;
 import org.silverpeas.components.scheduleevent.notification.ScheduleEventUserNotification;
@@ -455,12 +455,12 @@ public class ScheduleEventSessionController extends AbstractComponentSessionCont
     List<CalendarEvent> eventsToExport = asCalendarEvents(event, listDateOption);
 
     // export iCal
-    Exporter<ExportableCalendar> iCalExporter = ExporterProvider.getICalExporter();
+    Exporter<ExportableCalendar> iCalExporter = ICalExporterProvider.getICalExporter();
     String icsFileName = ICS_PREFIX + getUserId() + ".ics";
     String icsFilePath = FileRepositoryManager.getTemporaryPath() + icsFileName;
     FileWriter fileWriter = new FileWriter(icsFilePath);
     try {
-      iCalExporter.export(withWriter(fileWriter), ExportableCalendar.with(eventsToExport));
+      iCalExporter.exports(withWriter(fileWriter), () -> ExportableCalendar.with(eventsToExport));
     } catch (ExportException ex) {
       File fileToDelete = new File(icsFilePath);
       if (fileToDelete.exists()) {

--- a/scheduleEvent/scheduleEvent-war/src/main/java/org/silverpeas/components/scheduleevent/control/ScheduleEventSessionController.java
+++ b/scheduleEvent/scheduleEvent-war/src/main/java/org/silverpeas/components/scheduleevent/control/ScheduleEventSessionController.java
@@ -20,7 +20,7 @@
  */
 package org.silverpeas.components.scheduleevent.control;
 
-import org.silverpeas.core.calendar.event.CalendarEvent;
+import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.importexport.ExportException;
 import org.silverpeas.core.importexport.Exporter;
 import org.silverpeas.core.importexport.ExporterProvider;

--- a/silverCrawler/silverCrawler-war/src/main/webapp/silverCrawler/jsp/viewDirectory.jsp
+++ b/silverCrawler/silverCrawler-war/src/main/webapp/silverCrawler/jsp/viewDirectory.jsp
@@ -44,7 +44,7 @@
 <view:setConstant var="publisherRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.publisher"/>
 
 <c:set var="componentId" value="${requestScope.browseContext[3]}"/>
-<c:set var="greatestUserRole" value='<%=SilverpeasRole.from((String)request.getAttribute("Profile"))%>'/>
+<c:set var="highestUserRole" value='<%=SilverpeasRole.from((String)request.getAttribute("Profile"))%>'/>
 
 <%@ include file="check.jsp" %>
 <%
@@ -78,7 +78,7 @@ if ("user".equals(profile) && !allowedNav)
 
 <c:set var="folderIsWritable" value="<%=folderIsWritable%>"/>
 <c:set var="readWriteActivated" value="<%=readWriteActivated%>"/>
-<c:set var="dragAndDropEnable" value="${greatestUserRole.isGreaterThanOrEquals(publisherRole) and folderIsWritable and readWriteActivated}"/>
+<c:set var="dragAndDropEnable" value="${highestUserRole.isGreaterThanOrEquals(publisherRole) and folderIsWritable and readWriteActivated}"/>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -712,7 +712,7 @@ out.println(window.printAfter());
 </form>
 <view:progressMessage/>
 <c:if test="${dragAndDropEnable}">
-  <c:set var="ignoreFolders" value="${not greatestUserRole.isGreaterThanOrEquals(adminRole)}"/>
+  <c:set var="ignoreFolders" value="${not highestUserRole.isGreaterThanOrEquals(adminRole)}"/>
   <c:url var="uploadCompletedUrl" value="/SilverCrawlerDragAndDrop">
     <c:param name="ComponentId" value="${componentId}"/>
     <c:if test="${ignoreFolders}">
@@ -722,7 +722,7 @@ out.println(window.printAfter());
   <viewTags:commonDragAndDrop domSelector=".dragAndDropUpload"
                               domHelpHighlightSelector=".tableBoard"
                               componentInstanceId="${componentId}"
-                              greatestUserRole="${greatestUserRole}"
+                              highestUserRole="${highestUserRole}"
                               uploadCompletedUrl="${uploadCompletedUrl}"
                               uploadCompletedUrlSuccess="processDnD"
                               ignoreFolders="${ignoreFolders}"/>

--- a/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/Suggestion.java
+++ b/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/Suggestion.java
@@ -252,7 +252,7 @@ public class Suggestion extends SilverpeasJpaEntity<Suggestion, UuidIdentifier>
    */
   public boolean isPublishableBy(User user) {
     return (getValidation().isInDraft() || getValidation().isRefused()) && (user.isAccessAdmin()
-        || (getCreator().equals(user) && getSuggestionBox().getGreaterUserRole(user)
+        || (getCreator().equals(user) && getSuggestionBox().getHighestUserRole(user)
         .isGreaterThanOrEquals(SilverpeasRole.writer)));
   }
 

--- a/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/SuggestionBox.java
+++ b/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/SuggestionBox.java
@@ -145,15 +145,15 @@ public class SuggestionBox extends SilverpeasJpaEntity<SuggestionBox, UuidIdenti
   }
 
   /**
-   * Gets the greater role of the specified user on the suggestion box.
+   * Gets the highest role of the specified user on the suggestion box.
    * @param user the aimed user.
    * @return a {@link SilverpeasRole} instance.
    */
-  public SilverpeasRole getGreaterUserRole(User user) {
+  public SilverpeasRole getHighestUserRole(User user) {
     String[] profiles = OrganizationControllerProvider.getOrganisationController()
         .getUserProfiles(user.getId(), getComponentInstanceId());
     Set<SilverpeasRole> userRoles = SilverpeasRole.from(profiles);
-    SilverpeasRole role = SilverpeasRole.getGreaterFrom(userRoles);
+    SilverpeasRole role = SilverpeasRole.getHighestFrom(userRoles);
     return role != null ? role : SilverpeasRole.reader;
   }
 

--- a/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/SuggestionCollection.java
+++ b/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/SuggestionCollection.java
@@ -297,10 +297,10 @@ public class SuggestionCollection implements Collection<Suggestion> {
                 Suggestion actual = get(suggestion.getId());
                 if (actual.getValidation().isInDraft() || actual.getValidation().isRefused()) {
                   User updater = suggestion.getLastUpdater();
-                  SilverpeasRole greaterUserRole = suggestionBox.getGreaterUserRole(updater);
-                  if (greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.writer)) {
+                  SilverpeasRole highestUserRole = suggestionBox.getHighestUserRole(updater);
+                  if (highestUserRole.isGreaterThanOrEquals(SilverpeasRole.writer)) {
                     ContributionValidation validation = actual.getValidation();
-                    if (greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.publisher)) {
+                    if (highestUserRole.isGreaterThanOrEquals(SilverpeasRole.publisher)) {
                       validation.setStatus(ContributionStatus.VALIDATED);
                       validation.setDate(new Date());
                       validation.setValidator(updater);
@@ -358,8 +358,8 @@ public class SuggestionCollection implements Collection<Suggestion> {
                 Suggestion actual = get(suggestion.getId());
                 if (actual.getValidation().isPendingValidation()) {
                   User updater = suggestion.getLastUpdater();
-                  SilverpeasRole greaterUserRole = suggestionBox.getGreaterUserRole(updater);
-                  if (greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.publisher)) {
+                  SilverpeasRole highestUserRole = suggestionBox.getHighestUserRole(updater);
+                  if (highestUserRole.isGreaterThanOrEquals(SilverpeasRole.publisher)) {
                     ContributionValidation actualValidation = actual.getValidation();
                     actualValidation.setStatus(validation.getStatus());
                     actualValidation.setComment(validation.getComment());

--- a/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/common/SuggestionBoxWebServiceProvider.java
+++ b/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/common/SuggestionBoxWebServiceProvider.java
@@ -408,7 +408,7 @@ public class SuggestionBoxWebServiceProvider {
    */
   private static SilverpeasRole getHighestUserRoleFrom(User user,
       SuggestionBox suggestionBox) {
-    return SilverpeasRole.getGreatestFrom(SilverpeasRole.from(OrganizationController.get()
+    return SilverpeasRole.getHighestFrom(SilverpeasRole.from(OrganizationController.get()
             .getUserProfiles(user.getId(), suggestionBox.getComponentInstanceId())));
   }
 

--- a/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebController.java
+++ b/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebController.java
@@ -402,7 +402,7 @@ public class SuggestionBoxWebController extends
       context.getRequest().setAttribute("suggestion", entity);
       boolean isPublishable = entity.isPublishableBy(context.getUser());
       boolean isModeratorView = entity.getValidation().isPendingValidation() && context.
-          getGreaterUserRole().isGreaterThanOrEquals(SilverpeasRole.publisher);
+          getHighestUserRole().isGreaterThanOrEquals(SilverpeasRole.publisher);
       context.getRequest().setAttribute("isModeratorView", isModeratorView);
       context.getRequest().setAttribute("isPublishable", isPublishable);
       context.getRequest().setAttribute("isEditable", (isPublishable || isModeratorView));

--- a/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionBox.jsp
+++ b/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionBox.jsp
@@ -40,7 +40,7 @@
 <c:set var="currentUserId"    value="${currentUser.id}"/>
 <c:set var="isUserSubscribed" value="${requestScope.isUserSubscribed}"/>
 <c:set var="componentId"      value="${requestScope.browseContext[3]}"/>
-<c:set var="greaterUserRole"  value="${requestScope.greaterUserRole}"/>
+<c:set var="highestUserRole"  value="${requestScope.highestUserRole}"/>
 <c:set var="suggestionBox"    value="${requestScope.currentSuggestionBox}"/>
 <c:set var="suggestionBoxId"  value="${suggestionBox.id}"/>
 <c:set var="isEdito"          value="${requestScope.isEdito}"/>
@@ -117,15 +117,15 @@
 </head>
 <body ng-controller="mainController">
 <view:operationPane>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(adminRole)}">
     <view:operation action="${componentUriBase}edito/modify" altText="${modifyEditoLabel}"/>
     <view:operationSeparator/>
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
     <view:operation action="${componentUriBase}suggestions/pending" altText="${suggestionsInPendingLabel}"/>
     <view:operationSeparator/>
   </c:if>
-  <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+  <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
     <view:operationOfCreation action="${componentUriBase}suggestions/new" altText="${browseBarPathSuggestionLabel}" icon="${creationIconURL}"/>
     <view:operation action="${componentUriBase}suggestions/mine" altText="${mySuggestionsLabel}"/>
   </c:if>
@@ -150,11 +150,11 @@
           <view:displayWysiwyg objectId="${suggestionBoxId}" componentId="${componentId}" language="${null}"/>
         </div>
       </c:when>
-      <c:when test="${greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+      <c:when test="${highestUserRole.isGreaterThanOrEquals(adminRole)}">
         <div class="inlineMessage">${silfn:escapeHtmlWhitespaces(editoEmptyMessage)}</div>
       </c:when>
     </c:choose>
-    <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+    <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
       <div id="my-suggestionBox">
         <view:areaOfOperationOfCreation/>
         <fmt:message key="suggestionBox.label.suggestions.mine" var="labelMySuggestions"/>
@@ -174,7 +174,7 @@
           <div class="header">
             <h3 class="my-suggestionBox-inProgress-title"><fmt:message key="suggestionBox.label.suggestions.progress"/></h3>
           </div>
-          <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+          <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
             <ul ng-controller="myOutOfDraftSuggestionsController">
               <li ng-if="myOutOfDraftSuggestions.length === 0"><span class="txt-no-content">${noSuggestions}</span></li>
               <li ng-repeat="suggestion in myOutOfDraftSuggestions">
@@ -240,7 +240,7 @@
     suggestionBoxId : '${suggestionBoxId}',
     component : '${componentId}',
     componentUriBase : '${componentUriBase}',
-    userRole: '${greaterUserRole}'
+    userRole: '${highestUserRole}'
   });
 </script>
 <script type="text/javascript" src="${suggestionBoxJS}"></script>

--- a/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionEdit.jsp
+++ b/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionEdit.jsp
@@ -30,7 +30,7 @@
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
 
 <view:setConstant var="writerRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
 
 <fmt:setLocale value="${requestScope.resources.language}"/>
 <view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
@@ -50,7 +50,7 @@
   <c:set var="target" value="${suggestion.id}"/>
 </c:if>
 
-<c:if test="${not greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+<c:if test="${not highestUserRole.isGreaterThanOrEquals(writerRole)}">
   <c:redirect url="/Error403.jsp"/>
 </c:if>
 

--- a/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionList.jsp
+++ b/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionList.jsp
@@ -36,7 +36,7 @@
 <view:setConstant var="MySuggestionsViewContext"            constant="org.silverpeas.components.suggestionbox.control.SuggestionBoxWebController.ViewContext.MySuggestions"/>
 <view:setConstant var="SUGGESTION_LIST_IDENTIFIER"          constant="org.silverpeas.components.suggestionbox.control.SuggestionBoxWebController.SUGGESTION_LIST_ARRAYPANE_IDENTIFIER"/>
 
-<c:set var="greaterUserRole"     value="${requestScope.greaterUserRole}"/>
+<c:set var="highestUserRole"     value="${requestScope.highestUserRole}"/>
 <c:set var="currentUserLanguage" value="${requestScope.resources.language}"/>
 
 <fmt:setLocale  value="${currentUserLanguage}"/>
@@ -98,16 +98,16 @@
     <%-- ViewContext : all suggestions the user can see --%>
     <c:when test="${viewContext == AllSuggestionsViewContext}">
       <c:set var="routingAddress" value="${allSuggestionsUri}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
         <view:operation action="${pendingSuggestionsUri}" altText="${suggestionsInPendingLabel}"/>
         <view:operationSeparator/>
       </c:if>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operationOfCreation action="${componentUriBase}suggestions/new" altText="${proposeSuggestionLabel}" icon="${creationIcon}"/>
         <view:operationSeparator/>
       </c:if>
       <view:operation action="${publishedSuggestionsUri}" altText="${allPublishedSuggestionsLabel}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operation action="${mineSuggestionsUri}" altText="${mySuggestionsLabel}"/>
       </c:if>
     </c:when>
@@ -116,18 +116,18 @@
       <c:set var="routingAddress" value="${pendingSuggestionsUri}"/>
       <view:operation action="${publishedSuggestionsUri}" altText="${allPublishedSuggestionsLabel}"/>
       <view:operation action="${allSuggestionsUri}" altText="${allSuggestionsLabel}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operation action="${mineSuggestionsUri}" altText="${mySuggestionsLabel}"/>
       </c:if>
     </c:when>
     <%-- ViewContext : my suggestions --%>
     <c:when test="${viewContext == MySuggestionsViewContext}">
       <c:set var="routingAddress" value="${mineSuggestionsUri}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
         <view:operation action="${pendingSuggestionsUri}" altText="${suggestionsInPendingLabel}"/>
         <view:operationSeparator/>
       </c:if>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operationOfCreation action="${componentUriBase}suggestions/new" altText="${proposeSuggestionLabel}" icon="${creationIcon}"/>
         <view:operationSeparator/>
       </c:if>
@@ -137,16 +137,16 @@
     <%-- ViewContext : all published suggestions --%>
     <c:otherwise>
       <c:set var="routingAddress" value="${publishedSuggestionsUri}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(publisherRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(publisherRole)}">
         <view:operation action="${pendingSuggestionsUri}" altText="${suggestionsInPendingLabel}"/>
         <view:operationSeparator/>
       </c:if>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operationOfCreation action="${componentUriBase}suggestions/new" altText="${proposeSuggestionLabel}" icon="${creationIcon}"/>
         <view:operationSeparator/>
       </c:if>
       <view:operation action="${allSuggestionsUri}" altText="${allSuggestionsLabel}"/>
-      <c:if test="${greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+      <c:if test="${highestUserRole.isGreaterThanOrEquals(writerRole)}">
         <view:operation action="${mineSuggestionsUri}" altText="${mySuggestionsLabel}"/>
       </c:if>
     </c:otherwise>
@@ -160,7 +160,7 @@
         <view:displayWysiwyg objectId="${suggestionBoxId}" componentId="${componentId}" language="${null}"/>
       </div>
     </c:if>
-    <c:if test="${viewContext != SuggestionsInValidationViewContext and greaterUserRole.isGreaterThanOrEquals(writerRole)}">
+    <c:if test="${viewContext != SuggestionsInValidationViewContext and highestUserRole.isGreaterThanOrEquals(writerRole)}">
       <view:areaOfOperationOfCreation/>
     </c:if>
     <view:arrayPane var="${SUGGESTION_LIST_IDENTIFIER}" routingAddress="${routingAddress}" sortableLines="true">

--- a/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionView.jsp
+++ b/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionView.jsp
@@ -31,7 +31,7 @@
 
 <view:setConstant var="writerRole" constant="org.silverpeas.core.admin.user.model.SilverpeasRole.writer"/>
 <view:setConstant var="adminRole"  constant="org.silverpeas.core.admin.user.model.SilverpeasRole.admin"/>
-<c:set var="greaterUserRole" value="${requestScope.greaterUserRole}"/>
+<c:set var="highestUserRole" value="${requestScope.highestUserRole}"/>
 
 <c:set var="currentUserLanguage" value="${requestScope.resources.language}"/>
 <fmt:setLocale value="${currentUserLanguage}"/>
@@ -110,7 +110,7 @@
   <c:if test="${isPublishable}">
     <view:operation action="javascript:publish();" altText="${publishSuggestionMenuLabel}"/>
   </c:if>
-  <c:if test="${isPublishable or greaterUserRole.isGreaterThanOrEquals(adminRole)}">
+  <c:if test="${isPublishable or highestUserRole.isGreaterThanOrEquals(adminRole)}">
     <view:operation action="angularjs:remove(suggestion, true)" altText="${deleteSuggestionMenuLabel}"/>
     <div suggestionbox-deletion></div>
   </c:if>

--- a/suggestionBox/suggestionBox-war/src/test-awaiting/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebControllerTest.java
+++ b/suggestionBox/suggestionBox-war/src/test-awaiting/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebControllerTest.java
@@ -752,23 +752,23 @@ public class SuggestionBoxWebControllerTest {
         .getUsersIdsByRoleNames(anyString(), anyListOf(String.class));
   }
 
-  private SuggestionBoxWebRequestContext prepareViewSuggestionTest(SilverpeasRole greaterUserRole,
+  private SuggestionBoxWebRequestContext prepareViewSuggestionTest(SilverpeasRole highestUserRole,
       ContributionStatus suggestionStatus) {
     SuggestionBoxWebRequestContext context = aSuggestionBoxWebRequestContext();
     when(context.getPathVariables().get("id")).thenReturn(SUGGESTION_ID);
-    when(context.getGreaterUserRole())
-        .thenReturn(greaterUserRole != null ? greaterUserRole : SilverpeasRole.reader);
+    when(context.getHighestUserRole())
+        .thenReturn(highestUserRole != null ? highestUserRole : SilverpeasRole.reader);
     SuggestionBox box = context.getSuggestionBox();
     Suggestion theSuggestion = aSuggestionWithStatus(suggestionStatus);
     when(box.getSuggestions().get(SUGGESTION_ID)).thenReturn(theSuggestion);
-    boolean isPublishable = greaterUserRole != null &&
+    boolean isPublishable = highestUserRole != null &&
         (theSuggestion.getValidation().isInDraft() || theSuggestion.getValidation().isRefused()) &&
-        greaterUserRole.isGreaterThanOrEquals(SilverpeasRole.writer);
+        highestUserRole.isGreaterThanOrEquals(SilverpeasRole.writer);
     when(theSuggestion.isPublishableBy(any(UserDetail.class))).thenReturn(isPublishable);
 
     final String[] roles;
-    if (greaterUserRole != null) {
-      roles = new String[]{greaterUserRole.getName()};
+    if (highestUserRole != null) {
+      roles = new String[]{highestUserRole.getName()};
     } else {
       roles = new String[0];
     }


### PR DESCRIPTION
WARNING: as some database tables already exist into current installed Silverpeas V6 (after first integration of the engine) and also because in an other side we wanted to keep version 001 for SQL scripts all database tables linked to the feature must be droped.
A good way to perform that is to get an installer released after the date of 27/04/2017 and put into config.properties file the parameter "DEV_CLEANUP_CALENDAR = true" before a clean install actions.
Don't forget to remove this parameter after a successful Silverpeas update!!!

Linked to PR:
* https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/2
* https://github.com/Silverpeas/Silverpeas-Core/pull/829