### PR TITLE
Bug #10013: fixing an annoying modal message displayed by IE11...

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -364,9 +364,9 @@
       }
 
       function closeWindows() {
-        if (window.publicationWindow != null)
+        if (window.publicationWindow != null && window.publicationWindow !== window)
           window.publicationWindow.close();
-        if (window.publicVersionsWindow != null)
+        if (window.publicVersionsWindow != null && window.publicVersionsWindow !== window)
           window.publicVersionsWindow.close();
       }
 


### PR DESCRIPTION
...when the user is leaving the preview page of a publication by clicking on the Silverpeas logo from the header part of the main page.