### PR TITLE
Feature 10255

### DIFF
--- a/blog/blog-war/src/main/java/org/silverpeas/components/blog/control/BlogSessionController.java
+++ b/blog/blog-war/src/main/java/org/silverpeas/components/blog/control/BlogSessionController.java
@@ -256,7 +256,9 @@ public final class BlogSessionController extends AbstractComponentSessionControl
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
       final String postId = c.get(NotificationContext.CONTRIBUTION_ID);
-      return new BlogUserAlertNotification(getPost(postId), getUserDetail()).build();
+      final PostDetail post = getPost(postId);
+      c.put(NotificationContext.PUBLICATION_ID, post.getPublication().getId());
+      return new BlogUserAlertNotification(post, getUserDetail()).build();
     };
   }
 

--- a/blog/blog-war/src/main/java/org/silverpeas/components/blog/control/BlogSessionController.java
+++ b/blog/blog-war/src/main/java/org/silverpeas/components/blog/control/BlogSessionController.java
@@ -47,6 +47,7 @@ import org.silverpeas.core.mylinks.service.MyLinksService;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.pdc.pdc.model.PdcClassification;
 import org.silverpeas.core.pdc.pdc.model.PdcPosition;
 import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
@@ -254,7 +255,7 @@ public final class BlogSessionController extends AbstractComponentSessionControl
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String postId = c.get("postId");
+      final String postId = c.get(NotificationContext.CONTRIBUTION_ID);
       return new BlogUserAlertNotification(getPost(postId), getUserDetail()).build();
     };
   }

--- a/blog/blog-war/src/main/webapp/blog/jsp/viewPost.jsp
+++ b/blog/blog-war/src/main/webapp/blog/jsp/viewPost.jsp
@@ -31,6 +31,7 @@
 <%@ page import="org.silverpeas.components.blog.model.PostDetail" %>
 <%@page import="org.silverpeas.components.blog.control.StyleSheet"%>
 <%@page import="org.silverpeas.components.blog.control.WallPaper"%>
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%@ include file="check.jsp" %>
 
 <% 
@@ -74,7 +75,7 @@ StyleSheet styleSheet = (StyleSheet) request.getAttribute("StyleSheet");
   }
   if (!m_MainSessionCtrl.getCurrentUserDetail().isAccessGuest()) {
     operationPane.addOperation("useless", resource.getString("GML.notify"),
-        "javaScript:onClick=sp.messager.open('" + instanceId + "', {postId: '" + postId + "'});");
+        "javaScript:onClick=sp.messager.open('" + instanceId + "', {" + NotificationContext.CONTRIBUTION_ID + ": '" + postId + "'});");
   }
 %>
 

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/control/ClassifiedsSessionController.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/control/ClassifiedsSessionController.java
@@ -48,6 +48,7 @@ import org.silverpeas.core.contribution.template.publication.PublicationTemplate
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
 import org.silverpeas.core.index.search.model.QueryDescription;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.notification.user.builder.helper.UserNotificationHelper;
 import org.silverpeas.core.security.session.SessionInfo;
 import org.silverpeas.core.security.session.SessionManagement;
@@ -774,7 +775,7 @@ public final class ClassifiedsSessionController extends AbstractComponentSession
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String instanceId = c.get("componentId");
+      final String instanceId = c.get(NotificationContext.COMPONENT_ID);
       final String sessionKey = c.get("usk");
       final SessionManagement sessionManagement = SessionManagementProvider.getSessionManagement();
       final SessionInfo sessionInfo = sessionManagement.getSessionInfo(sessionKey);

--- a/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/control/GallerySessionController.java
+++ b/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/control/GallerySessionController.java
@@ -69,6 +69,7 @@ import org.silverpeas.core.notification.NotificationException;
 import org.silverpeas.core.notification.message.MessageNotifier;
 import org.silverpeas.core.notification.user.DefaultUserNotification;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.notification.user.client.NotificationMetaData;
 import org.silverpeas.core.notification.user.client.NotificationParameters;
 import org.silverpeas.core.notification.user.client.NotificationSender;
@@ -571,7 +572,7 @@ public final class GallerySessionController extends AbstractComponentSessionCont
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String mediaId = c.get("mediaId");
+      final String mediaId = c.get(NotificationContext.CONTRIBUTION_ID);
       return new DefaultUserNotification(getAlertNotificationMetaData(mediaId));
     };
   }

--- a/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/viewMediaLayout.tag
+++ b/gallery/gallery-war/src/main/webapp/WEB-INF/tags/silverpeas/gallery/viewMediaLayout.tag
@@ -1,6 +1,7 @@
 <%@ tag import="org.silverpeas.core.contribution.content.form.DataRecord" %>
 <%@ tag import="org.silverpeas.core.contribution.content.form.Form" %>
 <%@ tag import="org.silverpeas.core.contribution.content.form.PagesContext" %>
+<%@ tag import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%--
   Copyright (C) 2000 - 2018 Silverpeas
 
@@ -94,7 +95,7 @@
 <jsp:useBean id="albumId" type="java.lang.String"/>
 
 <c:set var="callback">function( event ) { if (event.type === 'listing') { commentCount = event.comments.length; $('#comment-tab').html('<c:out value="${commentTab}"/> ( ' + event.comments.length + ')'); } else if (event.type === 'deletion') { commentCount--; $('#comment-tab').html('<c:out value="${commentTab}"/> ( ' + commentCount + ')'); } else if (event.type === 'addition') { commentCount++; $('#comment-tab').html('<c:out value="${commentTab}"/> ( ' + commentCount + ')'); } }</c:set>
-
+<c:set var="contributionIdKey"><%=NotificationContext.CONTRIBUTION_ID%></c:set>
 <c:set var="mediaSrcValue" value="${not empty internalMedia ? internalMedia.fileName : media.streaming.homepageUrl}"/>
 <c:set var="mediaTitle" value="${(not empty media.title and media.title != mediaSrcValue) ? media.title : mediaSrcValue}"/>
 
@@ -149,7 +150,7 @@
   <fmt:message key="GML.notify" var="notifLabel"/>
   <fmt:message key="gallery.alert" var="notifIcon" bundle="${icons}"/>
   <c:url value="${notifIcon}" var="notifIcon"/>
-  <view:operation altText="${notifLabel}" action="javaScript:onClick=sp.messager.open('${instanceId}', {mediaId: '${mediaId}'});" icon="${notifIcon}"/>
+  <view:operation altText="${notifLabel}" action="javaScript:onClick=sp.messager.open('${instanceId}', {${contributionIdKey}: '${mediaId}'});" icon="${notifIcon}"/>
   <view:operationSeparator/>
   <c:if test="${requestScope.UpdateMediaAllowed}">
     <fmt:message key="GML.modify" var="modifyLabel"/>

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -61,8 +61,9 @@ import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygControlle
 import org.silverpeas.core.contribution.publication.datereminder.PublicationNoteReference;
 import org.silverpeas.core.contribution.publication.model.Alias;
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
-import org.silverpeas.core.contribution.publication.model.Link;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.model.ValidationStep;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
@@ -1940,9 +1941,9 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public List<KmeliaPublication> getLinkedPublications(KmeliaPublication publication,
       String userId) {
-    List<Link> allLinks = publication.getCompleteDetail().getLinkedPublications(userId);
+    List<PublicationLink> allLinks = publication.getCompleteDetail().getLinkedPublications(userId);
     List<KmeliaPublication> authorizedLinks = new ArrayList<>();
-    for (Link link : allLinks) {
+    for (PublicationLink link : allLinks) {
       authorizedLinks.add(KmeliaPublication.aKmeliaPublicationWithPk(link.getPubPK()));
     }
     return authorizedLinks;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -103,6 +103,7 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.node.model.NodeSelection;
 import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.pdc.pdc.model.ClassifyPosition;
 import org.silverpeas.core.pdc.pdc.model.PdcClassification;
@@ -3535,11 +3536,11 @@ public class KmeliaSessionController extends AbstractComponentSessionController
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String componentId = c.get("componentId");
+      final String componentId = c.get(NotificationContext.COMPONENT_ID);
       final String folderId = c.get("folderId");
       final UserNotification notification;
-      if (c.containsKey("pubId")) {
-        final String pubId = c.get("pubId");
+      if (c.containsKey(NotificationContext.CONTRIBUTION_ID)) {
+        final String pubId = c.get(NotificationContext.CONTRIBUTION_ID);
         if (c.containsKey("docId")) {
           final String docId = c.get("docId");
           notification = getUserNotification(componentId, folderId, pubId, docId);

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -47,7 +47,7 @@ import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygControlle
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
 import org.silverpeas.core.contribution.publication.model.Alias;
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
-import org.silverpeas.core.contribution.publication.model.Link;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
@@ -621,9 +621,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
           request.setAttribute("Languages", publicationLanguages);
 
           // see also management
-          List<Link> links = kmeliaPublication.getCompleteDetail().getLinkList();
+          List<PublicationLink> links = kmeliaPublication.getCompleteDetail().getLinkList();
           HashSet<String> linkedList = new HashSet<>(links.size());
-          for (Link link : links) {
+          for (PublicationLink link : links) {
             linkedList.add(link.getTarget().getId() + "-" + link.getTarget().getComponentInstanceId());
           }
           // put into session the current list of selected publications (see also)

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -48,7 +48,7 @@
 <%@page import="org.silverpeas.core.contribution.content.form.DataRecord"%>
 <%@page import="org.silverpeas.core.contribution.content.form.Form" %>
 <%@ page import="org.silverpeas.core.contribution.content.form.PagesContext" %>
-<%@ page import="org.silverpeas.core.contribution.publication.model.Link" %>
+<%@ page import="org.silverpeas.core.contribution.publication.model.PublicationLink" %>
 <%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%@ page import="org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail" %>
 <%@ page import="org.silverpeas.core.webapi.rating.RaterRatingEntity" %>
@@ -129,7 +129,7 @@
   List<String> availableFormats = kmeliaScc.getAvailableFormats();
 
   boolean sharingAllowed = kmeliaPublication.getDetail().isSharingAllowedForRolesFrom(currentUser);
-  List<Link> linkedPublications = pubComplete.getLinkedPublications(user_id);
+  List<PublicationLink> linkedPublications = pubComplete.getLinkedPublications(user_id);
 
   //Vrai si le user connecte est le createur de cette publication ou si il est admin
   boolean isOwner = false;

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -23,8 +23,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
-<%@page import="org.silverpeas.core.admin.user.model.SilverpeasRole"%>
-<%@page import="org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail"%>
+<%@page import="org.silverpeas.components.kmelia.KmeliaPublicationHelper"%>
+<%@page import="org.silverpeas.components.kmelia.SearchContext"%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -42,17 +42,16 @@
 <%@ include file="checkKmelia.jsp" %>
 <%@ include file="topicReport.jsp" %>
 
-<%@page import="org.silverpeas.components.kmelia.jstl.KmeliaDisplayHelper"%>
-<%@page import="org.silverpeas.components.kmelia.SearchContext"%>
-<%@page import="org.silverpeas.core.util.URLUtil"%>
-<%@page import="org.silverpeas.components.kmelia.KmeliaPublicationHelper"%>
-<%@page import="org.silverpeas.core.webapi.rating.RaterRatingEntity" %>
-<%@ page import="org.silverpeas.components.kmelia.model.KmeliaPublication" %>
-<%@ page import="org.silverpeas.core.contribution.content.form.Form" %>
-<%@ page import="org.silverpeas.core.contribution.content.form.DataRecord" %>
+<%@page import="org.silverpeas.components.kmelia.model.KmeliaPublication"%>
+<%@page import="org.silverpeas.core.admin.user.model.SilverpeasRole"%>
+<%@page import="org.silverpeas.core.admin.user.model.User"%>
+<%@page import="org.silverpeas.core.contribution.content.form.DataRecord"%>
+<%@page import="org.silverpeas.core.contribution.content.form.Form" %>
 <%@ page import="org.silverpeas.core.contribution.content.form.PagesContext" %>
-<%@ page import="org.silverpeas.core.admin.user.model.User" %>
 <%@ page import="org.silverpeas.core.contribution.publication.model.Link" %>
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
+<%@ page import="org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail" %>
+<%@ page import="org.silverpeas.core.webapi.rating.RaterRatingEntity" %>
 
 <c:set var="userLanguage" value="${requestScope.resources.language}"/>
 <c:set var="contentLanguage" value="${requestScope.Language}"/>
@@ -375,13 +374,13 @@
         jQuery.popup.confirm(label, function() {
           sp.messager.open('<%= componentId %>', {
             folderId: '<%= kmeliaScc.getCurrentFolderId() %>',
-            pubId: '<%= pubDetail.getId() %>'
+          <%= NotificationContext.CONTRIBUTION_ID %>: '<%= pubDetail.getId() %>'
           });
         });
       <% } else {%>
         sp.messager.open('<%= componentId %>', {
           folderId: '<%= kmeliaScc.getCurrentFolderId() %>',
-          pubId: '<%= pubDetail.getId() %>'
+         <%= NotificationContext.CONTRIBUTION_ID %>: '<%= pubDetail.getId() %>'
         });
       <% }%>
         }
@@ -393,14 +392,14 @@
           jQuery.popup.confirm(label, function() {
             sp.messager.open('<%= componentId %>', {
               folderId: '<%= kmeliaScc.getCurrentFolderId() %>',
-              pubId: '<%= pubDetail.getId() %>',
+             <%= NotificationContext.CONTRIBUTION_ID %>: '<%= pubDetail.getId() %>',
               docId: attachmentId
               });
           });
       <% } else {%>
           sp.messager.open('<%= componentId %>', {
             folderId: '<%= kmeliaScc.getCurrentFolderId() %>',
-            pubId: '<%= pubDetail.getId() %>',
+           <%= NotificationContext.CONTRIBUTION_ID %>: '<%= pubDetail.getId() %>',
             docId: attachmentId
           });
       <% }%>

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
@@ -30,19 +30,16 @@
 <%@taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@taglib tagdir="/WEB-INF/tags/silverpeas/util" prefix="viewTags" %>
 
-<%@page import="org.silverpeas.core.io.media.image.thumbnail.ThumbnailSettings"%>
-<%@page import="org.silverpeas.core.io.media.image.thumbnail.model.ThumbnailDetail"%>
-<%@page import="org.silverpeas.components.kmelia.jstl.KmeliaDisplayHelper"%>
-<%@page import="org.silverpeas.components.kmelia.model.KmeliaPublication" %>
+<%@page import="org.silverpeas.components.kmelia.model.KmeliaPublication"%>
+<%@page import="org.silverpeas.core.admin.user.model.User"%>
+<%@page import="org.silverpeas.core.contribution.content.form.Form"%>
+<%@page import="org.silverpeas.core.contribution.content.form.PagesContext" %>
 <%@page import="org.silverpeas.core.i18n.I18NHelper" %>
-<%@ page import="java.util.StringTokenizer" %>
+<%@ page import="org.silverpeas.core.io.media.image.thumbnail.ThumbnailSettings" %>
+<%@ page import="org.silverpeas.core.io.media.image.thumbnail.model.ThumbnailDetail" %>
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%@ page import="java.util.Date" %>
-<%@ page import="org.silverpeas.core.web.util.viewgenerator.html.browsebars.BrowseBar" %>
-<%@ page import="org.silverpeas.core.web.util.viewgenerator.html.operationpanes.OperationPane" %>
-<%@ page import="org.silverpeas.core.web.util.viewgenerator.html.frame.Frame" %>
-<%@ page import="org.silverpeas.core.admin.user.model.User" %>
-<%@ page import="org.silverpeas.core.contribution.content.form.Form" %>
-<%@ page import="org.silverpeas.core.contribution.content.form.PagesContext" %>
+<%@ page import="java.util.StringTokenizer" %>
 
 <c:set var="userLanguage" value="${requestScope.resources.language}"/>
 <fmt:setLocale value="${userLanguage}"/>
@@ -318,13 +315,13 @@
           jQuery.popup.confirm(label, function() {
             sp.messager.open('<%= componentId %>', {
               folderId: '<%= kmeliaScc.getCurrentFolderId()%>',
-              pubId: '<%= id %>'
+             <%= NotificationContext.CONTRIBUTION_ID %>: '<%= id %>'
             });
           });
       <% } else { %>
           sp.messager.open('<%= componentId %>', {
             folderId: '<%= kmeliaScc.getCurrentFolderId()%>',
-            pubId: '<%= id %>'
+            <%= NotificationContext.CONTRIBUTION_ID %>: '<%= id %>'
         });
       <% } %>
       }

--- a/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/control/QuickInfoSessionController.java
+++ b/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/control/QuickInfoSessionController.java
@@ -251,7 +251,8 @@ public class QuickInfoSessionController extends AbstractComponentSessionControll
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
       final String newsId = c.get(NotificationContext.CONTRIBUTION_ID);
-      return new NewsManualUserNotification(getNews(newsId, false), getUserDetail()).build();
+      final News news = getNews(newsId, false);
+      return new NewsManualUserNotification(news, getUserDetail()).build();
     };
   }
 

--- a/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/control/QuickInfoSessionController.java
+++ b/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/control/QuickInfoSessionController.java
@@ -34,6 +34,7 @@ import org.silverpeas.core.exception.DecodingException;
 import org.silverpeas.core.io.media.image.thumbnail.ThumbnailSettings;
 import org.silverpeas.core.io.upload.UploadedFile;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.pdc.pdc.model.PdcPosition;
 import org.silverpeas.core.silverstatistics.access.service.StatisticService;
 import org.silverpeas.core.silvertrace.SilverTrace;
@@ -249,7 +250,7 @@ public class QuickInfoSessionController extends AbstractComponentSessionControll
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String newsId = c.get("newsId");
+      final String newsId = c.get(NotificationContext.CONTRIBUTION_ID);
       return new NewsManualUserNotification(getNews(newsId, false), getUserDetail()).build();
     };
   }

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -26,6 +26,7 @@
 <%@page import="org.silverpeas.components.quickinfo.model.News"%>
 <%@page import="org.silverpeas.core.admin.user.model.SilverpeasRole" %>
 <%@ page import="org.silverpeas.core.util.URLUtil" %>
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
@@ -77,7 +78,7 @@ pageContext.setAttribute("componentURL", URLUtil.getFullApplicationURL(request)+
 <script type="text/javascript" src="js/quickinfo.js"></script>
 <script type="text/javascript">
 function notify() {
-	sp.messager.open('${news.componentInstanceId}', {newsId: '${news.id}'});
+	sp.messager.open('${news.componentInstanceId}', {<%= NotificationContext.CONTRIBUTION_ID %>: '${news.id}'});
 }
 
 function publish() {

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -78,7 +78,7 @@ pageContext.setAttribute("componentURL", URLUtil.getFullApplicationURL(request)+
 <script type="text/javascript" src="js/quickinfo.js"></script>
 <script type="text/javascript">
 function notify() {
-	sp.messager.open('${news.componentInstanceId}', {<%= NotificationContext.CONTRIBUTION_ID %>: '${news.id}'});
+	sp.messager.open('${news.componentInstanceId}', {<%= NotificationContext.CONTRIBUTION_ID %>: '${news.id}', <%= NotificationContext.PUBLICATION_ID %>: '${news.publicationId}'});
 }
 
 function publish() {

--- a/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebController.java
+++ b/suggestionBox/suggestionBox-war/src/main/java/org/silverpeas/components/suggestionbox/control/SuggestionBoxWebController.java
@@ -32,6 +32,7 @@ import org.silverpeas.components.suggestionbox.web.SuggestionEntity;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.subscription.SubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionServiceProvider;
 import org.silverpeas.core.subscription.service.ComponentSubscription;
@@ -508,8 +509,8 @@ public class SuggestionBoxWebController extends
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String boxId = c.get("componentId");
-      final String suggestionId = c.get("suggestionId");
+      final String boxId = c.get(NotificationContext.COMPONENT_ID);
+      final String suggestionId = c.get(NotificationContext.CONTRIBUTION_ID);
       final SuggestionBox box = SuggestionBox.getByComponentInstanceId(boxId);
       final Suggestion suggestion = box.getSuggestions().get(suggestionId);
       return new SuggestionNotifyManuallyUserNotification(suggestion,

--- a/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionView.jsp
+++ b/suggestionBox/suggestionBox-war/src/main/webapp/suggestionBox/jsp/suggestionView.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %><%--
   Copyright (C) 2000 - 2018 Silverpeas
 
   This program is free software: you can redistribute it and/or modify
@@ -89,7 +89,7 @@
       $('#actions').attr('method', 'GET').attr('action', '${backUri}').submit();
     }
     function notify() {
-      sp.messager.open('${componentId}', {suggestionId: '${target}'});
+      sp.messager.open('${componentId}', {<%=NotificationContext.CONTRIBUTION_ID%>: '${target}'});
     }
   </script>
 </head>

--- a/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
+++ b/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
@@ -67,6 +67,7 @@ import org.silverpeas.core.exception.DecodingException;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.notification.user.DefaultUserNotification;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.notification.user.builder.helper.UserNotificationHelper;
 import org.silverpeas.core.notification.user.client.NotificationMetaData;
 import org.silverpeas.core.notification.user.client.NotificationParameters;
@@ -663,7 +664,7 @@ public class SurveySessionController extends AbstractComponentSessionController 
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String surveyId = c.get("surveyId");
+      final String surveyId = c.get(NotificationContext.CONTRIBUTION_ID);
       try {
         return new DefaultUserNotification(getAlertNotificationMetaData(surveyId));
       } catch (SurveyException e) {

--- a/survey/survey-war/src/main/webapp/survey/jsp/surveyDetail.jsp
+++ b/survey/survey-war/src/main/webapp/survey/jsp/surveyDetail.jsp
@@ -1,6 +1,7 @@
 <%@ page import="org.silverpeas.core.web.util.viewgenerator.html.browsebars.BrowseBar" %>
 <%@ page import="org.silverpeas.core.web.util.viewgenerator.html.operationpanes.OperationPane" %>
-<%@ page import="org.silverpeas.core.util.SettingBundle" %><%--
+<%@ page import="org.silverpeas.core.util.SettingBundle" %>
+<%@ page import="org.silverpeas.core.notification.user.NotificationContext" %><%--
 
     Copyright (C) 2000 - 2018 Silverpeas
 
@@ -277,7 +278,7 @@
     // notification
     OperationPane operationPane = window.getOperationPane();
     operationPane.addOperation(alertSrc, resources.getString("GML.notify"),
-        "javaScript:onClick=sp.messager.open('" + componentId + "', {surveyId: '" + surveyId + "'});");
+        "javaScript:onClick=sp.messager.open('" + componentId + "', {" + NotificationContext.CONTRIBUTION_ID + ": '" + surveyId + "'});");
 
     window.addBody(surveyPart);
     %>
@@ -457,7 +458,7 @@ function clipboardCopy() {
     // notification
     OperationPane operationPane = window.getOperationPane();
     operationPane.addOperation(alertSrc, resources.getString("GML.notify"),
-        "javaScript:onClick=sp.messager.open('" + componentId + "', {surveyId: '" + surveyId + "'});");
+        "javaScript:onClick=sp.messager.open('" + componentId + "', {" + NotificationContext.CONTRIBUTION_ID + ": '" + surveyId + "'});");
   
     // copier
     operationPane.addOperation(copySrc, resources.getString("GML.copy"),
@@ -584,7 +585,7 @@ function clipboardCopy() {
 </view:browseBar>
 <view:operationPane>
   <fmt:message key="GML.notify" var="notifyUserMsg" />
-  <c:set var="notifyUserAction">javaScript:onClick=sp.messager.open('<%= componentId %>', {surveyId: '<%=surveyId%>'});</c:set>
+  <c:set var="notifyUserAction">javaScript:onClick=sp.messager.open('<%= componentId %>', {<%=NotificationContext.CONTRIBUTION_ID%>: '<%=surveyId%>'});</c:set>
   <view:operation altText="${notifyUserMsg}" icon="${alertSrc}" action="${notifyUserAction}" />
   
   <%

--- a/webPages/webPages-war/src/main/java/org/silverpeas/components/webpages/control/WebPagesSessionController.java
+++ b/webPages/webPages-war/src/main/java/org/silverpeas/components/webpages/control/WebPagesSessionController.java
@@ -44,6 +44,7 @@ import org.silverpeas.core.index.indexing.model.FullIndexEntry;
 import org.silverpeas.core.index.indexing.model.IndexEngineProxy;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.subscription.SubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionServiceProvider;
 import org.silverpeas.core.subscription.service.ComponentSubscription;
@@ -247,7 +248,7 @@ public class WebPagesSessionController extends AbstractComponentSessionControlle
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String componentId = c.get("componentId");
+      final String componentId = c.get(NotificationContext.COMPONENT_ID);
       return new WebPagesUserAlertNotifier(new NodePK(null, componentId),
           User.getCurrentRequester()).build();
     };


### PR DESCRIPTION
Now the user manual notification has the following improvements:

- the notification window text area is replaced by a WYSIWYG editor to write a more rich text for notification message.
- for manual notifications on a contribution that have attachments, a link to each of the documents attached to the contribution in Silverpeas is automatically added in the notification message when such notifications are sent through SMTP. This concerns both the immediate and the delayed transmission.

 Don't forget to merge before the PR https://github.com/Silverpeas/Silverpeas-Core/pull/955