### PR TITLE
FIx bug #10358

### DIFF
--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/workflowextensions/SendInAlmanach.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/workflowextensions/SendInAlmanach.java
@@ -24,13 +24,11 @@
 package org.silverpeas.components.almanach.workflowextensions;
 
 import org.silverpeas.core.admin.service.OrganizationController;
-import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.calendar.Calendar;
 import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.calendar.Priority;
 import org.silverpeas.core.contribution.content.form.DataRecordUtil;
 import org.silverpeas.core.date.Period;
-import org.silverpeas.core.persistence.datasource.OperationContext;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.workflow.api.WorkflowException;
@@ -105,7 +103,6 @@ public class SendInAlmanach extends ExternalActionImpl {
         event.withPriority(Priority.HIGH);
       }
 
-      OperationContext.fromUser(getBestUser());
       event.planOn(almanach);
     } else {
       StringBuilder warnMsg = new StringBuilder();
@@ -206,19 +203,6 @@ public class SendInAlmanach extends ExternalActionImpl {
 
   private void setRole(String role) {
     this.role = role;
-  }
-
-  /**
-   * Get actor if exist, admin otherwise
-   * @return {@link User} instance.
-   */
-  private User getBestUser() {
-    String currentUserId = ADMIN_ID;
-    // For a manual action (event)
-    if (getEvent().getUser() != null) {
-      currentUserId = getEvent().getUser().getUserId();
-    }
-    return User.getById(currentUserId);
   }
 
   private OrganizationController getOrganizationController() {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
@@ -199,14 +199,8 @@ public class KmeliaImportExport extends GEDImportExport {
   @Override
   protected NodePK addSubTopicToTopic(NodeDetail nodeDetail, int topicId,
       MassiveReport massiveReport) throws ImportExportException {
-    NodePK nodePK = null;
-    try {
-      // On renvoie le topic déjà existant si c'est le cas
-      nodePK = getNodeService().getDetailByNameAndFatherId(new NodePK("unKnown", null,
+    NodePK nodePK = getNodeService().getDetailByNameAndFatherId(new NodePK("unKnown", null,
           getCurrentComponentId()), nodeDetail.getName(), topicId).getNodePK();
-    } catch (Exception ex) {
-
-    }
     if (nodePK == null) {
       try {
         // Il n'y a pas de topic, on le crée


### PR DESCRIPTION
In SendInKmelia: the creation of the node(s) into which the publication will
be put are now performed into a new transaction so that if the creation fails
it doesn't rollback all the process and once the creation is done, the nodes
are accessed out of the transaction further in the task execution.

Don't forget to merge before https://github.com/Silverpeas/Silverpeas-Core/pull/962