### PR TITLE
correction liée au Bug#10485 

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/styleSheets/kmelia.css
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/styleSheets/kmelia.css
@@ -1039,3 +1039,14 @@ a.button.refuse span {
 .publistDisplay {
   min-width: 480px;
 }
+/* fix bug#10485 */
+body.treeView .ui-dialog {
+	overflow:inherit !important;
+	height:600px !important;
+	max-height:90% !important;
+}
+body.treeView .ui-dialog .ui-dialog-content {
+	overflow:auto;
+	max-height: calc(100% - 100px) !important;
+	height: auto;
+}


### PR DESCRIPTION
pour que si la pop in est plus grande que l'écran, elle prenne un ascenseur et non qu'elle dépasse. Seulement nécessaire dans le cadre du treeView 