### PR TITLE
Fix le comportement de la hauteur du panel treeview 

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/styleSheets/kmelia.css
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/styleSheets/kmelia.css
@@ -26,14 +26,19 @@ html , body.treeView,
 body.treeView > div[id*="kmelia"],
 body.treeView > div[id*="kmelia"] > div.kmelia,
 body.treeView > div[id*="kmelia"] > div.kmelia  #topPage,
-body.treeView > div[id*="kmelia"] > div.kmelia  #topPage .cellBodyWindows,
 body.treeView > div[id*="kmelia"] > div.kmelia  #topPage .cellBodyWindows .tableFrame,
 body.treeView > div[id*="kmelia"] > div.kmelia  #topPage .cellBodyWindows .tableFrame .hautFrame{
-  height:100%
+	height:100%;
+	padding:0;
+	margin:0;
 }
 
-body.treeView {
-	overflow:hidden;
+body.treeView .sp_goToTop {
+	display:none;
+}
+
+body.treeView > div[id*="kmelia"] > div.kmelia  #topPage .cellBodyWindows{
+	height:calc( 100% - 60px ) ; /* hauteur 100% - la hauteur du fil d'ariane */
 }
 
 .vakata-context, .vakata-context ul {
@@ -1038,15 +1043,4 @@ a.button.refuse span {
 
 .publistDisplay {
   min-width: 480px;
-}
-/* fix bug#10485 */
-body.treeView .ui-dialog {
-	overflow:inherit !important;
-	height:600px !important;
-	max-height:90% !important;
-}
-body.treeView .ui-dialog .ui-dialog-content {
-	overflow:auto;
-	max-height: calc(100% - 100px) !important;
-	height: auto;
 }


### PR DESCRIPTION
La hauteur 100 % comportait des erreurs - Cela corrige les impactes négatifs sur les pop in (qui étaient coupées si trop haute)