### PR TITLE
Bug #10722

### DIFF
--- a/quizz/quizz-war/src/main/java/org/silverpeas/components/quizz/control/QuizzSessionController.java
+++ b/quizz/quizz-war/src/main/java/org/silverpeas/components/quizz/control/QuizzSessionController.java
@@ -67,7 +67,7 @@ import static org.silverpeas.core.pdc.pdc.model.PdcClassification.aPdcClassifica
 public final class QuizzSessionController extends AbstractComponentSessionController {
 
   private QuestionContainerService questionContainerService =
-      QuestionContainerService.getInstance();
+      QuestionContainerService.get();
   private SettingBundle settings = null;
   private int nbTopScores = 0;
   private boolean isAllowedTopScores = false;

--- a/quizz/quizz-war/src/main/java/org/silverpeas/components/quizz/servlets/GoToQuizz.java
+++ b/quizz/quizz-war/src/main/java/org/silverpeas/components/quizz/servlets/GoToQuizz.java
@@ -55,6 +55,6 @@ public class GoToQuizz extends GoTo {
   }
 
   private QuestionContainerService getQuestionContainerService() {
-    return QuestionContainerService.getInstance();
+    return QuestionContainerService.get();
   }
 }

--- a/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
+++ b/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
@@ -21,30 +21,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-/*
- * Copyright (C) 2000 - 2018 Silverpeas
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception. You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
- * "https://www.silverpeas.org/legal/floss_exception.html"
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
 package org.silverpeas.components.survey.control;
 
 import org.apache.commons.fileupload.FileItem;
@@ -154,7 +130,7 @@ public class SurveySessionController extends AbstractComponentSessionController 
       ComponentContext componentContext) {
     super(mainSessionCtrl, componentContext, "org.silverpeas.survey.multilang.surveyBundle", null,
         "org.silverpeas.survey.surveySettings");
-    questionContainerService = QuestionContainerService.getInstance();
+    questionContainerService = QuestionContainerService.get();
     questionResultService = QuestionResultService.get();
   }
 
@@ -652,13 +628,6 @@ public class SurveySessionController extends AbstractComponentSessionController 
    */
   private List<PdcPosition> getNewSurveyPositions() {
     return newSurveyPositions;
-  }
-
-  @Override
-  public void close() {
-    if (questionContainerService != null) {
-      questionContainerService = null;
-    }
   }
 
   @Override

--- a/survey/survey-war/src/main/java/org/silverpeas/components/survey/servlets/GoToSurvey.java
+++ b/survey/survey-war/src/main/java/org/silverpeas/components/survey/servlets/GoToSurvey.java
@@ -82,6 +82,6 @@ public class GoToSurvey extends GoTo {
   }
 
   private QuestionContainerService getQuestionContainerBm() {
-    return QuestionContainerService.getInstance();
+    return QuestionContainerService.get();
   }
 }


### PR DESCRIPTION
 Remove the implemenation of the SurveySessionController#close() method.

Warning: when a lambda is passed, the context of that lambda seems to be cloned
(the owner) and not passed as such.