### PR TITLE
Bug #9194

### DIFF
--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -31,7 +31,7 @@ import org.silverpeas.components.blog.model.Category;
 import org.silverpeas.components.blog.model.PostDetail;
 import org.silverpeas.components.blog.notification.BlogUserSubscriptionNotification;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.comment.model.Comment;
 import org.silverpeas.core.comment.model.CommentPK;
@@ -191,7 +191,7 @@ public class DefaultBlogService implements BlogService {
       for (String userId : subscriberIds) {
         if (organizationController.isComponentAvailable(fatherPK.getInstanceId(), userId) &&
             (!node.haveRights() ||
-                organizationController.isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+                organizationController.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
                     fatherPK.getInstanceId(), userId))) {
           newSubscribers.add(userId);
         }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
@@ -23,7 +23,7 @@ package org.silverpeas.components.kmelia;
 import org.silverpeas.components.kmelia.model.KmeliaRuntimeException;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
@@ -364,7 +364,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
         if (!node.haveRights()) {
           objectAvailable = true;
         } else {
-          objectAvailable = controller.isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+          objectAvailable = controller.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
               nodePK.getInstanceId(), userId);
         }
       } else {
@@ -393,7 +393,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
             lProfiles.addAll(Arrays.asList(getAppProfiles(userId, pubPK.getInstanceId())));
           } else {
             lProfiles.addAll(Arrays.asList(controller.getUserProfiles(userId,
-                pubPK.getInstanceId(), node.getRightsDependsOn(), ObjectType.NODE)));
+                pubPK.getInstanceId(), node.getRightsDependsOn(), ProfiledObjectType.NODE)));
           }
         }
       }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaInstanceManualUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaInstanceManualUserNotification.java
@@ -25,7 +25,7 @@
 package org.silverpeas.components.kmelia.notification;
 
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -99,6 +99,6 @@ public class KmeliaInstanceManualUserNotification extends
   }
 
   private String asResourceId(final int folderId) {
-    return ObjectType.NODE.getCode() + folderId;
+    return ProfiledObjectType.NODE.getCode() + folderId;
   }
 }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -31,7 +31,7 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationBehavior;
 import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.subscription.constant.SubscriberType;
-import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
+import org.silverpeas.core.subscription.constant.SubscriptionResourceType;
 import org.silverpeas.core.subscription.service.ResourceSubscriptionProvider;
 import org.silverpeas.core.subscription.util.SubscriptionSubscriberMapBySubscriberType;
 
@@ -62,8 +62,13 @@ public class KmeliaSubscriptionPublicationUserNotification
     // Subscribers
     // ###########
 
-    subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
-        .getSubscribersOfSubscriptionResource(NodeSubscriptionResource.from(getNodePK())));
+    if (getNodePK().isRoot()) {
+      subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
+          .getSubscribersOfComponent(getComponentInstanceId()));
+    } else {
+      subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
+          .getSubscribersOfComponentAndTypedResource(getComponentInstanceId(), SubscriptionResourceType.NODE, getNodePK().getId()));
+    }
 
     Collection<String> allUserSubscriberIds = subscriberIdsByTypes.getAllUserIds();
     if (!allUserSubscriberIds.isEmpty()) {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -23,17 +23,17 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
+import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.contribution.publication.model.PublicationDetail;
+import org.silverpeas.core.node.model.NodeDetail;
+import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationBehavior;
+import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.subscription.constant.SubscriberType;
 import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.subscription.service.ResourceSubscriptionProvider;
 import org.silverpeas.core.subscription.util.SubscriptionSubscriberMapBySubscriberType;
-import org.silverpeas.core.notification.user.client.constant.NotifAction;
-import org.silverpeas.core.admin.ObjectType;
-import org.silverpeas.core.node.model.NodeDetail;
-import org.silverpeas.core.node.model.NodePK;
-import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.admin.service.OrganizationController;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -74,7 +74,7 @@ public class KmeliaSubscriptionPublicationUserNotification
       for (final String userId : allUserSubscriberIds) {
         if (!orgaController.isComponentAvailable(getNodePK().getInstanceId(), userId) || (node.
             haveRights() && !orgaController
-            .isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+            .isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
                 getNodePK().getInstanceId(), userId))) {
           userIdsToExcludeFromNotifying.add(userId);
         }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -91,11 +91,11 @@ public class KmeliaTopicUserNotification extends AbstractKmeliaFolderUserNotific
       profileNames.add("user");
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ObjectType.NODE, profileNames);
+              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
     } else if (alertType.equals("Publisher")) {
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ObjectType.NODE, profileNames);
+              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
     } else {
       users = null;
     }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -105,6 +105,8 @@ import org.silverpeas.core.subscription.Subscription;
 import org.silverpeas.core.subscription.SubscriptionResource;
 import org.silverpeas.core.subscription.SubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionServiceProvider;
+import org.silverpeas.core.subscription.service.ComponentSubscription;
+import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
 import org.silverpeas.core.subscription.service.NodeSubscription;
 import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.subscription.service.UserSubscriptionSubscriber;
@@ -834,7 +836,12 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public void removeSubscriptionToCurrentUser(NodePK topicPK, String userId) {
     try {
-      getSubscribeService().unsubscribe(new NodeSubscription(userId, topicPK));
+      if (topicPK.isRoot()) {
+        getSubscribeService().unsubscribe(
+            new ComponentSubscription(userId, topicPK.getInstanceId()));
+      } else {
+        getSubscribeService().unsubscribe(new NodeSubscription(userId, topicPK));
+      }
     } catch (Exception e) {
       throw new KmeliaRuntimeException(e);
     }
@@ -849,7 +856,12 @@ public class DefaultKmeliaService implements KmeliaService {
     try {
       Collection<SubscriptionResource> subscriptionResourcesToDelete = new ArrayList<>();
       for (NodePK topicPK : topicPKsToDelete) {
-        subscriptionResourcesToDelete.add(NodeSubscriptionResource.from(topicPK));
+        if (topicPK.isRoot()) {
+          subscriptionResourcesToDelete.add(
+              ComponentSubscriptionResource.from(topicPK.getInstanceId()));
+        } else {
+          subscriptionResourcesToDelete.add(NodeSubscriptionResource.from(topicPK));
+        }
       }
       getSubscribeService().unsubscribeByResources(subscriptionResourcesToDelete);
     } catch (Exception e) {
@@ -865,7 +877,11 @@ public class DefaultKmeliaService implements KmeliaService {
    */
   @Override
   public void addSubscription(NodePK topicPK, String userId) {
-    getSubscribeService().subscribe(new NodeSubscription(userId, topicPK));
+    if (topicPK.isRoot()) {
+      getSubscribeService().subscribe(new ComponentSubscription(userId, topicPK.getInstanceId()));
+    } else {
+      getSubscribeService().subscribe(new NodeSubscription(userId, topicPK));
+    }
   }
 
   /**
@@ -875,7 +891,15 @@ public class DefaultKmeliaService implements KmeliaService {
    */
   @Override
   public boolean checkSubscription(NodePK topicPK, String userId) {
-    return !getSubscribeService().existsSubscription(new NodeSubscription(userId, topicPK));
+    final boolean alreadyExist;
+    if (topicPK.isRoot()) {
+      alreadyExist = getSubscribeService().existsSubscription(
+          new ComponentSubscription(userId, topicPK.getInstanceId()));
+    } else {
+      alreadyExist =
+          getSubscribeService().existsSubscription(new NodeSubscription(userId, topicPK));
+    }
+    return !alreadyExist;
   }
 
   /**

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilter.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilter.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.service;
 
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
@@ -173,7 +173,7 @@ class KmeliaUserTreeViewFilter {
    */
   private String[] getNodeUserRoles(Integer nodeId) {
     if (nodeUserRoles == null) {
-      nodeUserRoles = orga.getUserObjectProfiles(userId, instanceId, ObjectType.NODE);
+      nodeUserRoles = orga.getUserObjectProfiles(userId, instanceId, ProfiledObjectType.NODE);
     }
     List<String> roles = nodeUserRoles.get(nodeId);
     return (roles != null) ? roles.toArray(new String[roles.size()]) : new String[0];

--- a/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilterTest.java
+++ b/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilterTest.java
@@ -26,8 +26,7 @@ package org.silverpeas.components.kmelia.service;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -231,7 +230,7 @@ public class KmeliaUserTreeViewFilterTest {
     assertThat(node_AAB.haveRights(), is(true));
     assertThat(node_AAB.getChildrenDetails(), empty());
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_AAB_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -278,7 +277,7 @@ public class KmeliaUserTreeViewFilterTest {
       node.setRightsDependsOnMe();
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_AAA_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -299,7 +298,7 @@ public class KmeliaUserTreeViewFilterTest {
       node.setRightsDependsOnMe();
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_BA_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -359,7 +358,7 @@ public class KmeliaUserTreeViewFilterTest {
       }
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_A_ID, ADMIN_ROLE, WRITER_ROLE)
             .put(NODE_AA_ID, WRITER_ROLE));
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -40,7 +40,8 @@ import org.silverpeas.components.kmelia.search.KmeliaSearchServiceProvider;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.component.model.ComponentInst;
 import org.silverpeas.core.admin.component.model.GlobalContext;
 import org.silverpeas.core.admin.service.AdminController;
@@ -643,8 +644,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       NodeDetail node = getNodeHeader(getCurrentFolderId());
       if (node.haveRights()) {
         int rightsDependsOn = node.getRightsDependsOn();
-        return getOrganisationController()
-            .isObjectAvailable(rightsDependsOn, ObjectType.NODE, getComponentId(), getUserId());
+        return getOrganisationController().isObjectAvailable(rightsDependsOn,
+            ProfiledObjectType.NODE, getComponentId(), getUserId());
       }
     }
     return true;
@@ -1663,7 +1664,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     }
     boolean haveRights = isRightsOnTopicsEnabled() && node.haveRights();
     if (haveRights) {
-      sug.setObjectId(ObjectType.NODE.getCode() + node.getRightsDependsOn());
+      sug.setObjectId(ProfiledObjectType.NODE.getCode() + node.getRightsDependsOn());
     }
     sug.setProfileNames(profiles);
 
@@ -2153,7 +2154,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     sel.setHtmlFormName("dummy");
 
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(nodeId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(nodeId, ProfiledObjectType.NODE.getCode(), getComponentId());
     ProfileInst topicProfile = getProfile(profiles, role);
 
     SelectionUsersGroups sug = new SelectionUsersGroups();
@@ -2206,8 +2207,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
         getAdmin().updateProfileInst(profile);
       }
     } else {
-      profile.setObjectId(Integer.parseInt(nodeId));
-      profile.setObjectType(ObjectType.NODE.getCode());
+      profile.setObjectId(new ProfiledObjectId(ProfiledObjectType.NODE, nodeId));
       profile.setComponentFatherId(getComponentId());
       // Create the profile
       getAdmin().addProfileInst(profile);
@@ -2216,7 +2216,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
 
   public ProfileInst getTopicProfile(String role, String topicId) {
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(topicId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(topicId, ProfiledObjectType.NODE.getCode(),
+            getComponentId());
     for (ProfileInst profile: profiles) {
       if (profile.getName().equals(role)) {
         return profile;
@@ -2248,11 +2249,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       return inheritedProfile;
     } else {
       // merge des profiles
-      ProfileInst newProfile = (ProfileInst) profile.clone();
-      newProfile.setObjectFatherId(profile.getObjectFatherId());
-      newProfile.setObjectType(profile.getObjectType());
-      newProfile.setInherited(profile.isInherited());
-
+      ProfileInst newProfile = profile.copy();
       newProfile.addGroups(inheritedProfile.getAllGroups());
       newProfile.addUsers(inheritedProfile.getAllUsers());
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -114,6 +114,7 @@ import org.silverpeas.core.security.authorization.NodeAccessController;
 import org.silverpeas.core.security.authorization.PublicationAccessController;
 import org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail;
 import org.silverpeas.core.silverstatistics.access.service.StatisticService;
+import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
 import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.template.SilverpeasTemplateFactory;
@@ -3162,11 +3163,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController
   }
 
   public String manageSubscriptions() {
-    SubscriptionContext subscriptionContext = getSubscriptionContext();
-    List<NodeDetail> nodePath = getTopicPath(getCurrentFolderId());
-    nodePath.remove(0);
-    subscriptionContext
-        .initializeFromNode(NodeSubscriptionResource.from(getCurrentFolderPK()), nodePath);
+    final SubscriptionContext subscriptionContext = getSubscriptionContext();
+    if (getCurrentFolder().getNodePK().isRoot()) {
+      subscriptionContext.initialize(ComponentSubscriptionResource.from(getComponentId()));
+    } else {
+      List<NodeDetail> nodePath = getTopicPath(getCurrentFolderId());
+      nodePath.remove(0);
+      subscriptionContext.initializeFromNode(NodeSubscriptionResource.from(getCurrentFolderPK()),
+          nodePath);
+    }
     return subscriptionContext.getDestinationUrl();
   }
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -2195,9 +2195,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     topic.setRightsDependsOnMe();
     getNodeService().updateRightsDependency(topic);
 
-    profile.removeAllGroups();
-    profile.removeAllUsers();
-    profile.setGroupsAndUsers(groupIds, userIds);
+    profile.setUsers(Arrays.asList(userIds));
+    profile.setGroups(Arrays.asList(groupIds));
 
     if (StringUtil.isDefined(profile.getId())) {
       if (profile.isEmpty()) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
@@ -25,7 +25,7 @@ import org.silverpeas.core.importexport.model.ImportExportException;
 import org.silverpeas.core.importexport.report.MassiveReport;
 import org.silverpeas.core.importexport.report.UnitReport;
 import org.silverpeas.core.silvertrace.SilverTrace;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.components.kmelia.KmeliaException;
 import org.silverpeas.components.kmelia.service.KmeliaService;
@@ -107,7 +107,7 @@ public class KmeliaImportExport extends GEDImportExport {
         NodeDetail topic = getNodeService().getHeader(topicPK);
         if (topic.haveRights()) {
           profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
-              .getId(), topicPK.getInstanceId(), topic.getRightsDependsOn(), ObjectType.NODE));
+              .getId(), topicPK.getInstanceId(), topic.getRightsDependsOn(), ProfiledObjectType.NODE));
         } else {
           profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
               .getId(), topicPK.getInstanceId()));

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/JSONServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/JSONServlet.java
@@ -144,7 +144,8 @@ public class JSONServlet extends HttpServlet {
 
         operations.put("exportSelection", !user.isAnonymous());
         operations.put("manageSubscriptions", isAdmin);
-        operations.put("subscriptions", !user.isAnonymous());
+        operations.put("subscriptions", isRoot && !user.isAnonymous());
+        operations.put("topicSubscriptions", !isRoot && !user.isAnonymous());
         operations.put("favorites", !isRoot && !user.isAnonymous());
         if (isRoot && canShowStats) {
           operations.put("statistics", true);

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -395,6 +395,13 @@ function initOperations(id, op) {
   }
 
   if (op.subscriptions) {
+    label = getString('GML.subscribe');
+    url = "javascript:onclick=addSubscription()";
+    menuItem = new YAHOO.widget.MenuItem(label, {url: url});
+    oMenu.addItem(menuItem, groupIndex);
+    groupEmpty = false;
+    //addCreationItem(url, icons["operation.subscribe"], label);
+  } else if (op.topicSubscriptions) {
     label = getString('SubscriptionsAdd');
     url = "javascript:onclick=addSubscription()";
     menuItem = new YAHOO.widget.MenuItem(label, {url: url});
@@ -402,6 +409,7 @@ function initOperations(id, op) {
     groupEmpty = false;
     //addCreationItem(url, icons["operation.subscribe"], label);
   }
+
   if (op.favorites) {
     label = getString('FavoritesAdd1') + ' ' + getString('FavoritesAdd2');
     url = "javascript:onclick=addCurrentNodeAsFavorite()";

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
@@ -73,9 +73,10 @@ boolean userCanSeeStats = kmeliaScc.isStatisticAllowed();
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.kmelia">
+<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.kmelia" xml:lang="<%=language%>">
 <head>
 <view:looknfeel/>
+	<title></title>
 <view:includePlugin name="popup"/>
 <view:includePlugin name="preview"/>
 <view:includePlugin name="rating" />
@@ -199,7 +200,7 @@ $(document).ready(function() {
 
     	if (!isGuest) {
     	  	operationPane.addOperation("useless", resources.getString("kmelia.operation.exportSelection"), "javascript:onclick=exportPublications()");
-    		operationPane.addOperation("useless", resources.getString("kmelia.folderSubscription"), "javascript:onClick=addSubscription()");
+    		operationPane.addOperation("useless", resources.getString("GML.subscribe"), "javascript:onClick=addSubscription()");
       		operationPane.addOperation("useless", resources.getString("FavoritesAdd1")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+
               WebEncodeHelper.javaStringToHtmlString(WebEncodeHelper.javaStringToJsString(namePath))+"','','"+urlTopic+"')");
     	}
@@ -223,7 +224,8 @@ $(document).ready(function() {
 						Button searchButton = gef.getFormButton(resources.getString("GML.search"), "javascript:onClick=searchInTopic();", false); %>
 						<div id="searchZone">
 						<view:board>
-						<table id="searchLine">
+						<table id="searchLine"  aria-describedby="search">
+							<th id="searchHeader"></th>
 						<tr><td><div id="searchLabel"><%=resources.getString("kmelia.SearchInTopics") %></div>&nbsp;<input type="text" id="topicQuery" size="50" value="<%=query%>" onkeydown="checkSubmitToSearch(event)"/></td><td><%=searchButton.print() %></td></tr>
 						</table>
 						</view:board>
@@ -236,8 +238,8 @@ $(document).ready(function() {
               <br/>
               <view:board>
                 <br/>
-                <center><%=resources.getString("kmelia.inProgressPublications") %>
-                  <br/><br/><img src="<%=resources.getIcon("kmelia.progress") %>"/></center>
+                <span text-align="center"><%=resources.getString("kmelia.inProgressPublications") %>
+                  <br/><br/><img alt="progress..." src="<%=resources.getIcon("kmelia.progress") %>"/></span>
                 <br/>
               </view:board>
             </div>

--- a/projectManager/projectManager-war/src/main/java/org/silverpeas/components/projectmanager/servlets/ProjectManagerRequestRouter.java
+++ b/projectManager/projectManager-war/src/main/java/org/silverpeas/components/projectmanager/servlets/ProjectManagerRequestRouter.java
@@ -387,9 +387,9 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
     if ("admin".equals(projectManagerSC.getRole())) {
       task.setResponsableId(Integer.parseInt(request.getParameter("ResponsableId")));
       task.setNom(request.getParameter("Nom"));
-      task.setCharge(StringUtil.convertFloat(request.getParameter("Charge")));
-      task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-      task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+      task.setCharge(StringUtil.asFloat(request.getParameter("Charge")));
+      task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+      task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
       task.setStatut(Integer.valueOf(request.getParameter("Statut")));
       task.setDescription(request.getParameter("Description"));
       task.setDateDebut(projectManagerSC.uiDate2Date(request.getParameter("DateDebut")));
@@ -398,8 +398,8 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
 
       task.setResources(request2Resources(request));
     } else if ("responsable".equals(projectManagerSC.getRole())) {
-      task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-      task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+      task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+      task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
       task.setStatut(Integer.valueOf(request.getParameter("Statut")));
       task.setResources(request2Resources(request));
     }
@@ -425,9 +425,9 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
     }
 
     task.setNom(request.getParameter("Nom"));
-    task.setCharge(StringUtil.convertFloat(request.getParameter("Charge")));
-    task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-    task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+    task.setCharge(StringUtil.asFloat(request.getParameter("Charge")));
+    task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+    task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
     task.setStatut(Integer.parseInt(request.getParameter("Statut")));
     task.setDescription(request.getParameter("Description"));
     task.setDateDebut(projectManagerSC.uiDate2Date(request.getParameter("DateDebut")));


### PR DESCRIPTION
Update some Silverpeas components (aka applications) with some changes in
Silverpeas-Core: the main change is to structure the objects concerned by a
right access profile into an object: ProfiledObjectId. This object is an
identifier to a given resource in Silverpeas and that is convered directly by a
right profile. AS the referred object can be any type, its type is indicated
by the enum ProfiledObjectType and it's embodied in the ProfileObjectId.

Don't forget to merge before https://github.com/Silverpeas/Silverpeas-Core/pull/1002