### PR TITLE
Bug #10884

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,9 +82,9 @@ def computeSnapshotVersion() {
   final String version = pom.version
   final String defaultVersion = env.BRANCH_NAME == 'master' ? version :
       env.BRANCH_NAME.toLowerCase().replaceAll('[# -]', '')
-  Matcher m = env.CHANGE_TITLE =~ /^(Bug #\d+|Feature #\d+).*$/
+  Matcher m = env.CHANGE_TITLE =~ /^(Bug #?\d+|Feature #?\d+).*$/
   String snapshot = m.matches()
-      ? m.group(1).toLowerCase().replaceAll(' #', '')
+      ? m.group(1).toLowerCase().replaceAll(' #?', '')
       : ''
   if (snapshot.isEmpty()) {
     m = env.CHANGE_TITLE =~ /^\[([^\[\]]+)].*$/

--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -314,14 +314,12 @@ public class DefaultBlogService implements BlogService {
 
   @Override
   public Collection<PostDetail> getAllPosts(String instanceId) {
-    PublicationPK pubPK = new PublicationPK(USELESS, instanceId);
-
     Collection<PostDetail> posts = new ArrayList<>();
     try(Connection con = openConnection()) {
       // rechercher les publications classée par date d'évènement
       Collection<String> lastEvents = PostDAO.getAllEvents(con, instanceId);
       Collection<PublicationDetail> publications =
-          getPublicationService().getAllPublications(pubPK);
+          getPublicationService().getAllPublications(instanceId);
       for (String pubId : lastEvents) {
         for (PublicationDetail publication : publications) {
           if (publication.getPK().getId().equals(pubId)) {
@@ -337,15 +335,13 @@ public class DefaultBlogService implements BlogService {
 
   @Override
   public Collection<PostDetail> getAllValidPosts(String instanceId, int nbReturned) {
-    PublicationPK pubPK = new PublicationPK(USELESS, instanceId);
-
     Collection<PostDetail> posts = new ArrayList<>();
     int count = nbReturned;
     try (Connection con = openConnection()) {
       // rechercher les publications classées par date d'évènement
       Collection<String> lastEvents = PostDAO.getAllEvents(con, instanceId);
       Collection<PublicationDetail> publications =
-          getPublicationService().getAllPublications(pubPK);
+          getPublicationService().getAllPublications(instanceId);
       for (String pubId : lastEvents) {
         for (PublicationDetail publication : publications) {
           if (publication.getPK().getId().equals(pubId) && PublicationDetail.VALID_STATUS.
@@ -398,16 +394,13 @@ public class DefaultBlogService implements BlogService {
   @Override
   public Collection<PostDetail> getPostsByArchive(String beginDate, String endDate,
       String instanceId) {
-
-
-    PublicationPK pubPK = new PublicationPK(USELESS, instanceId);
     Collection<PostDetail> posts = new ArrayList<>();
     try (Connection con = openConnection()) {
       // rechercher les publications classée par date d'évènement
       Collection<String> lastEvents = PostDAO.getEventsByDates(con, instanceId, beginDate, endDate);
 
       Collection<PublicationDetail> publications =
-          getPublicationService().getAllPublications(pubPK);
+          getPublicationService().getAllPublications(instanceId);
       for (String pubId : lastEvents) {
         // pour chaque publication, créer le post correspondant
         for (PublicationDetail publication : publications) {
@@ -544,16 +537,16 @@ public class DefaultBlogService implements BlogService {
   @Override
   public void indexBlog(String componentId) {
     indexTopics(new NodePK(USELESS, componentId));
-    indexPublications(new PublicationPK(USELESS, componentId));
+    indexPublications(componentId);
   }
 
-  private void indexPublications(PublicationPK pubPK) {
+  private void indexPublications(String componentId) {
     Collection<PublicationDetail> pubs;
     try {
-      pubs = getPublicationService().getAllPublications(pubPK);
+      pubs = getPublicationService().getAllPublications(componentId);
     } catch (Exception e) {
       throw new BlogRuntimeException(
-          failureOnGetting("[INDEXING] all publications in blog", pubPK.getInstanceId()), e);
+          failureOnGetting("[INDEXING] all publications in blog", componentId), e);
     }
 
     if (pubs != null) {
@@ -561,7 +554,7 @@ public class DefaultBlogService implements BlogService {
         try {
           indexPublication(pub.getPK());
         } catch (Exception e) {
-          throw new BlogRuntimeException(failureOnIndexing("publication", pubPK.toString()), e);
+          throw new BlogRuntimeException(failureOnIndexing("publication", pub.getPK().toString()), e);
         }
       }
     }

--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -211,7 +211,7 @@ public class DefaultBlogService implements BlogService {
       PublicationDetail pub = post.getPublication();
 
       // Remove last category
-      getPublicationService().removeAllFather(pubPk);
+      getPublicationService().removeAllFathers(pubPk);
 
       // Save the publication
       getPublicationService().setDetail(pub);
@@ -251,7 +251,7 @@ public class DefaultBlogService implements BlogService {
     try (Connection con = openConnection()) {
       PublicationPK pubPK = new PublicationPK(postId, instanceId);
       // Delete link with categorie
-      getPublicationService().removeAllFather(pubPK);
+      getPublicationService().removeAllFathers(pubPK);
       // Delete date event
       PostDAO.deleteDateEvent(con, pubPK.getId());
       // Delete comments

--- a/blog/blog-war/src/main/java/org/silverpeas/components/blog/access/BlogPostWriteAccessController.java
+++ b/blog/blog-war/src/main/java/org/silverpeas/components/blog/access/BlogPostWriteAccessController.java
@@ -36,7 +36,7 @@ import javax.inject.Singleton;
  * A controller of write access on a blog. It controls the user can access the blog and have enough
  * privileges to contribute in the blog.
  * <p>
- * With right accesses, a user can create/modify/delete a post.
+ * With access rightes, a user can create/modify/delete a post.
  * @author mmoquillon
  */
 @Singleton

--- a/delegatednews/delegatednews-library/src/main/java/org/silverpeas/components/delegatednews/model/DelegatedNews.java
+++ b/delegatednews/delegatednews-library/src/main/java/org/silverpeas/components/delegatednews/model/DelegatedNews.java
@@ -24,14 +24,13 @@
 
 package org.silverpeas.components.delegatednews.model;
 
-import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.model.PublicationRuntimeException;
+import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.persistence.datasource.model.identifier.ExternalIntegerIdentifier;
 import org.silverpeas.core.persistence.datasource.model.jpa.BasicJpaEntity;
 import org.silverpeas.core.util.ServiceProvider;
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -41,6 +40,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 @Entity
 @Table(name = "sc_delegatednews_news")
@@ -199,9 +199,7 @@ public class DelegatedNews extends BasicJpaEntity<DelegatedNews, ExternalInteger
       PublicationPK pubPk = new PublicationPK(getId(), this.instanceId);
       return publicationService.getDetail(pubPk);
     } catch (Exception e) {
-      throw new PublicationRuntimeException("DelegatedNews.getPublicationDetail()",
-          SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", "pubId = " + getId(),
-          e);
+      throw new PublicationRuntimeException(e);
     }
   }
 
@@ -217,30 +215,25 @@ public class DelegatedNews extends BasicJpaEntity<DelegatedNews, ExternalInteger
     if (this.getPubId() != other.getPubId()) {
       return false;
     }
-    if ((this.instanceId == null) ? (other.instanceId != null) :
-        !this.instanceId.equals(other.instanceId)) {
+    if (!Objects.equals(this.instanceId, other.instanceId)) {
       return false;
     }
-    if ((this.status == null) ? (other.status != null) : !this.status.equals(other.status)) {
+    if (!Objects.equals(this.status, other.status)) {
       return false;
     }
-    if ((this.contributorId == null) ? (other.contributorId != null) :
-        !this.contributorId.equals(other.contributorId)) {
+    if (!Objects.equals(this.contributorId, other.contributorId)) {
       return false;
     }
-    if ((this.validatorId == null) ? (other.validatorId != null) :
-        !this.validatorId.equals(other.validatorId)) {
+    if (!Objects.equals(this.validatorId, other.validatorId)) {
       return false;
     }
-    if ((this.validationDate == null) ? (other.validationDate != null) :
-        !this.validationDate.equals(other.validationDate)) {
+    if (!Objects.equals(this.validationDate, other.validationDate)) {
       return false;
     }
-    if ((this.beginDate == null) ? (other.beginDate != null) :
-        !this.beginDate.equals(other.beginDate)) {
+    if (!Objects.equals(this.beginDate, other.beginDate)) {
       return false;
     }
-    if ((this.endDate == null) ? (other.endDate != null) : !this.endDate.equals(other.endDate)) {
+    if (!Objects.equals(this.endDate, other.endDate)) {
       return false;
     }
     return this.newsOrder == -1 ? other.newsOrder == -1 : this.newsOrder == other.newsOrder;

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmax/KmaxStatistics.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmax/KmaxStatistics.java
@@ -21,7 +21,6 @@
 package org.silverpeas.components.kmax;
 
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.silverstatistics.volume.model.UserIdCountVolumeCouple;
 import org.silverpeas.core.silverstatistics.volume.service.ComponentStatisticsProvider;
@@ -42,7 +41,7 @@ public class KmaxStatistics implements ComponentStatisticsProvider {
 
   @Override
   public Collection<UserIdCountVolumeCouple> getVolume(String spaceId, String componentId) {
-    Collection<PublicationDetail> publications = getPublications(spaceId, componentId);
+    Collection<PublicationDetail> publications = getPublications(componentId);
     List<UserIdCountVolumeCouple> myArrayList = new ArrayList<>(publications.size());
     for (PublicationDetail detail : publications) {
       UserIdCountVolumeCouple myCouple = new UserIdCountVolumeCouple();
@@ -57,8 +56,8 @@ public class KmaxStatistics implements ComponentStatisticsProvider {
     return publicationService;
   }
 
-  private Collection<PublicationDetail> getPublications(String spaceId, String componentId) {
+  private Collection<PublicationDetail> getPublications(String componentId) {
     return getPublicationService()
-        .getAllPublications(new PublicationPK("useless", spaceId, componentId));
+        .getAllPublications(componentId);
   }
 }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaCopyDetail.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaCopyDetail.java
@@ -32,12 +32,12 @@ import java.util.HashMap;
 
 public class KmeliaCopyDetail extends PasteDetailFromToPK<NodePK, NodePK> {
 
-  public final static String PUBLICATION_HEADER = PasteDetail.OPTION_PREFIX + "PublicationHeader";
-  public final static String PUBLICATION_CONTENT = PasteDetail.OPTION_PREFIX + "PublicationContent";
-  public final static String PUBLICATION_FILES = PasteDetail.OPTION_PREFIX + "PublicationFiles";
-  public final static String PUBLICATION_PDC = PasteDetail.OPTION_PREFIX + "PublicationPDC";
-  public final static String NODE_RIGHTS = PasteDetail.OPTION_PREFIX + "NodeRights";
-  public final static String ADMINISTRATIVE_OPERATION =
+  public static final String PUBLICATION_HEADER = PasteDetail.OPTION_PREFIX + "PublicationHeader";
+  public static final String PUBLICATION_CONTENT = PasteDetail.OPTION_PREFIX + "PublicationContent";
+  public static final String PUBLICATION_FILES = PasteDetail.OPTION_PREFIX + "PublicationFiles";
+  public static final String PUBLICATION_PDC = PasteDetail.OPTION_PREFIX + "PublicationPDC";
+  public static final String NODE_RIGHTS = PasteDetail.OPTION_PREFIX + "NodeRights";
+  public static final String ADMINISTRATIVE_OPERATION =
       PasteDetail.OPTION_PREFIX + "AdministrativeOperation";
 
   private String publicationTargetValidatorIds;
@@ -70,6 +70,7 @@ public class KmeliaCopyDetail extends PasteDetailFromToPK<NodePK, NodePK> {
 
   public void setFromNodePK(NodePK fromNodePK) {
     setFromPK(fromNodePK);
+    setFromComponentId(fromNodePK.getInstanceId());
   }
 
   public NodePK getFromNodePK() {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaCopyDetail.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaCopyDetail.java
@@ -56,6 +56,7 @@ public class KmeliaCopyDetail extends PasteDetailFromToPK<NodePK, NodePK> {
       KmeliaCopyDetail copyDetail = (KmeliaCopyDetail) pasteDetail;
       setPublicationStatus(copyDetail.getPublicationStatus());
       setPublicationTargetValidatorIds(copyDetail.getPublicationValidatorIds());
+      setFromComponentId(copyDetail.getFromComponentId());
     }
   }
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaPasteDetail.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaPasteDetail.java
@@ -9,11 +9,12 @@ public class KmeliaPasteDetail {
 
   private String userId;
   private NodePK toPK;
+  private NodePK fromPK;
   private String targetValidatorIds;
   private String status;
 
-  public KmeliaPasteDetail(NodePK pk) {
-    toPK = pk;
+  public KmeliaPasteDetail(final NodePK toNode) {
+    toPK = toNode;
   }
 
   public String getUserId() {
@@ -26,6 +27,14 @@ public class KmeliaPasteDetail {
 
   public NodePK getToPK() {
     return toPK;
+  }
+
+  public NodePK getFromPK() {
+    return fromPK;
+  }
+
+  public void setFromPK(final NodePK fromPK) {
+    this.fromPK = fromPK;
   }
 
   public String getTargetValidatorIds() {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaStatistics.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaStatistics.java
@@ -21,7 +21,6 @@
 package org.silverpeas.components.kmelia;
 
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.silverstatistics.volume.model.UserIdCountVolumeCouple;
 import org.silverpeas.core.silverstatistics.volume.service.ComponentStatisticsProvider;
@@ -60,6 +59,6 @@ public class KmeliaStatistics implements ComponentStatisticsProvider {
   }
 
   private Collection<PublicationDetail> getElements(String componentId) {
-    return getPublicationService().getAllPublications(new PublicationPK("useless", componentId));
+    return getPublicationService().getAllPublications(componentId);
   }
 }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/PublicationImport.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/PublicationImport.java
@@ -361,8 +361,7 @@ public class PublicationImport {
   public Collection<String> getPublicationsSpecificValues(String componentId, String xmlFormName,
       String fieldName) {
     PublicationService publicationService = getPublicationService();
-    Collection<PublicationDetail> publications = publicationService.getAllPublications(new PublicationPK(
-        "useless", componentId));
+    Collection<PublicationDetail> publications = publicationService.getAllPublications(componentId);
     List<String> result = new ArrayList<>();
     Iterator<PublicationDetail> iter = publications.iterator();
     while (iter.hasNext()) {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/model/KmeliaPublication.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/model/KmeliaPublication.java
@@ -62,7 +62,6 @@ public class KmeliaPublication implements SilverpeasContent {
   private static final long serialVersionUID = 4861635754389280165L;
   private PublicationDetail detail;
   private CompletePublication completeDetail;
-  private boolean alias = false;
   private final PublicationPK pk;
   private int rank;
   private boolean read = false;
@@ -86,7 +85,7 @@ public class KmeliaPublication implements SilverpeasContent {
    */
   public static KmeliaPublication aKmeliaPublicationWithPk(final PublicationPK pk) {
     KmeliaPublication publication = new KmeliaPublication(pk);
-    publication.getDetail();
+    publication.loadPublicationDetail();
     return publication;
   }
 
@@ -121,13 +120,16 @@ public class KmeliaPublication implements SilverpeasContent {
   }
 
   /**
-   * Sets this Kmelia publication as an alias one.
-   *
-   * @return itself.
+   * Is the specified publication located in the given Kmelia topic an alias?
+   * @param pub the publication. In the case of an alias, it is the original publication referred
+   * by the alias.
+   * @param topicPK the identifying key of a topic in a Kmelia instance that contains the
+   * publication.
+   * @return true if the specified publication located in the given topic is in fact an alias of
+   * an original publication. False otherwise.
    */
-  public KmeliaPublication asAlias() {
-    this.alias = true;
-    return this;
+  public static boolean isAnAlias(final PublicationDetail pub, final NodePK topicPK) {
+    return !pub.getPK().getInstanceId().equals(topicPK.getInstanceId());
   }
 
   public boolean isRead() {
@@ -144,7 +146,7 @@ public class KmeliaPublication implements SilverpeasContent {
    * @return true if this publication is an alias, false otherwise.
    */
   public boolean isAlias() {
-    return this.alias;
+    return isAnAlias(getDetail(), new NodePK(null, getPk().getInstanceId()));
   }
 
   /**
@@ -186,7 +188,7 @@ public class KmeliaPublication implements SilverpeasContent {
    */
   public PublicationDetail getDetail() {
     if (detail == null) {
-      setPublicationDetail(getKmeliaService().getPublicationDetail(pk));
+      loadPublicationDetail();
     }
     return detail;
   }
@@ -313,6 +315,10 @@ public class KmeliaPublication implements SilverpeasContent {
 
   private OrganizationController getOrganizationController() {
     return OrganizationControllerProvider.getOrganisationController();
+  }
+
+  private void loadPublicationDetail() {
+    setPublicationDetail(getKmeliaService().getPublicationDetail(pk));
   }
 
   @Override

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/AbstractKmeliaUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/AbstractKmeliaUserNotification.java
@@ -88,7 +88,7 @@ public abstract class AbstractKmeliaUserNotification<T> extends AbstractTemplate
       htmlPath = getSpacesPath(nodePK.getInstanceId(), language)
           + getComponentLabel(nodePK.getInstanceId(), language);
       if (!nodePK.isRoot() && !nodePK.getId().equals("-1")) {
-        final List<NodeDetail> path = (List<NodeDetail>) getNodeService().getPath(nodePK);
+        final List<NodeDetail> path = getNodeService().getPath(nodePK);
         if (!path.isEmpty()) {
           // remove root topic "Accueil"
           path.remove(path.size() - 1);

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -278,7 +278,7 @@ public class DefaultKmeliaService implements KmeliaService {
         throw new KmeliaRuntimeException(e);
       }
     }
-    return pubDetails2userPubs(pk, pubDetails);
+    return asRankedKmeliaPublication(pk, pubDetails);
   }
 
   @Override
@@ -300,7 +300,7 @@ public class DefaultKmeliaService implements KmeliaService {
       pubDetails.clear();
       pubDetails.addAll(filteredList);
     }
-    return pubDetails2userPubs(fatherPK, pubDetails);
+    return asRankedKmeliaPublication(pubDetails);
   }
 
   @Override
@@ -515,39 +515,25 @@ public class DefaultKmeliaService implements KmeliaService {
       // get all nodes which will be deleted
       Collection<NodePK> nodesToDelete = nodeService.getDescendantPKs(pkToDelete);
       nodesToDelete.add(pkToDelete);
-      Iterator<PublicationPK> itPub;
-      Collection<PublicationPK> pubsToCheck; // contains all PubPKs concerned by
-      // the delete
-      NodePK oneNodeToDelete; // current node to delete
-      Collection<NodePK> pubFathers; // contains all fatherPKs to a given
-      // publication
-      PublicationPK onePubToCheck; // current pub to check
-      Iterator<NodePK> itNode = nodesToDelete.iterator();
-      List<Location> locations = new ArrayList<>();
-      while (itNode.hasNext()) {
-        oneNodeToDelete = itNode.next();
+      for (NodePK oneNodeToDelete : nodesToDelete) {
         // get pubs linked to current node (includes alias)
-        pubsToCheck = publicationService.getPubPKsInFatherPK(oneNodeToDelete);
-        itPub = pubsToCheck.iterator();
+        Collection<PublicationDetail> pubsToCheck =
+            publicationService.getDetailsByFatherPK(oneNodeToDelete);
         // check each pub contained in current node
-        while (itPub.hasNext()) {
-          onePubToCheck = itPub.next();
-          if (onePubToCheck.getInstanceId().equals(oneNodeToDelete.getInstanceId())) {
-            // get fathers of the pub
-            pubFathers = publicationService.getAllFatherPK(onePubToCheck);
-            if (pubFathers.size() >= 2) {
-              // the pub have got many fathers
-              // delete only the link between pub and current node
-              publicationService.removeFather(onePubToCheck, oneNodeToDelete);
-            } else {
-              sendPublicationToBasket(onePubToCheck);
-            }
+        for (PublicationDetail onePubToCheck : pubsToCheck) {
+          KmeliaPublication kmeliaPub =
+              KmeliaPublication.fromDetail(onePubToCheck, oneNodeToDelete);
+          final Collection<Location> aliases;
+          if (!kmeliaPub.isAlias()) {
+            // remove all aliases of the publication and send it into the basket
+            aliases = publicationService.getAllAliases(kmeliaPub.getPk());
+            sendPublicationToBasket(kmeliaPub.getPk());
           } else {
-            // remove alias
-            locations.clear();
-            locations.add(new Location(oneNodeToDelete.getId(), oneNodeToDelete.getInstanceId()));
-            publicationService.removeAliases(onePubToCheck, locations);
+            // remove only the alias
+            aliases = Collections.singletonList(
+                new Location(oneNodeToDelete.getId(), oneNodeToDelete.getInstanceId()));
           }
+          publicationService.removeAliases(kmeliaPub.getPk(), aliases);
         }
       }
 
@@ -876,21 +862,27 @@ public class DefaultKmeliaService implements KmeliaService {
     return !getSubscribeService().existsSubscription(new NodeSubscription(userId, topicPK));
   }
 
-  /**
-   * ***********************************************************************************
-   * Interface - Gestion des publications
-   * **********************************************************************************
-   */
-  private List<KmeliaPublication> pubDetails2userPubs(NodePK fatherPK, Collection<PublicationDetail> pubDetails) {
+  private List<KmeliaPublication> asRankedKmeliaPublication(NodePK fatherPK, Collection<PublicationDetail> pubDetails) {
     List<KmeliaPublication> publications = new ArrayList<>();
     int i = -1;
     for (PublicationDetail publicationDetail : pubDetails) {
       publications.add(KmeliaPublication.fromDetail(publicationDetail, fatherPK, i++));
     }
+
     return publications;
   }
 
-  private List<KmeliaPublication> pubDetails2userPubs(Collection<PublicationDetail> pubDetails) {
+  private List<KmeliaPublication> asRankedKmeliaPublication(Collection<PublicationDetail> pubDetails) {
+    List<KmeliaPublication> publications = new ArrayList<>();
+    int i = -1;
+    for (PublicationDetail publicationDetail : pubDetails) {
+      publications.add(KmeliaPublication.fromDetail(publicationDetail, i++));
+    }
+
+    return publications;
+  }
+
+  private List<KmeliaPublication> asKmeliaPublication(Collection<PublicationDetail> pubDetails) {
     return pubDetails.stream().map(KmeliaPublication::fromDetail).collect(Collectors.toList());
   }
 
@@ -1024,18 +1016,15 @@ public class DefaultKmeliaService implements KmeliaService {
   }
 
   private String getProfileOnPublication(String userId, PublicationPK pubPK) {
-    final String profile;
-    final List<NodePK> fathers = (List<NodePK>) getPublicationFathers(pubPK);
-    profile = getProfileForDirectNodeOfPublication(userId, pubPK, fathers);
-    return profile;
+    final NodePK fatherPK = getPublicationFatherPK(pubPK);
+    return getProfileForDirectNodeOfPublication(userId, pubPK, fatherPK);
   }
 
   private String getProfileForDirectNodeOfPublication(final String userId,
-      final PublicationPK pubPK, final List<NodePK> fathers) {
+      final PublicationPK pubPK, final NodePK fatherPK) {
     final String profile;
-    if (fathers != null && !fathers.isEmpty()) {
-      final NodePK nodePK = fathers.get(0);
-      profile = getProfile(userId, nodePK);
+    if (fatherPK != null) {
+      profile = getProfile(userId, fatherPK);
     } else {
       // peculiar case in which the publication isn't in any node: this situation occurs if the
       // publication is definitely deleted or orphaned. In that case, we take the profile of the
@@ -1091,36 +1080,39 @@ public class DefaultKmeliaService implements KmeliaService {
    * @return true if status has changed, false otherwise
    */
   private boolean changePublicationStatusOnUpdate(PublicationDetail pubDetail) {
-    String oldStatus = pubDetail.getStatus();
-    String newStatus = oldStatus;
-
-    List<NodePK> fathers = (List<NodePK>) getPublicationFathers(pubDetail.getPK());
-
+    final String previousStatus = pubDetail.getStatus();
+    final String newStatus;
+    final NodePK father = getPublicationFatherPK(pubDetail.getPK());
     if (pubDetail.isStatusMustBeChecked() && !pubDetail.isDraft() && !pubDetail.isClone()) {
-      newStatus = setPublicationStatus(pubDetail, newStatus, fathers);
+      newStatus = setPublicationStatus(pubDetail, previousStatus, father);
+    } else {
+      newStatus = previousStatus;
     }
 
     KmeliaHelper.checkIndex(pubDetail);
 
-    if (fathers == null || fathers.isEmpty() || (fathers.size() == 1 && fathers.get(0).isTrash())) {
-      // la publication est dans la corbeille
+    if (father == null || father.isTrash()) {
+      // the publication is in the trash
       pubDetail.setIndexOperation(IndexManager.NONE);
     }
-    return !oldStatus.equalsIgnoreCase(newStatus);
+    return !previousStatus.equalsIgnoreCase(newStatus);
   }
 
-  private String setPublicationStatus(final PublicationDetail pubDetail, String newStatus,
-      final List<NodePK> fathers) {
+  private String setPublicationStatus(final PublicationDetail pubDetail, final String newStatus,
+      final NodePK father) {
     final String profile =
-        getProfileForDirectNodeOfPublication(pubDetail.getUpdaterId(), pubDetail.getPK(), fathers);
+        getProfileForDirectNodeOfPublication(pubDetail.getUpdaterId(), pubDetail.getPK(), father);
+    final String status;
     if (SilverpeasRole.writer.isInRole(profile)) {
-      newStatus = PublicationDetail.TO_VALIDATE_STATUS;
+      status = PublicationDetail.TO_VALIDATE_STATUS;
     } else if (pubDetail.isRefused() &&
         (SilverpeasRole.admin.isInRole(profile) || SilverpeasRole.publisher.isInRole(profile))) {
-      newStatus = PublicationDetail.VALID_STATUS;
+      status = PublicationDetail.VALID_STATUS;
+    } else {
+      status = newStatus;
     }
-    pubDetail.setStatus(newStatus);
-    return newStatus;
+    pubDetail.setStatus(status);
+    return status;
   }
 
   /**
@@ -1304,7 +1296,7 @@ public class DefaultKmeliaService implements KmeliaService {
       sendPublicationToBasket(pub.getPK());
     } else {
       // update parent
-      publicationService.removeAllFather(pub.getPK());
+      publicationService.removeAllFathers(pub.getPK());
       publicationService.addFather(pub.getPK(), to);
       pub.setTargetValidatorId(pasteContext.getTargetValidatorIds());
       processPublicationAfterMove(pub, to, pasteContext.getUserId());
@@ -1542,7 +1534,7 @@ public class DefaultKmeliaService implements KmeliaService {
       // delete all reading controls associated to this publication
       deleteAllReadingControlsByPublication(pubPK);
       // delete all links
-      publicationService.removeAllFather(pubPK);
+      publicationService.removeAllFathers(pubPK);
       // delete the publication
       publicationService.removePublication(pubPK);
       // delete reference to contentManager
@@ -1583,7 +1575,7 @@ public class DefaultKmeliaService implements KmeliaService {
       }
 
       // remove all links between this publication and topics
-      publicationService.removeAllFather(pubPK);
+      publicationService.removeAllFathers(pubPK);
       // add link between this publication and the basket topic
       publicationService.addFather(pubPK, new NodePK("1", pubPK));
 
@@ -1683,22 +1675,18 @@ public class DefaultKmeliaService implements KmeliaService {
 
   private NodePK sendSubscriptionsNotification(PublicationDetail pubDetail, NotifAction action,
       final boolean sendOnlyToAliases) {
-    NodePK oneFather = null;
+    NodePK father = null;
     // We alert subscribers only if publication is Valid
     if (!pubDetail.haveGotClone() && pubDetail.isValid() && pubDetail.isVisible()) {
-      // Topic subscriptions
-      Collection<NodePK> fathers = getPublicationFathers(pubDetail.getPK());
-      if (!sendOnlyToAliases) {
-        for (NodePK father : fathers) {
-          oneFather = father;
-          sendSubscriptionsNotification(father, pubDetail, action);
-        }
+      // Subscription to the main topic
+      father = getPublicationFatherPK(pubDetail.getPK());
+      if (!sendOnlyToAliases && father != null) {
+        sendSubscriptionsNotification(father, pubDetail, action);
       }
 
       // Subscriptions related to aliases
-      List<Location> locations = (List<Location>) getAlias(pubDetail.getPK());
-      sendSubscriptionNotificationForAliases(pubDetail, action, sendOnlyToAliases, fathers,
-          locations);
+      Collection<Location> locations = publicationService.getAllAliases(pubDetail.getPK());
+      sendSubscriptionNotificationForAliases(pubDetail, action, sendOnlyToAliases, locations);
 
       // PDC subscriptions
       try {
@@ -1718,19 +1706,16 @@ public class DefaultKmeliaService implements KmeliaService {
             new String[] {pubDetail.getPK().getId()}, e);
       }
     }
-    return oneFather;
+    return father;
   }
 
   private void sendSubscriptionNotificationForAliases(final PublicationDetail pubDetail,
-      final NotifAction action, final boolean sendOnlyToAliases, final Collection<NodePK> fathers,
-      final List<Location> locations) {
-    for (Location location : locations) {
+      final NotifAction action, final boolean sendOnlyToAliases,
+      final Collection<Location> aliases) {
+    for (Location location : aliases) {
       // Transform the current alias to a NodePK (even if Alias is extending NodePK) in the aim
       // to execute the equals method of NodePK
-      NodePK aliasNodePk = new NodePK(location.getId(), location.getInstanceId());
-      if ((sendOnlyToAliases && location.isAlias()) || !fathers.contains(aliasNodePk)) {
-        // Perform subscription notification sendings when the alias is not the one of the
-        // original publication
+      if (sendOnlyToAliases && location.isAlias() || location.isAlias()) {
         pubDetail.setAlias(true);
         sendSubscriptionsNotification(location, pubDetail, action);
       }
@@ -1739,10 +1724,7 @@ public class DefaultKmeliaService implements KmeliaService {
 
   private void sendSubscriptionsNotification(NodePK fatherPK, PublicationDetail pubDetail,
       NotifAction action) {
-
-    // Send email alerts
     try {
-
       // Building and sending the notification
       UserNotificationHelper.buildAndSend(
           new KmeliaSubscriptionPublicationUserNotification(fatherPK, pubDetail, action));
@@ -1777,7 +1759,7 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public void deletePublicationFromAllTopics(PublicationPK pubPK) {
     try {
-      publicationService.removeAllFather(pubPK);
+      publicationService.removeAllFathers(pubPK);
 
       // la publication n'a qu'un seul emplacement
       // elle est donc placée dans la corbeille du créateur
@@ -1836,64 +1818,72 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public NodePK getPublicationFatherPK(PublicationPK pubPK, boolean isTreeStructureUsed,
       String userId, boolean isRightsOnTopicsUsed) {
-    // fetch one of the publication fathers
-    Collection<NodePK> fathers = getPublicationFathers(pubPK);
-    NodePK fatherPK = new NodePK("0", pubPK); // By default --> Root
-    if (fathers != null) {
-      Iterator<NodePK> it = fathers.iterator();
-      if (!isRightsOnTopicsUsed) {
-        if (it.hasNext()) {
-          fatherPK = it.next();
-        }
-      } else {
-        fatherPK = getAllowedFather(userId, fatherPK, it);
-      }
+    final NodePK fatherPK;
+    final Location root = new Location(NodePK.ROOT_NODE_ID, pubPK.getInstanceId());
+    Collection<Location> locations = getPublicationLocations(pubPK);
+    if (locations.isEmpty()) {
+      fatherPK = root;
+    } else if (!isRightsOnTopicsUsed) {
+      fatherPK = locations.stream().filter(l -> !l.isAlias()).findFirst().orElse(root);
+    } else {
+      fatherPK = getAllowedFather(userId, root, locations);
     }
     return fatherPK;
   }
 
-  private NodePK getAllowedFather(final String userId, NodePK fatherPK, final Iterator<NodePK> it) {
-    NodeDetail allowedFather = null;
-    while (allowedFather == null && it.hasNext()) {
-      fatherPK = it.next();
-      NodeDetail father = getNodeHeader(fatherPK);
-      if (!father.haveRights() ||
-          getOrganisationController().isObjectAvailable(father.getRightsDependsOn(),
-              ObjectType.NODE, fatherPK.getInstanceId(), userId)) {
-        allowedFather = father;
+  private NodePK getAllowedFather(final String userId, final Location defaultFatherPK,
+      final Collection<Location> locations) {
+    Optional<Location> main = locations.stream().filter(l -> !l.isAlias()).findFirst();
+    if (main.isPresent()) {
+      NodeDetail mainFather = getNodeHeader(main.get());
+      if (!mainFather.haveRights() ||
+          getOrganisationController().isObjectAvailable(mainFather.getRightsDependsOn(),
+              ObjectType.NODE, main.get().getInstanceId(), userId)) {
+        return main.get();
       }
     }
-    if (allowedFather != null) {
-      fatherPK = allowedFather.getNodePK();
+    return locations.stream()
+        .filter(Location::isAlias)
+        .map(this::getNodeHeader)
+        .filter(f -> !f.haveRights() ||
+            getOrganisationController().isObjectAvailable(f.getRightsDependsOn(), ObjectType.NODE,
+                f.getNodePK().getInstanceId(), userId))
+        .findFirst()
+        .map(NodeDetail::getNodePK)
+        .orElse(defaultFatherPK);
+  }
+
+  /**
+   * Gets all the locations of the publication in the original Kmelia instance.
+   * @param pubPK the identifying key of the publication
+   * @return a collection of {@link Location} objects.
+   */
+  private Collection<Location> getPublicationLocations(PublicationPK pubPK) {
+    Collection<Location> locations =
+        publicationService.getLocationsInComponentInstance(pubPK, pubPK.getInstanceId());
+    if (locations.isEmpty()) {
+      // This publication have got no father!
+      // Check if it's a clone (a clone have got no father ever)
+      boolean alwaysVisibleModeActivated = StringUtil.getBooleanValue(getOrganisationController().
+          getComponentParameterValue(pubPK.getInstanceId(), "publicationAlwaysVisible"));
+      if (alwaysVisibleModeActivated) {
+        PublicationDetail publi = publicationService.getDetail(pubPK);
+        if (publi != null && isClone(publi)) {
+          // This publication is a clone
+          // Get fathers from main publication
+          final PublicationPK clonedPK = publi.getClonePK();
+          locations = publicationService.getLocationsInComponentInstance(clonedPK,
+              clonedPK.getInstanceId());
+        }
+      }
     }
-    return fatherPK;
+    return locations;
   }
 
   @Override
-  public Collection<NodePK> getPublicationFathers(PublicationPK pubPK) {
-    try {
-      Collection<NodePK> fathers = publicationService.getAllFatherPK(pubPK);
-      if (CollectionUtil.isEmpty(fathers)) {
-        // This publication have got no father !
-        // Check if it's a clone (a clone have got no father ever)
-        boolean alwaysVisibleModeActivated = StringUtil.getBooleanValue(getOrganisationController().
-            getComponentParameterValue(pubPK.getInstanceId(), "publicationAlwaysVisible"));
-        if (alwaysVisibleModeActivated) {
-          PublicationDetail publi = publicationService.getDetail(pubPK);
-          if (publi != null) {
-            boolean isClone = isClone(publi);
-            if (isClone) {
-              // This publication is a clone
-              // Get fathers from main publication
-              fathers = publicationService.getAllFatherPK(publi.getClonePK());
-            }
-          }
-        }
-      }
-      return fathers;
-    } catch (Exception e) {
-      throw new KmeliaRuntimeException(e);
-    }
+  public NodePK getPublicationFatherPK(PublicationPK pubPK) {
+    Collection<Location> locations = getPublicationLocations(pubPK);
+    return locations.stream().filter(l -> !l.isAlias()).findFirst().orElse(null);
   }
 
   /**
@@ -1945,7 +1935,7 @@ public class DefaultKmeliaService implements KmeliaService {
       }
     }
     Collection<PublicationDetail> publications = getPublicationDetails(allowedPublicationIds);
-    return pubDetails2userPubs(publications);
+    return asKmeliaPublication(publications);
   }
 
   /**
@@ -1982,7 +1972,7 @@ public class DefaultKmeliaService implements KmeliaService {
     } catch (Exception e) {
       throw new KmeliaRuntimeException(e);
     }
-    return pubDetails2userPubs(publications);
+    return asKmeliaPublication(publications);
   }
 
   private void addPublicationsToValidate(final String userId,
@@ -2077,23 +2067,16 @@ public class DefaultKmeliaService implements KmeliaService {
 
   private void addAdminAndPublishers(final PublicationPK pubPK, final List<String> allValidators,
       final List<String> roles) {
-    List<NodePK> nodePKs = (List<NodePK>) getPublicationFathers(pubPK);
-    NodePK nodePK;
-    NodeDetail node;
-    boolean oneNodeIsPublic = false;
-    for (int n = 0; !oneNodeIsPublic && nodePKs != null && n < nodePKs.size(); n++) {
-      nodePK = nodePKs.get(n);
-      node = getNodeHeader(nodePK);
-      if (node != null) {
-        if (!node.haveRights()) {
-          allValidators.addAll(Arrays.asList(
-              getOrganisationController().getUsersIdsByRoleNames(pubPK.getInstanceId(), roles)));
-          oneNodeIsPublic = true;
-        } else {
-          allValidators.addAll(Arrays.asList(
-              getOrganisationController().getUsersIdsByRoleNames(pubPK.getInstanceId(),
-                  Integer.toString(node.getRightsDependsOn()), ObjectType.NODE, roles)));
-        }
+    NodePK father = getPublicationFatherPK(pubPK);
+    if (father != null) {
+      NodeDetail topic = getNodeHeader(father);
+      if (!topic.haveRights()) {
+        allValidators.addAll(Arrays.asList(
+            getOrganisationController().getUsersIdsByRoleNames(pubPK.getInstanceId(), roles)));
+      } else {
+        allValidators.addAll(Arrays.asList(
+            getOrganisationController().getUsersIdsByRoleNames(pubPK.getInstanceId(),
+                Integer.toString(topic.getRightsDependsOn()), ObjectType.NODE, roles)));
       }
     }
   }
@@ -2145,7 +2128,7 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public boolean validatePublication(PublicationPK pubPK, String userId, boolean force,
       final boolean hasUserNoMoreValidationRight) {
-    boolean validationComplete = false;
+    boolean validationComplete;
     try {
       CompletePublication currentPub = publicationService.getCompletePublication(pubPK);
       PublicationDetail currentPubDetail = currentPub.getPublicationDetail();
@@ -2403,12 +2386,8 @@ public class DefaultKmeliaService implements KmeliaService {
         publicationService.setDetail(currentPubDetail);
 
         // we have to alert publication's last updater
-        List<NodePK> fathers = (List<NodePK>) getPublicationFathers(pubPK);
-        NodePK oneFather = null;
-        if (fathers != null && !fathers.isEmpty()) {
-          oneFather = fathers.get(0);
-        }
-        sendValidationNotification(oneFather, clone, refusalMotive, userId);
+        NodePK fatherPK =  getPublicationFatherPK(pubPK);
+        sendValidationNotification(fatherPK, clone, refusalMotive, userId);
 
         // remove tasks
         removeAllTodosForPublication(clone.getPK());
@@ -2424,12 +2403,8 @@ public class DefaultKmeliaService implements KmeliaService {
         updateSilverContentVisibility(currentPubDetail);
 
         // we have to alert publication's creator
-        List<NodePK> fathers = (List<NodePK>) getPublicationFathers(pubPK);
-        NodePK oneFather = null;
-        if (fathers != null && !fathers.isEmpty()) {
-          oneFather = fathers.get(0);
-        }
-        sendValidationNotification(oneFather, currentPubDetail, refusalMotive, userId);
+        NodePK fatherPK = getPublicationFatherPK(pubPK);
+        sendValidationNotification(fatherPK, currentPubDetail, refusalMotive, userId);
 
         //remove tasks
         removeAllTodosForPublication(currentPubDetail.getPK());
@@ -3299,13 +3274,13 @@ public class DefaultKmeliaService implements KmeliaService {
     if (publications == null) {
       return new ArrayList<>();
     }
-    return pubDetails2userPubs(publications);
+    return asKmeliaPublication(publications);
   }
 
   @Override
   public List<KmeliaPublication> search(List<String> combination, int nbDays, String componentId) {
     Collection<PublicationDetail> publications = searchPublications(combination, componentId);
-    return pubDetails2userPubs(filterPublicationsByBeginDate(publications, nbDays));
+    return asKmeliaPublication(filterPublicationsByBeginDate(publications, nbDays));
   }
 
   private Collection<PublicationDetail> searchPublications(List<String> combination,
@@ -3359,7 +3334,7 @@ public class DefaultKmeliaService implements KmeliaService {
     } catch (Exception e) {
       throw new KmaxRuntimeException(e);
     }
-    return pubDetails2userPubs(publications);
+    return asKmeliaPublication(publications);
   }
 
   private Collection<PublicationDetail> filterPublicationsByBeginDate(
@@ -3567,16 +3542,31 @@ public class DefaultKmeliaService implements KmeliaService {
   }
 
   @Override
-  public Collection<Location> getAlias(PublicationPK pubPK) {
+  public Collection<Location> getLocations(PublicationPK pubPK) {
     try {
-      return publicationService.getLocations(pubPK);
+      Collection<Location> locations = publicationService.getAllLocations(pubPK);
+      if (locations.isEmpty()) {
+        // This publication doesn't yet have any location!
+        // Check if it's a clone (a clone doesn't have a location. It is orphaned)
+        boolean alwaysVisibleModeActivated = StringUtil.getBooleanValue(getOrganisationController().
+            getComponentParameterValue(pubPK.getInstanceId(), "publicationAlwaysVisible"));
+        if (alwaysVisibleModeActivated) {
+          PublicationDetail publication = publicationService.getDetail(pubPK);
+          if (publication != null && isClone(publication)) {
+            // This publication is a clone
+            // Get locations from the main publication
+            locations = publicationService.getAllLocations(publication.getClonePK());
+          }
+        }
+      }
+      return locations;
     } catch (Exception e) {
       throw new KmeliaRuntimeException(e);
     }
   }
 
   @Override
-  public void setAlias(PublicationPK pubPK, List<Location> locations) {
+  public void setAliases(PublicationPK pubPK, List<Location> locations) {
 
     publicationService.setAliases(pubPK, locations);
 
@@ -3809,7 +3799,7 @@ public class DefaultKmeliaService implements KmeliaService {
   }
 
   @Override
-  public Collection<NodeDetail> getFolderChildren(NodePK nodePK, String userId) {
+  public NodeDetail getFolder(final NodePK nodePK, final String userId) {
     NodeDetail node = nodeService.getDetail(nodePK);
     if (node.getNodePK().isRoot()) {
       node.setChildrenDetails(getRootChildren(node, userId, null));
@@ -3818,8 +3808,16 @@ public class DefaultKmeliaService implements KmeliaService {
     }
 
     // set nb objects in nodes
-    setNbItemsOfSubfolders(node, null, userId);
+    final List<NodeDetail> treeView = getTreeview(nodePK, userId);
+    setNbItemsOfFolders(node.getNodePK().getInstanceId(), Collections.singletonList(node),
+        treeView);
+    setNbItemsOfSubfolders(node, treeView, userId);
+    return node;
+  }
 
+  @Override
+  public Collection<NodeDetail> getFolderChildren(NodePK nodePK, String userId) {
+    NodeDetail node = getFolder(nodePK, userId);
     return node.getChildrenDetails();
   }
 
@@ -4303,8 +4301,7 @@ public class DefaultKmeliaService implements KmeliaService {
     NodePK toNodePK = copyDetail.getToNodePK();
     String userId = copyDetail.getUserId();
     final String toComponentId = toNodePK.getInstanceId();
-    final NodePK fromNodePK = copyDetail.getFromNodePK() != null ? copyDetail.getFromNodePK() :
-        new NodePK("0", copyDetail.getFromComponentId());
+    final NodePK fromNodePK = copyDetail.getFromNodePK();
     final KmeliaPublication publication = KmeliaPublication.fromDetail(publiToCopy, fromNodePK);
     try {
       if (publication.isAlias()) {
@@ -4729,9 +4726,9 @@ public class DefaultKmeliaService implements KmeliaService {
       }
 
       if (alertPublicationOwnerThereIsNoMoreValidator) {
-        Collection<NodePK> fatherPks = getPublicationFathers(currentPubDetail.getPK());
-        if (!fatherPks.isEmpty()) {
-          sendNoMoreValidatorNotification(fatherPks.iterator().next(), currentPubDetail);
+        NodePK fatherPK = getPublicationFatherPK(currentPubDetail.getPK());
+        if (fatherPK != null) {
+          sendNoMoreValidatorNotification(fatherPK, currentPubDetail);
         }
       }
       return this;

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -44,6 +44,7 @@ import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.cache.service.CacheServiceProvider;
 import org.silverpeas.core.comment.service.CommentService;
 import org.silverpeas.core.contribution.attachment.AttachmentException;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
@@ -83,6 +84,7 @@ import org.silverpeas.core.node.coordinates.model.CoordinatePoint;
 import org.silverpeas.core.node.coordinates.service.CoordinatesService;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
+import org.silverpeas.core.node.model.NodePath;
 import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.notification.user.builder.helper.UserNotificationHelper;
@@ -151,6 +153,7 @@ public class DefaultKmeliaService implements KmeliaService {
   private static final String USELESS = "useless";
   private static final String NODE_PREFIX = "Node_";
   private static final String ADMIN_ROLE = "admin";
+  private static final String ALIASES_CACHE_KEY = "NEW_PUB_ALIASES";
   @Inject
   private NodeService nodeService;
   @Inject
@@ -799,8 +802,9 @@ public class DefaultKmeliaService implements KmeliaService {
       Collection<Collection<NodeDetail>> detailedList = new ArrayList<>();
       // For each favorite, get the path from root to favorite
       for (Subscription subscription : list) {
-        Collection<NodeDetail> path =
-            nodeService.getPath(subscription.getResource().getPK());
+        final SubscriptionResource resource = subscription.getResource();
+        final NodePK nodePK = new NodePK(resource.getId(), resource.getInstanceId());
+        final NodePath path = NodeService.get().getPath((NodePK) resource.getPK());
         detailedList.add(path);
       }
       return detailedList;
@@ -1673,6 +1677,7 @@ public class DefaultKmeliaService implements KmeliaService {
     return false;
   }
 
+  @SuppressWarnings("unchecked")
   private NodePK sendSubscriptionsNotification(PublicationDetail pubDetail, NotifAction action,
       final boolean sendOnlyToAliases) {
     NodePK father = null;
@@ -1685,7 +1690,13 @@ public class DefaultKmeliaService implements KmeliaService {
       }
 
       // Subscriptions related to aliases
-      Collection<Location> locations = publicationService.getAllAliases(pubDetail.getPK());
+      Collection<Location> locations =
+          (Collection<Location>) CacheServiceProvider.getRequestCacheService()
+              .getCache()
+              .get(ALIASES_CACHE_KEY);
+      if (locations == null) {
+        locations = getAliases(pubDetail.getPK());
+      }
       sendSubscriptionNotificationForAliases(pubDetail, action, sendOnlyToAliases, locations);
 
       // PDC subscriptions
@@ -1696,14 +1707,13 @@ public class DefaultKmeliaService implements KmeliaService {
                 getInstanceId());
         if (positions != null) {
           for (ClassifyPosition position : positions) {
-            pdcSubscriptionManager
-                .checkSubscriptions(position.getValues(), pubDetail.getPK().getInstanceId(),
-                    silverObjectId);
+            pdcSubscriptionManager.checkSubscriptions(position.getValues(),
+                pubDetail.getPK().getInstanceId(), silverObjectId);
           }
         }
       } catch (PdcException e) {
-        SilverLogger.getLogger(this).error("PdC subscriptions notification failure for publication {0}",
-            new String[] {pubDetail.getPK().getId()}, e);
+        SilverLogger.getLogger(this)
+            .error("PdC subscriptions notification failure for publication {0}", new String[] {pubDetail.getPK().getId()}, e);
       }
     }
     return father;
@@ -3542,6 +3552,15 @@ public class DefaultKmeliaService implements KmeliaService {
   }
 
   @Override
+  public Collection<Location> getAliases(final PublicationPK pubPK) {
+    try {
+      return publicationService.getAllAliases(pubPK);
+    } catch (Exception e) {
+      throw new KmeliaRuntimeException(e);
+    }
+  }
+
+  @Override
   public Collection<Location> getLocations(PublicationPK pubPK) {
     try {
       Collection<Location> locations = publicationService.getAllLocations(pubPK);
@@ -3568,9 +3587,13 @@ public class DefaultKmeliaService implements KmeliaService {
   @Override
   public void setAliases(PublicationPK pubPK, List<Location> locations) {
 
-    publicationService.setAliases(pubPK, locations);
+    Pair<Collection<Location>, Collection<Location>> result =
+        publicationService.setAliases(pubPK, locations);
 
     // Send subscriptions to aliases subscribers
+    CacheServiceProvider.getRequestCacheService()
+        .getCache()
+        .put(ALIASES_CACHE_KEY, result.getFirst());
     PublicationDetail pubDetail = getPublicationDetail(pubPK);
     sendSubscriptionsNotification(pubDetail, NotifAction.PUBLISHED, true);
   }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -28,13 +28,11 @@ import org.silverpeas.core.ApplicationService;
 import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.contribution.content.form.XMLField;
-import org.silverpeas.core.contribution.publication.model.Alias;
+import org.silverpeas.core.contribution.publication.model.Location;
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.node.coordinates.model.Coordinate;
-import org.silverpeas.core.node.coordinates.model.CoordinatePK;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserNotification;
@@ -43,9 +41,7 @@ import org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail;
 import org.silverpeas.core.util.ServiceProvider;
 
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This is the Service interface controller of the MVC. It controls all the activities that happen
@@ -282,9 +278,24 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    */
   void addInfoLinks(PublicationPK pubPK, List<ResourceReference> links);
 
+  /**
+   * Gets the complete details about the publication referred by the specified unique identifier.
+   * @param pubPK the unique identifier of a Kmelia publication.
+   * @return a {@link CompletePublication} object.
+   */
   CompletePublication getCompletePublication(PublicationPK pubPK);
 
-  KmeliaPublication getPublication(PublicationPK pubPK);
+  /**
+   * Gets the Kmelia publication identified by the specified identifying key and that is located
+   * into the specified topic. As a Kmelia publication can be in different locations, all
+   * publications other than the original father of the publication are considered as an alias of
+   * that original publication. This is why it is required to know the father of the asked
+   * publication.
+   * @param pubPK identifier of the publication to get.
+   * @param topicPK identifier of the topic in which the publication is located.
+   * @return the asked {@link KmeliaPublication} instance.
+   */
+  KmeliaPublication getPublication(PublicationPK pubPK, NodePK topicPK);
 
   TopicDetail getPublicationFather(PublicationPK pubPK, boolean isTreeStructureUsed, String userId,
       boolean isRightsOnTopicsUsed);
@@ -571,57 +582,15 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    */
   String createKmaxPublication(PublicationDetail pubDetail);
 
-  /**
-   * Delete coordinates of a publication (ie: when publication is deleted)
-   * @param coordinatePK
-   * @param coordinates
-   */
-  void deleteCoordinates(CoordinatePK coordinatePK, List<String> coordinates);
+  Collection<Location> getAlias(PublicationPK pubPK);
 
-  Collection<Alias> getAlias(PublicationPK pubPK);
-
-  void setAlias(PublicationPK pubPK, List<Alias> alias);
+  void setAlias(PublicationPK pubPK, List<Location> locations);
 
   void addAttachmentToPublication(PublicationPK pubPK, String userId, String filename,
       String description, byte[] contents);
 
-  boolean importPublication(String componentId, String topicId, String spaceId, String userId,
-      Map<String, String> publiParams, Map<String, String> formParams, String language,
-      String xmlFormName, String discrimatingParameterName, String userProfile);
-
-  boolean importPublication(String componentId, String topicId, String userId,
-      Map<String, String> publiParams, Map<String, String> formParams, String language,
-      String xmlFormName, String discriminantParameterName, String userProfile,
-      boolean ignoreMissingFormFields);
-
-  boolean importPublication(String publicationId, String componentId, String topicId,
-      String spaceId, String userId, Map<String, String> publiParams,
-      Map<String, String> formParams, String language, String xmlFormName, String userProfile);
-
-  void importPublications(String componentId, String topicId, String spaceId, String userId,
-      List<Map<String, String>> publiParamsList, List<Map<String, String>> formParamsList,
-      String language, String xmlFormName, String discrimatingParameterName, String userProfile);
-
-  List<XMLField> getPublicationXmlFields(String publicationId, String componentId, String spaceId,
-      String userId);
-
-  List<XMLField> getPublicationXmlFields(String publicationId, String componentId, String spaceId,
-      String userId, String language);
-
   String createTopic(String componentId, String topicId, String spaceId, String userId, String name,
       String description);
-
-  Collection<String> getPublicationsSpecificValues(String componentId, String xmlFormName,
-      String fieldName);
-
-  void draftInPublication(String componentId, String xmlFormName, String fieldName,
-      String fieldValue);
-
-  void updatePublicationEndDate(String componentId, String spaceId, String userId,
-      String xmlFormName, String fieldName, String fieldValue, Date endDate);
-
-  String findPublicationIdBySpecificValue(String componentId, String xmlFormName, String fieldName,
-      String fieldValue, String topicId, String spaceId, String userId);
 
   void doAutomaticDraftOut();
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -197,7 +197,14 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    */
   Collection<Collection<NodeDetail>> getPathList(PublicationPK pubPK);
 
-  Collection<NodePK> getPublicationFathers(PublicationPK pubPK);
+  /**
+   * Gets the father of the specified publication. If the publication is a clone of a main one, then
+   * gets the father of the cloned publication. The father returned should be the main location of
+   * the publication. It the publication is an orphaned one, null is returned.
+   * @param pubPK the identifying key of the publication.
+   * @return the father of the publication or null if the publication is an orphaned one.
+   */
+  NodePK getPublicationFatherPK(PublicationPK pubPK);
 
   /**
    * Create a new Publication (only the header - parameters) to the current Topic
@@ -297,9 +304,33 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    */
   KmeliaPublication getPublication(PublicationPK pubPK, NodePK topicPK);
 
+  /**
+   * Gets the details about the father from which the specified publication is accessible to the
+   * given user. If the main location of the publication isn't accessible by the user, then the
+   * first accessible alias of the publication is returned. If no aliases are accessible or defined,
+   * the the details of the root topic is returned.
+   * @param pubPK the unique identifier of the publication.
+   * @param isTreeStructureUsed is the tree view of the topics enabled?
+   * @param userId the unique identifier of a user.
+   * @param isRightsOnTopicsUsed is the rights on the topics enabled in the component instance
+   * in which is defined the publication?
+   * @return the details of the topic in which the publication is accessible by the given user.
+   */
   TopicDetail getPublicationFather(PublicationPK pubPK, boolean isTreeStructureUsed, String userId,
       boolean isRightsOnTopicsUsed);
 
+  /**
+   * Gets the father of the specified publication according to the rights of the user. If the main
+   * location of the publication isn't accessible by the user, then the first accessible alias of
+   * the publication is returned. If no aliases are accessible or defined, the the root topic is
+   * returned.
+   * @param pubPK the unique identifier of the publication
+   * @param isTreeStructureUsed is the tree view of the topics is used?
+   * @param userId the unique identifier of a user.
+   * @param isRightsOnTopicsUsed is the rights on the topics enabled in the component instance
+   * in which is defined the publication?
+   * @return a topic in which the publication is accessible by the given user.
+   */
   NodePK getPublicationFatherPK(PublicationPK pubPK, boolean isTreeStructureUsed, String userId,
       boolean isRightsOnTopicsUsed);
 
@@ -582,9 +613,15 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    */
   String createKmaxPublication(PublicationDetail pubDetail);
 
-  Collection<Location> getAlias(PublicationPK pubPK);
+  /**
+   * Gets all the locations of the specified publication. If the given publication is a clone, then
+   * gets all the locations of the main publication.
+   * @param pubPK the unique identifier of the publication.
+   * @return a collection of the locations of the given publication.
+   */
+  Collection<Location> getLocations(PublicationPK pubPK);
 
-  void setAlias(PublicationPK pubPK, List<Location> locations);
+  void setAliases(PublicationPK pubPK, List<Location> locations);
 
   void addAttachmentToPublication(PublicationPK pubPK, String userId, String filename,
       String description, byte[] contents);
@@ -610,6 +647,16 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
   NodeDetail getRoot(String componentId, String userId);
 
   Collection<NodeDetail> getFolderChildren(NodePK nodePK, String userId);
+
+  /**
+   * Gets the details about the specified folder. The difference with
+   * {@link KmeliaService#getNodeHeader(String, String)} is that the children are also set as well
+   * as other information like the number of publications.
+   * @param nodePK the unique identifier of the folder.
+   * @param userId the unique identifier of the user for which the folder is asked.
+   * @return the {@link NodeDetail} instance corresponding to the folder.
+   */
+  NodeDetail getFolder(NodePK nodePK, String userId);
 
   NodeDetail getExpandedPathToNode(NodePK pk, String userId);
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -614,12 +614,22 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
   String createKmaxPublication(PublicationDetail pubDetail);
 
   /**
-   * Gets all the locations of the specified publication. If the given publication is a clone, then
-   * gets all the locations of the main publication.
+   * Gets all the locations of the specified publication; whatever the component instance.
+   * If the given publication is a clone, then gets all the locations of the main
+   * publication.
    * @param pubPK the unique identifier of the publication.
    * @return a collection of the locations of the given publication.
    */
   Collection<Location> getLocations(PublicationPK pubPK);
+
+  /**
+   * Gets all the aliases of the specified publication, whatever the component instance and without
+   * taking into account the publication is a clone or not. If the publication is a clone, then
+   * nothing will be returned.
+   * @param pubPK the unique identifier of the publication.
+   * @return a collection of locations that are all the aliases for the given publication.
+   */
+  Collection<Location> getAliases(PublicationPK pubPK);
 
   void setAliases(PublicationPK pubPK, List<Location> locations);
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/stats/StatisticServiceImpl.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/stats/StatisticServiceImpl.java
@@ -26,7 +26,6 @@ import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.admin.service.AdminException;
 import org.silverpeas.core.admin.user.model.Group;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
@@ -161,7 +160,7 @@ public class StatisticServiceImpl implements
       }
       validPubli =
           getPublicationService().getDetailsByFatherIdsAndStatus(fatherIds,
-          new PublicationPK("", statFilter.getInstanceId()), null, "Valid");
+              statFilter.getInstanceId(), null, "Valid");
       publis.addAll(validPubli);
     }
     return publis;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -2542,6 +2542,10 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     return languages;
   }
 
+  public Collection<Location> getPublicationAliases() {
+    return getKmeliaService().getAliases(getSessionPublication().getDetail().getPK());
+  }
+
   public void setPublicationAliases(List<Location> locations) {
     getKmeliaService().setAliases(getSessionPublication().getDetail().getPK(), locations);
   }

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -824,10 +824,6 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     return getKmeliaService().getPathList(pk);
   }
 
-  public synchronized Collection<NodePK> getPublicationFathers(String pubId) {
-    return getKmeliaService().getPublicationFathers(getPublicationPK(pubId));
-  }
-
   public NodePK getAllowedPublicationFather(String pubId) {
     return getKmeliaService()
         .getPublicationFatherPK(getPublicationPK(pubId), isTreeStructure(), getUserId(),
@@ -2546,16 +2542,12 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     return languages;
   }
 
-  public void setAliases(List<Location> locations) {
-    getKmeliaService().setAlias(getSessionPublication().getDetail().getPK(), locations);
+  public void setPublicationAliases(List<Location> locations) {
+    getKmeliaService().setAliases(getSessionPublication().getDetail().getPK(), locations);
   }
 
-  public void setAliases(PublicationPK pubPK, List<Location> locations) {
-    getKmeliaService().setAlias(pubPK, locations);
-  }
-
-  public Collection<Location> getAliases() {
-    return getKmeliaService().getAlias(getSessionPublication().getDetail().getPK());
+  public Collection<Location> getPublicationLocations() {
+    return getKmeliaService().getLocations(getSessionPublication().getDetail().getPK());
   }
 
   /**

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -2330,7 +2330,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     PublicationAccessController publicationAccessController =
         ServiceProvider.getService(PublicationAccessController.class);
     if (publicationAccessController.isUserAuthorized(getUserId(), pub.getPK())) {
-      PublicationSelection pubSelect = new PublicationSelection(pub);
+      PublicationSelection pubSelect = new PublicationSelection(pub, getComponentId());
       addClipboardSelection(pubSelect);
     } else {
       SilverLogger.getLogger(this)
@@ -2357,7 +2357,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     PublicationAccessController publicationAccessController =
         ServiceProvider.getService(PublicationAccessController.class);
     if (publicationAccessController.isUserAuthorized(getUserId(), pub.getPK())) {
-      PublicationSelection pubSelect = new PublicationSelection(pub);
+      PublicationSelection pubSelect = new PublicationSelection(pub, getComponentId());
       pubSelect.setCutted(true);
 
       addClipboardSelection(pubSelect);
@@ -2437,12 +2437,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       KmeliaPasteDetail pasteDetail) throws UnsupportedFlavorException {
     NodeDetail folder = getNodeHeader(pasteDetail.getToPK().getId());
     if (selection.isDataFlavorSupported(PublicationSelection.PublicationDetailFlavor)) {
-      PublicationDetail pub = (PublicationDetail) selection.getTransferData(
+      PublicationSelection.TransferData data = (PublicationSelection.TransferData) selection.getTransferData(
           PublicationSelection.PublicationDetailFlavor);
+      PublicationDetail pub = data.getPublicationDetail();
       if (selection.isCutted()) {
         movePublication(pub.getPK(), folder.getNodePK(), pasteDetail);
       } else {
         KmeliaCopyDetail copyDetail = KmeliaCopyDetail.fromPasteDetail(pasteDetail);
+        copyDetail.setFromNodePK(pasteDetail.getFromPK());
+        copyDetail.setFromComponentId(data.getInstanceId());
         getKmeliaService().copyPublication(pub, copyDetail);
       }
       return pub;
@@ -2458,6 +2461,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
           // copy node
           KmeliaCopyDetail copyDetail = KmeliaCopyDetail.fromPasteDetail(pasteDetail);
           copyDetail.setFromNodePK(node.getNodePK());
+          copyDetail.setFromComponentId(node.getNodePK().getInstanceId());
           getKmeliaService().copyNode(copyDetail);
         }
         return node;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -1141,7 +1141,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     String spaceLabel = Encode.forHtml(orga.
         getSpaceInstLightById(compoInstLight.getDomainFatherId())
         .getName(kmelia.getCurrentLanguage()));
-    List<NodePK> nodesPK = (List<NodePK>) pub.getPublicationBm().getAllFatherPK(pub.getPK());
+    List<NodePK> nodesPK = (List<NodePK>) pub.getPublicationService().getAllFatherPK(pub.getPK());
     if (nodesPK != null) {
       NodePK firstNodePK = nodesPK.get(0);
       String topicPathName = spaceLabel + " > " + componentLabel + " > " + kmelia.displayPath(

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -385,7 +385,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
           }
         }
 
-        if (!pub.getPK().getInstanceId().equals(kmeliaScc.getComponentId())) {
+        if (pub.isAlias()) {
           pubState = resources.getString("kmelia.Shortcut");
         }
 
@@ -503,7 +503,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     boolean canBeCut = KmeliaPublicationHelper
         .isCanBeCut(kmeliaScc.getComponentId(), userId, kmeliaScc.getUserTopicProfile(),
             aPub.getCreator());
-    boolean alias = isAlias(kmeliaScc, aPub.getDetail());
+    boolean alias = aPub.isAlias();
     fragmentSettings.draggable = canBeCut && !alias && !KmeliaHelper.isToValidateFolder(topicId);
 
     if (specificTemplateUsed) {
@@ -719,16 +719,12 @@ public class AjaxPublicationsListServlet extends HttpServlet {
     if (displayFiles) {
       sb.append("<span class=\"files\">");
       // Can be a shortcut. Must check attachment mode according to publication source.
-      boolean alias = isAlias(kmeliaScc, pub);
+      boolean alias = pub.isAlias();
       sb.append(displayAttachments(kmeliaScc, pub, resources, linkAttachment, alias));
 
       sb.append("</span>");
     }
     return sb.toString();
-  }
-
-  private boolean isAlias(KmeliaSessionController kmeliaScc, PublicationDetail pub) {
-    return !kmeliaScc.getComponentId().equalsIgnoreCase(pub.getPK().getInstanceId());
   }
 
   private void displayThumbnail(PublicationDetail pub, KmeliaSessionController ksc,
@@ -1097,7 +1093,7 @@ public class AjaxPublicationsListServlet extends HttpServlet {
         KmeliaPublication kmeliaPub = iterator.next();
         PublicationDetail pub = kmeliaPub.getDetail();
         String shortcut;
-        if (!pub.getPK().getInstanceId().equals(kmeliaScc.getComponentId())) {
+        if (pub.isAlias()) {
           shortcut = " (" + resources.getString("kmelia.Shortcut") + ")";
         } else {
           shortcut = "";

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AliasFileServer.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AliasFileServer.java
@@ -28,7 +28,7 @@ import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.contribution.publication.model.Alias;
+import org.silverpeas.core.contribution.publication.model.Location;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.silvertrace.SilverTrace;
@@ -101,17 +101,17 @@ public class AliasFileServer extends HttpServlet {
 
     if (foreignKey != null) {
       PublicationPK pubPK = new PublicationPK(foreignKey.getId(), foreignKey.getInstanceId());
-      List<Alias> aliases = (List<Alias>) getPublicationService().getAlias(pubPK);
+      List<Location> locations = (List<Location>) getPublicationService().getLocations(pubPK);
 
       // check if user have rights to see alias files
       boolean rightsOK = false;
       KmeliaAuthorization security = new KmeliaAuthorization();
-      for (int a = 0; !rightsOK && a < aliases.size(); a++) {
-        Alias alias = aliases.get(a);
-        if (!foreignKey.getInstanceId().equals(alias.getInstanceId())) {
+      for (int a = 0; !rightsOK && a < locations.size(); a++) {
+        Location location = locations.get(a);
+        if (!foreignKey.getInstanceId().equals(location.getInstanceId())) {
           // it's an alias
           // Check if user is allowed to see topic's content
-          rightsOK = security.isAccessAuthorized(alias.getInstanceId(), userId, alias.getId(),
+          rightsOK = security.isAccessAuthorized(location.getInstanceId(), userId, location.getId(),
               KmeliaAuthorization.NODE_TYPE);
         }
       }

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaActionAccessController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaActionAccessController.java
@@ -50,10 +50,10 @@ public class KmeliaActionAccessController {
 
 
   /**
-   * Check if user role has right access to the given action
+   * Check if user role has access right to the given action
    * @param action the checked action
    * @param role the highest user role
-   * @return true if given role has right access to the action
+   * @return true if given role has access right to the action
    */
   public boolean hasRightAccess(String action, SilverpeasRole role) {
     boolean actionExist = actionRole.containsKey(action);

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -646,7 +646,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
           request.setAttribute("NotificationAllowed", kmelia.isNotificationAllowed());
 
           // check is requested publication is an alias
-          boolean alias = checkAlias(kmelia, kmeliaPublication);
+          boolean alias = kmeliaPublication.isAlias();
 
           if (alias) {
             request.setAttribute("Profile", "user");
@@ -1880,14 +1880,6 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
 
   private String checkLanguage(KmeliaSessionController kmelia, PublicationDetail pubDetail) {
     return pubDetail.getLanguageToDisplay(kmelia.getCurrentLanguage());
-  }
-
-  private boolean checkAlias(KmeliaSessionController kmelia, KmeliaPublication publication) {
-    if (!kmelia.getComponentId().equals(publication.getDetail().getPK().getInstanceId())) {
-      publication.asAlias();
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -1034,9 +1034,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         }
 
         // Tous les composants ayant un alias n'ont pas forcément été chargés
-        Collection<Location> oldLocations = kmelia.getPublicationLocations();
+        Collection<Location> oldLocations = kmelia.getPublicationAliases();
         for (Location oldLocation : oldLocations) {
-          if (!loadedComponentIds.contains(oldLocation.getInstanceId())) {
+          if (!loadedComponentIds.contains(oldLocation.getInstanceId()) && oldLocation.isAlias()) {
             // le composant de l'alias n'a pas été chargé
             locations.add(oldLocation);
           }
@@ -1049,7 +1049,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         String componentId = request.getParameter("ComponentId");
 
         request.setAttribute("Tree", kmelia.getAliasTreeview(componentId));
-        request.setAttribute("Aliases", kmelia.getPublicationLocations());
+        request.setAttribute("Aliases", kmelia.getPublicationAliases());
 
         destination = rootDestination + "treeview4PublicationPaths.jsp";
       } else if (function.equals("AddLinksToPublication")) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -45,7 +45,7 @@ import org.silverpeas.core.contribution.content.form.PagesContext;
 import org.silverpeas.core.contribution.content.form.RecordSet;
 import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
-import org.silverpeas.core.contribution.publication.model.Alias;
+import org.silverpeas.core.contribution.publication.model.Location;
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
 import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
@@ -1013,9 +1013,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         if (toolboxMode) {
           request.setAttribute("Topics", kmelia.getAllTopics());
         } else {
-          List<Alias> aliases = kmelia.getAliases();
-          request.setAttribute("Aliases", aliases);
-          request.setAttribute("Components", kmelia.getComponents(aliases));
+          Collection<Location> locations = kmelia.getAliases();
+          request.setAttribute("Aliases", locations);
+          request.setAttribute("Components", kmelia.getComponents(locations));
         }
 
         destination = rootDestination + "publicationPaths.jsp";
@@ -1023,29 +1023,29 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         String[] topics = request.getParameterValues("topicChoice");
         String loadedComponentIds = request.getParameter("LoadedComponentIds");
 
-        Alias alias;
-        List<Alias> aliases = new ArrayList<Alias>();
+        Location location;
+        List<Location> locations = new ArrayList<>();
         for (int i = 0; topics != null && i < topics.length; i++) {
           String topicId = topics[i];
           StringTokenizer tokenizer = new StringTokenizer(topicId, ",");
           String nodeId = tokenizer.nextToken();
           String instanceId = tokenizer.nextToken();
 
-          alias = new Alias(nodeId, instanceId);
-          alias.setUserId(kmelia.getUserId());
-          aliases.add(alias);
+          location = new Location(nodeId, instanceId);
+          location.setAsAlias(kmelia.getUserId());
+          locations.add(location);
         }
 
         // Tous les composants ayant un alias n'ont pas forcément été chargés
-        List<Alias> oldAliases = kmelia.getAliases();
-        for (Alias oldAlias : oldAliases) {
-          if (!loadedComponentIds.contains(oldAlias.getInstanceId())) {
+        Collection<Location> oldLocations = kmelia.getAliases();
+        for (Location oldLocation : oldLocations) {
+          if (!loadedComponentIds.contains(oldLocation.getInstanceId())) {
             // le composant de l'alias n'a pas été chargé
-            aliases.add(oldAlias);
+            locations.add(oldLocation);
           }
         }
 
-        kmelia.setAliases(aliases);
+        kmelia.setAliases(locations);
 
         destination = getDestination("ViewPublication", kmelia, request);
       } else if (function.equals("ShowAliasTree")) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -1004,17 +1004,14 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         String folderId = request.getParameter("FolderId");
         destination = kmelia.initUPToSelectValidator(formElementName, formElementId, folderId);
       } else if (function.equals("PublicationPaths")) {
-        PublicationDetail publication = kmelia.getSessionPublication().getDetail();
-        String pubId = publication.getPK().getId();
+        KmeliaPublication publication = kmelia.getSessionPublication();
         request.setAttribute("Publication", publication);
         request.setAttribute("LinkedPathString", kmelia.getSessionPath());
-        request.setAttribute("PathList", kmelia.getPublicationFathers(pubId));
-
         if (toolboxMode) {
           request.setAttribute("Topics", kmelia.getAllTopics());
         } else {
-          Collection<Location> locations = kmelia.getAliases();
-          request.setAttribute("Aliases", locations);
+          Collection<Location> locations = kmelia.getPublicationLocations();
+          request.setAttribute("Locations", locations);
           request.setAttribute("Components", kmelia.getComponents(locations));
         }
 
@@ -1037,7 +1034,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         }
 
         // Tous les composants ayant un alias n'ont pas forcément été chargés
-        Collection<Location> oldLocations = kmelia.getAliases();
+        Collection<Location> oldLocations = kmelia.getPublicationLocations();
         for (Location oldLocation : oldLocations) {
           if (!loadedComponentIds.contains(oldLocation.getInstanceId())) {
             // le composant de l'alias n'a pas été chargé
@@ -1045,14 +1042,14 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
           }
         }
 
-        kmelia.setAliases(locations);
+        kmelia.setPublicationAliases(locations);
 
         destination = getDestination("ViewPublication", kmelia, request);
       } else if (function.equals("ShowAliasTree")) {
         String componentId = request.getParameter("ComponentId");
 
         request.setAttribute("Tree", kmelia.getAliasTreeview(componentId));
-        request.setAttribute("Aliases", kmelia.getAliases());
+        request.setAttribute("Aliases", kmelia.getPublicationLocations());
 
         destination = rootDestination + "treeview4PublicationPaths.jsp";
       } else if (function.equals("AddLinksToPublication")) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/ajax/handlers/DeleteHandler.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/ajax/handlers/DeleteHandler.java
@@ -33,6 +33,6 @@ public class DeleteHandler implements AjaxHandler {
   @Override
   public String handleRequest(HttpServletRequest request, KmeliaSessionController controller) {
     String id = request.getParameter("Id");
-      return controller.deleteTopic(id);
-    }
+    return controller.deleteTopic(id);
+  }
 }

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/ajax/handlers/MovePublicationHandler.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/ajax/handlers/MovePublicationHandler.java
@@ -46,6 +46,7 @@ public class MovePublicationHandler implements AjaxHandler {
       NodePK from = new NodePK(sourceId, controller.getComponentId());
       NodePK to = new NodePK(targetId, controller.getComponentId());
       KmeliaPasteDetail pasteDetail = new KmeliaPasteDetail(to);
+      pasteDetail.setFromPK(from);
       pasteDetail.setUserId(controller.getUserId());
       pasteDetail.setTargetValidatorIds(validatorIds);
       getKmeliaService().movePublicationInSameApplication(pubPK, from, pasteDetail);

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/FolderResource.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/FolderResource.java
@@ -79,7 +79,7 @@ public class FolderResource extends RESTWebService {
   public NodeEntity getRoot(@QueryParam("lang") String language) {
     NodeDetail root;
     try {
-      root = getKmeliaBm().getRoot(componentId, getUser().getId());
+      root = getKmeliaService().getRoot(componentId, getUser().getId());
     } catch (Exception e) {
       throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
     }
@@ -128,7 +128,7 @@ public class FolderResource extends RESTWebService {
 
     List<NodeDetail> nodes;
     try {
-      nodes = new ArrayList<>(getNodeBm().getPath(nodePK));
+      nodes = new ArrayList<>(getNodeService().getPath(nodePK));
       Collections.reverse(nodes);
 
       String requestUri = getUri().getRequestUri().toString();
@@ -167,7 +167,7 @@ public class FolderResource extends RESTWebService {
 
     Collection<NodeDetail> children;
     try {
-      children = getKmeliaBm().getFolderChildren(nodePK, getUser().getId());
+      children = getKmeliaService().getFolderChildren(nodePK, getUser().getId());
     } catch (Exception e) {
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
@@ -213,7 +213,7 @@ public class FolderResource extends RESTWebService {
 
     Collection<NodeDetail> children;
     try {
-      children = getKmeliaBm().getFolderChildren(nodePK, getUser().getId());
+      children = getKmeliaService().getFolderChildren(nodePK, getUser().getId());
     } catch (Exception e) {
       throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
     }
@@ -234,7 +234,7 @@ public class FolderResource extends RESTWebService {
     String description = nodeAttr.getDescription();
 
     try {
-      String nodeId = getKmeliaBm().createTopic(
+      String nodeId = getKmeliaService().createTopic(
           componentId, parentNodeId, null, userId, nodeName, description);
 
       NodeDetail node = getNodeDetail(nodeId);
@@ -285,10 +285,10 @@ public class FolderResource extends RESTWebService {
     String nodeId = nodeIds[nodeIds.length - 2];
 
     try {
-      List<NodeDetail> nodes = new ArrayList<>(getNodeBm().getPath(new NodePK(nodeId,
+      List<NodeDetail> nodes = new ArrayList<>(getNodeService().getPath(new NodePK(nodeId,
           componentId)));
       Collections.reverse(nodes);
-      NodeDetail root = getKmeliaBm().getExpandedPathToNode(new NodePK(nodeId, componentId),
+      NodeDetail root = getKmeliaService().getExpandedPathToNode(new NodePK(nodeId, componentId),
           getUser().getId());
 
       String requestUri = getUri().getRequestUri().toString();
@@ -340,7 +340,7 @@ public class FolderResource extends RESTWebService {
 
   private NodeDetail getNodeDetail(String id) {
     try {
-      return getNodeBm().getDetail(getNodePK(id));
+      return getNodeService().getDetail(getNodePK(id));
     } catch (Exception e) {
       throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
     }
@@ -350,7 +350,7 @@ public class FolderResource extends RESTWebService {
     return new NodePK(id, getComponentId());
   }
 
-  private NodeService getNodeBm() {
+  private NodeService getNodeService() {
     try {
       return NodeService.get();
     } catch (Exception e) {
@@ -358,7 +358,7 @@ public class FolderResource extends RESTWebService {
     }
   }
 
-  public KmeliaService getKmeliaBm() {
+  public KmeliaService getKmeliaService() {
     try {
       return ServiceProvider.getService(KmeliaService.class);
     } catch (Exception e) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/KmeliaResource.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/web/KmeliaResource.java
@@ -87,7 +87,7 @@ public class KmeliaResource extends RESTWebService {
 
       NodePK nodePK = getNodePK(nodeId);
 
-      String pubId = getKmeliaBm().createPublicationIntoTopic(publication, nodePK);
+      String pubId = getKmeliaService().createPublicationIntoTopic(publication, nodePK);
       publication.getPK().setId(pubId);
 
       URI publicationURI = getUri().getRequestUriBuilder().path(publication.getPK().getId())
@@ -117,10 +117,10 @@ public class KmeliaResource extends RESTWebService {
       // Publication status is a mandatory data into the context of publication update.
       // As this data is not handled by this service, it is retrieved from the silverpeas data
       // before performing the update.
-      publication.setStatus(getKmeliaBm().getPublicationDetail(publication.getPK()).getStatus());
+      publication.setStatus(getKmeliaService().getPublicationDetail(publication.getPK()).getStatus());
 
       // Now, the update can be performed
-      getKmeliaBm().updatePublication(publication);
+      getKmeliaService().updatePublication(publication);
 
       URI publicationURI = getUri().getRequestUriBuilder().path(publication.getPK().getId())
           .build();
@@ -145,7 +145,7 @@ public class KmeliaResource extends RESTWebService {
     return PublicationEntity.fromPublicationDetail(publication, publicationURI);
   }
 
-  private KmeliaService getKmeliaBm() {
+  private KmeliaService getKmeliaService() {
     try {
       return ServiceProvider.getService(KmeliaService.class);
     } catch (Exception e) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -586,7 +586,7 @@ function deleteFolder(nodeId, nodeLabel) {
     var url = getWebContext() + '/KmeliaAJAXServlet';
     $.post(url, {Id: nodeId, ComponentId: componentId, Action: 'Delete'},
     function(data) {
-      if ((data - 0) == data && data.length > 0) {
+      if (data !== null && data.length > 0 && !isNaN(data)) {
         // fires event
         try {
           nodeDeleted(nodeId);
@@ -616,6 +616,20 @@ function addNodeToCurrentNode() {
   topicAdd(getCurrentNodeId(), false);
 }
 
+function applyWithNodePath(path, operation) {
+  var url = getWebContext() + "/services/folders/" + getComponentId() + "/" + path + "/path?lang=" + getTranslation() + "&IEFix=" + new Date().getTime();
+  $.getJSON(url, function(data) {
+    operation(data);
+  });
+}
+
+function applyWithNode(nodeId, operation) {
+  var url = getWebContext() + "/services/folders/" + getComponentId() + "/" + nodeId + "?lang=" + getTranslation() + "&IEFix=" + new Date().getTime();
+  $.getJSON(url, function(data) {
+    operation(data);
+  });
+}
+
 function topicAdd(topicId, isLinked) {
   var translation = getTranslation();
   var rightsOnTopic = params["rightsOnTopic"];
@@ -634,8 +648,7 @@ function topicAdd(topicId, isLinked) {
     $("#deleteTranslation").remove();
 
     // display path of parent
-    url = getWebContext() + "/services/folders/" + getComponentId() + "/" + topicId + "/path?lang=" + getTranslation() + "&IEFix=" + new Date().getTime();
-    $.getJSON(url, function(data) {
+    applyWithNodePath(topicId, function(data) {
       //remove topic breadcrumb
       $("#addOrUpdateNode #path").html("");
       $(data).each(function(i, topic) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -101,11 +101,11 @@
   String id = pubDetail.getPK().getId();
 
   String contextComponentId = componentId;
-  //surcharge le componentId du composant courant (cas de l'alias)
+  //surcharge le componentId du composant courant (cas de l'locations)
   componentId = pubDetail.getPK().getInstanceId();
-  String alias = "";
+  String locations = "";
   if (kmeliaPublication.isAlias()) {
-    alias = contextComponentId;
+    locations = contextComponentId;
   }
 
   String linkedPathString = kmeliaScc.getSessionPath();
@@ -629,7 +629,7 @@
         <c:set var="attachmentPosition"><%=resources.getSetting("attachmentPosition")%></c:set>
         <c:set var="callbackUrl"><%=URLUtil.getURL("useless", componentId) + "ViewPublication"%></c:set>
         <viewTags:displayAttachments componentInstanceId="<%=componentId%>"
-                                     componentInstanceIdAlias="<%=alias%>"
+                                     componentInstanceIdAlias="<%=locations%>"
                                      resourceId="<%=id%>"
                                      resourceType="<%=resourceType%>"
                                      contentLanguage="<%=language%>"

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -52,6 +52,8 @@
 <%@ page import="org.silverpeas.core.notification.user.NotificationContext" %>
 <%@ page import="org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail" %>
 <%@ page import="org.silverpeas.core.webapi.rating.RaterRatingEntity" %>
+<%@ page import="java.util.Optional" %>
+<%@ page import="org.silverpeas.core.contribution.publication.model.Location" %>
 
 <c:set var="userLanguage" value="${requestScope.resources.language}"/>
 <c:set var="contentLanguage" value="${requestScope.Language}"/>
@@ -758,12 +760,13 @@
          }
 
          if (kmeliaPublication.isAlias()) {
-      	   NodePK originalFatherPK = kmeliaPublication.getOriginalLocation(user_id);
-      	   if (originalFatherPK != null) {
+      	   Optional<Location> originalLocation = kmeliaPublication.getOriginalLocation(user_id);
+      	   if (originalLocation.isPresent()) {
+      	     Location original = originalLocation.get();
         %>
             <div class="inlineMessage">
               <div><%=resources.getString("kmelia.publication.shortcut.source.label")%>
-                <view:componentPath componentId="<%=originalFatherPK.getInstanceId()%>" nodeId="<%=originalFatherPK.getId()%>" language="<%=language%>" link="true"/>
+                <view:componentPath componentId="<%=original.getInstanceId()%>" nodeId="<%=original.getId()%>" language="<%=language%>" link="true"/>
               </div>
               <a href="<%=kmeliaPublication.getDetail().getPermalink()%>" class="button sp-permalink"><span><%=resources.getString("kmelia.publication.shortcut.source.go")%></span></a>
             </div>

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationPaths.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationPaths.jsp
@@ -28,6 +28,7 @@
 <%@ page import="org.silverpeas.core.contribution.publication.model.Location" %>
 <%@ page import="org.silverpeas.components.kmelia.model.Treeview" %>
 <%@page import="org.silverpeas.components.kmelia.jstl.KmeliaDisplayHelper"%>
+<%@ page import="org.silverpeas.components.kmelia.model.KmeliaPublication" %>
 <%
 response.setHeader("Cache-Control","no-store"); //HTTP 1.1
 response.setHeader("Pragma","no-cache"); //HTTP 1.0
@@ -37,16 +38,15 @@ response.setDateHeader ("Expires",-1); //prevents caching at the proxy server
 <%@ include file="checkKmelia.jsp" %>
 
 <%
-PublicationDetail 	publication 		= (PublicationDetail) request.getAttribute("Publication");
-Collection<NodePK>	pathList 			= (Collection<NodePK>) request.getAttribute("PathList");
+KmeliaPublication publication 		= (KmeliaPublication) request.getAttribute("Publication");
 String 				linkedPathString 	= (String) request.getAttribute("LinkedPathString");
 Collection<NodeDetail> topics			= (Collection<NodeDetail>) request.getAttribute("Topics");
 String				currentLang 		= (String) request.getAttribute("Language");
 List<Treeview>		components			= (List<Treeview>) request.getAttribute("Components");
-List<Location> locations = (List<Location>) request.getAttribute("Aliases");
+Collection<Location> locations = (Collection<Location>) request.getAttribute("Locations");
 
-String pubName 	= publication.getName(currentLang);
-String id 		= publication.getPK().getId();
+String pubName 	= publication.getDetail().getName(currentLang);
+String id 		= publication.getDetail().getPK().getId();
 
 Button validateButton = gef.getFormButton(resources.getString("GML.validate"), "javascript:onClick=sendData();", false);
 Button cancelButton = gef.getFormButton(resources.getString("GML.cancel"), "ViewPublication?PubId="+id, false);
@@ -176,12 +176,10 @@ function getObjects(selected) {
         out.println(board.printBefore());
         
      	//regarder si la publication est dans la corbeille
-		for (NodePK node : pathList) {
-    		if ("1".equals(node.getId())) {
+    		if (NodePK.BIN_NODE_ID.equals(publication.getLocation().getId())) {
     			//la publi est dans la corbeille
         		out.println(kmeliaScc.getString("kmelia.PubInBasket")+"<br/><br/>");
     		}
-    	}
         %>
         <form name="paths" action="SetPath" method="post">
         	<input type="hidden" name="PubId" value="<%=id%>"/>
@@ -208,7 +206,7 @@ function getObjects(selected) {
     				
     				// recherche si ce th�me est dans la liste des locations de la publication
 					  String usedCheck = "";
-    				for (NodePK node : pathList) {
+    				for (Location node : locations) {
 	    				String nodeId = node.getId();
 	    				if (Integer.toString(topic.getId()).equals(nodeId)) {
 	    					usedCheck = " checked=\"checked\"";

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationPaths.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationPaths.jsp
@@ -25,7 +25,7 @@
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
-<%@ page import="org.silverpeas.core.contribution.publication.model.Alias" %>
+<%@ page import="org.silverpeas.core.contribution.publication.model.Location" %>
 <%@ page import="org.silverpeas.components.kmelia.model.Treeview" %>
 <%@page import="org.silverpeas.components.kmelia.jstl.KmeliaDisplayHelper"%>
 <%
@@ -43,7 +43,7 @@ String 				linkedPathString 	= (String) request.getAttribute("LinkedPathString")
 Collection<NodeDetail> topics			= (Collection<NodeDetail>) request.getAttribute("Topics");
 String				currentLang 		= (String) request.getAttribute("Language");
 List<Treeview>		components			= (List<Treeview>) request.getAttribute("Components");
-List<Alias>			aliases				= (List<Alias>) request.getAttribute("Aliases");
+List<Location> locations = (List<Location>) request.getAttribute("Aliases");
 
 String pubName 	= publication.getName(currentLang);
 String id 		= publication.getPK().getId();
@@ -53,7 +53,7 @@ Button cancelButton = gef.getFormButton(resources.getString("GML.cancel"), "View
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
+<html xml:lang="<%=currentLang%>%>">
 <head>
 <title></title>
 <view:looknfeel/>
@@ -206,7 +206,7 @@ function getObjects(selected) {
     				}
     				name = ind + name;	
     				
-    				// recherche si ce th�me est dans la liste des alias de la publication
+    				// recherche si ce th�me est dans la liste des locations de la publication
 					  String usedCheck = "";
     				for (NodePK node : pathList) {
 	    				String nodeId = node.getId();
@@ -254,12 +254,12 @@ function getObjects(selected) {
 	    			nbAliases = "<span align=\"right\">"+treeview.getNbAliases()+" "+resources.getString("kmelia.paths.paths")+"</span>";
 	    		}  
 	%>
-				<a href="javascript: void(0)" id="<%=treeview.getComponentId()%>"><table width="100%" cellspacing="0" cellpadding="0"><tr><td><%=panelTitle%></td><td align="right"><%=nbAliases%></td></tr></table></a>
+				<a href="javascript: void(0)" id="<%=treeview.getComponentId()%>"><table><caption></caption><th id="all-locations"></th><tr><td><%=panelTitle%></td><td text-align="right"><%=nbAliases%></td></tr></table></a>
 					<div id="content_<%=treeview.getComponentId()%>" class="content">
 	<%
 					out.println("<table border=\"0\">");
 					if (t == 0) {
-		    			List<NodeDetail> otherTree = (List<NodeDetail>) treeview.getTree();
+		    			List<NodeDetail> otherTree = treeview.getTree();
 		    			for (NodeDetail topic : otherTree) {
 		        			if (topic.getId() != 1 && topic.getId() != 2) {
 	    	    				String name = topic.getName(currentLang);
@@ -278,13 +278,18 @@ function getObjects(selected) {
 	    	    				// recherche si ce dossier est dans la liste des dossiers de la publication
 	    	    				String aliasDecoration = "&nbsp;";
 	    	    				String checked = "";
-	    	    				for (Alias alias : aliases) {
-	    		    				String nodeId = alias.getId();	    		    				
-	    		    				if (Integer.toString(topic.getId()).equals(nodeId) && topic.getNodePK().getInstanceId().equals(alias.getInstanceId())) {
+	    	    				String readonly = "";
+	    	    				for (Location location : locations) {
+	    		    				String nodeId = location.getId();
+	    		    				if (Integer.toString(topic.getId()).equals(nodeId) && topic.getNodePK().getInstanceId().equals(
+													location.getInstanceId())) {
 	    		    					checked = " checked=\"checked\"";
-	    		    					if (!alias.getInstanceId().equals(componentId)) {
-	    		    						aliasDecoration = "<i>"+alias.getUserName()+" - "+resources.getOutputDateAndHour(alias.getDate())+"</i>";
-	    		    					}
+	    		    					if (location.isAlias()) {
+	    		    						aliasDecoration = "<i>"+
+															location.getAlias().getUserName()+" - "+resources.getOutputDateAndHour(location.getAlias().getDate())+"</i>";
+	    		    					} else {
+	    		    						readonly = "readonly=\"readonly\" disabled=\"disabled\"";
+												}
 	    		    				}
 	    		    			}
 	    	    				boolean displayCheckbox = false;
@@ -297,7 +302,7 @@ function getObjects(selected) {
 	    	    				}
 	    	    	        	out.println("<tr><td width=\"10px\">");
 	    	    	        	if (displayCheckbox) {
-	    	    	        		out.println("<input type=\"checkbox\" valign=\"absmiddle\" name=\"topicChoice\" value=\""+topic.getId()+","+topic.getNodePK().getInstanceId()+"\""+checked+readonlyCheckbox+">");
+	    	    	        		out.println("<input type=\"checkbox\" valign=\"absmiddle\" name=\"topicChoice\" value=\""+topic.getId()+","+topic.getNodePK().getInstanceId()+"\""+checked+readonlyCheckbox+readonly+">");
 	    	    	        	} else {
 	    	    	        		out.println("&nbsp;");
 	    	    	        	}

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -277,14 +277,21 @@ function nodeDeleted(nodeId) {
 		// change nb publications on each parent of deleted node (except root)
 		var nbPublisRemoved = getNbPublis(nodeId);
 		var path = getTreeview().get_path("#"+nodeId, false, true);
-		for (i=0; i<path.length; i++) {
-			var elementId = path[i];
-			if (elementId != "0" && elementId != nodeId) {
-				addNbPublis(elementId, 0-nbPublisRemoved);
-			}
-		}
-		// add nb of removed publis in bin
-		addNbPublis("1", nbPublisRemoved);
+		path.forEach(function(elementId, index) {
+       if (elementId !== nodeId) {
+          applyWithNode(elementId, function(data) {
+             var nodeTitle = getNodeTitle(elementId);
+             var nbPublis = data.attr.nbItems;
+             getTreeview().rename_node("#"+elementId, nodeTitle+" ("+nbPublis+")");
+          });
+       }
+     });
+     var binId = '1';
+     applyWithNode(binId, function(data) {
+        var nodeTitle = getNodeTitle(binId);
+        var nbPublis = data.attr.nbItems;
+        getTreeview().rename_node("#"+binId, nodeTitle+" ("+nbPublis+")");
+     });
 	}
 	getTreeview().delete_node("#"+nodeId);
 }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview4PublicationPaths.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview4PublicationPaths.jsp
@@ -28,26 +28,24 @@
 <%@ page import="java.util.List"%>
 <%@ page import="java.util.Iterator"%>
 <%@ page import="org.silverpeas.core.node.model.NodeDetail"%>
-<%@ page import="org.silverpeas.core.contribution.publication.model.Alias" %>
+<%@ page import="org.silverpeas.core.contribution.publication.model.Location" %>
 <%@ page import="org.silverpeas.core.util.MultiSilverpeasBundle"%>
-<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
 <%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
 
 <%
 MultiSilverpeasBundle resources = (MultiSilverpeasBundle)request.getAttribute("resources");
 
-List 	otherTree 	= (List) request.getAttribute("Tree");
+List<NodeDetail> 	otherTree 	= (List<NodeDetail>) request.getAttribute("Tree");
 String	currentLang = (String) request.getAttribute("Language");
-List	aliases		= (List) request.getAttribute("Aliases");
+List<Location>	locations		= (List<Location>) request.getAttribute("Aliases");
 %>
 
-<table border="0" width="100%">
+<table>
+	<caption></caption>
+	<th id="locations"></th>
 <%
-Iterator otherTopics = otherTree.iterator();
-while(otherTopics.hasNext())
+for(NodeDetail topic: otherTree)
 {
-	NodeDetail topic = (NodeDetail) otherTopics.next();
-
 	if (topic.getId() != 1 && topic.getId() != 2)
 	{
 			String name = WebEncodeHelper.convertHTMLEntities(topic.getName(currentLang));
@@ -69,16 +67,15 @@ while(otherTopics.hasNext())
 			// recherche si ce th�me est dans la liste des th�mes de la publication
 			String aliasDecoration = "&nbsp;";
 			String checked = "";
-			Iterator it = aliases.iterator();
-			while (it.hasNext())
+			for(Location location: locations)
 			{
-				Alias alias = (Alias) it.next();
-				String nodeId = alias.getId();
+				String nodeId = location.getId();
 
-				if (Integer.toString(topic.getId()).equals(nodeId) && topic.getNodePK().getInstanceId().equals(alias.getInstanceId()))
+				if (location.isNode(topic))
 				{
 					checked = " checked";
-					aliasDecoration = "<i>"+WebEncodeHelper.convertHTMLEntities(alias.getUserName())+" - "+resources.getOutputDateAndHour(alias.getDate())+"</i>";
+					aliasDecoration = "<i>"+WebEncodeHelper.convertHTMLEntities(location.getAlias().getUserName())+" - "+resources.getOutputDateAndHour(
+              location.getAlias().getDate())+"</i>";
 				}
 			}
 			boolean displayCheckbox = false;

--- a/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/service/QuickinfoStatistics.java
+++ b/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/service/QuickinfoStatistics.java
@@ -25,7 +25,6 @@
 package org.silverpeas.components.quickinfo.service;
 
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.silverstatistics.volume.model.UserIdCountVolumeCouple;
 import org.silverpeas.core.silverstatistics.volume.service.ComponentStatisticsProvider;
@@ -45,7 +44,7 @@ public class QuickinfoStatistics implements ComponentStatisticsProvider {
 
   @Override
   public Collection<UserIdCountVolumeCouple> getVolume(String spaceId, String componentId) {
-    Collection<PublicationDetail> infos = getQuickInfos(spaceId, componentId);
+    Collection<PublicationDetail> infos = getQuickInfos(componentId);
     List<UserIdCountVolumeCouple> myArrayList = new ArrayList<>(infos.size());
     for (PublicationDetail detail : infos) {
       UserIdCountVolumeCouple myCouple = new UserIdCountVolumeCouple();
@@ -63,8 +62,7 @@ public class QuickinfoStatistics implements ComponentStatisticsProvider {
     return publicationService;
   }
 
-  private Collection<PublicationDetail> getQuickInfos(String spaceId, String componentId) {
-    return getPublicationService()
-        .getOrphanPublications(new PublicationPK("", spaceId, componentId));
+  private Collection<PublicationDetail> getQuickInfos(String componentId) {
+    return getPublicationService().getOrphanPublications(componentId);
   }
 }

--- a/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
+++ b/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
@@ -624,8 +624,8 @@ public class DefaultWebSiteService implements WebSiteService {
         nodeService.createIndex(node);
       }
       // index all publications
-      PublicationPK pubPK = new PublicationPK(NO_ID, NO_ID, componentId);
-      Collection<PublicationDetail> publications = publicationService.getAllPublications(pubPK);
+      Collection<PublicationDetail> publications =
+          publicationService.getAllPublications(componentId);
       for (final PublicationDetail pub : publications) {
         publicationService.createIndex(pub);
       }

--- a/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
+++ b/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
@@ -355,7 +355,7 @@ public class DefaultWebSiteService implements WebSiteService {
   public void deletePublication(PublicationPK pubPK) {
 
     try {
-      publicationService.removeAllFather(pubPK);
+      publicationService.removeAllFathers(pubPK);
       publicationService.removePublication(pubPK);
     } catch (Exception re) {
       throw new WebSitesRuntimeException(re);

--- a/yellowpages/yellowpages-war/src/main/java/org/silverpeas/components/yellowpages/servlets/YellowpagesActionAccessController.java
+++ b/yellowpages/yellowpages-war/src/main/java/org/silverpeas/components/yellowpages/servlets/YellowpagesActionAccessController.java
@@ -43,10 +43,10 @@ public class YellowpagesActionAccessController {
 
 
   /**
-   * Check if user role has right access to the given action
+   * Check if user role has access right to the given action
    * @param action the checked action
    * @param role the highest user role
-   * @return true if given role has right access to the action
+   * @return true if given role has access right to the action
    */
   public boolean hasRightAccess(String action, SilverpeasRole role) {
     boolean actionExist = actionRole.containsKey(action);


### PR DESCRIPTION
Several problems were encountered and resolved here, all of them related to the shortcuts to a publication:
* Any other locations of a given publication in the same Kmelia instance weren't considered as a shortcut although it should be as it is wen the location is in another Kmelia instance.
* The copy or the move of a folder containing a shortcut copied or moved directly the original publication instead of just the shortcut
* The when deleting a folder containing at least one shortcut.

To address these problems, the Alias class is now renamed Location (because this class groups in fact two different concepts: the location of a publication and the alias (aka shortcut) of a publication). And this Location can return an Alias object in the case such a location is an alias of the original location of a given publication. By using the new class Location, it is now more easy to know if the father of a publication is an alias or not, whatever the component instance.

In Kmelia, the KmeliaPublication represents now a publication in Kmelia located in a given folder. For doing, it uses behind the scene the new Location class. With it, it can answer to the question of being or not an alias.