### PR TITLE
Bug #9194

### DIFF
--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -31,7 +31,7 @@ import org.silverpeas.components.blog.model.Category;
 import org.silverpeas.components.blog.model.PostDetail;
 import org.silverpeas.components.blog.notification.BlogUserSubscriptionNotification;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.comment.model.Comment;
 import org.silverpeas.core.comment.model.CommentPK;
@@ -194,7 +194,7 @@ public class DefaultBlogService implements BlogService {
       for (String userId : subscriberIds) {
         if (organizationController.isComponentAvailable(fatherPK.getInstanceId(), userId) &&
             (!node.haveRights() ||
-                organizationController.isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+                organizationController.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
                     fatherPK.getInstanceId(), userId))) {
           newSubscribers.add(userId);
         }

--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -31,7 +31,7 @@ import org.silverpeas.components.blog.model.Category;
 import org.silverpeas.components.blog.model.PostDetail;
 import org.silverpeas.components.blog.notification.BlogUserSubscriptionNotification;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.comment.model.Comment;
 import org.silverpeas.core.comment.model.CommentPK;
@@ -193,9 +193,9 @@ public class DefaultBlogService implements BlogService {
       final List<String> newSubscribers = new ArrayList<>(subscriberIds.size());
       for (String userId : subscriberIds) {
         if (organizationController.isComponentAvailable(fatherPK.getInstanceId(), userId) &&
-            (!node.haveRights() ||
-                organizationController.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
-                    fatherPK.getInstanceId(), userId))) {
+            (!node.haveRights() || organizationController.isObjectAvailable(
+                ProfiledObjectId.fromNode(node.getRightsDependsOn()), fatherPK.getInstanceId(),
+                userId))) {
           newSubscribers.add(userId);
         }
       }

--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -192,8 +192,8 @@ public class DefaultBlogService implements BlogService {
       NodeDetail node = getNodeBm().getHeader(fatherPK);
       final List<String> newSubscribers = new ArrayList<>(subscriberIds.size());
       for (String userId : subscriberIds) {
-        if (organizationController.isComponentAvailable(fatherPK.getInstanceId(), userId) &&
-            (!node.haveRights() || organizationController.isObjectAvailable(
+        if (organizationController.isComponentAvailableToUser(fatherPK.getInstanceId(), userId) &&
+            (!node.haveRights() || organizationController.isObjectAvailableToUser(
                 ProfiledObjectId.fromNode(node.getRightsDependsOn()), fatherPK.getInstanceId(),
                 userId))) {
           newSubscribers.add(userId);

--- a/gallery/gallery-library/src/test/java/org/silverpeas/components/gallery/notification/user/GalleryAlbumMediaSubscriptionNotificationBuilderTest.java
+++ b/gallery/gallery-library/src/test/java/org/silverpeas/components/gallery/notification/user/GalleryAlbumMediaSubscriptionNotificationBuilderTest.java
@@ -41,6 +41,8 @@ import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePath;
 import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.notification.user.UserNotification;
+import org.silverpeas.core.security.authorization.ComponentAccessControl;
+import org.silverpeas.core.security.authorization.NodeAccessControl;
 import org.silverpeas.core.subscription.ResourceSubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionResource;
 import org.silverpeas.core.subscription.service.ResourceSubscriptionProvider;
@@ -49,6 +51,7 @@ import org.silverpeas.core.subscription.util.SubscriptionSubscriberList;
 import org.silverpeas.core.test.extention.EnableSilverTestEnv;
 import org.silverpeas.core.test.extention.LocalizationBundleStub;
 import org.silverpeas.core.test.extention.TestManagedMock;
+import org.silverpeas.core.test.extention.TestManagedMocks;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -65,6 +68,7 @@ import static org.mockito.Mockito.when;
  * @author silveryocha
  */
 @EnableSilverTestEnv
+@TestManagedMocks({NodeAccessControl.class, ComponentAccessControl.class})
 class GalleryAlbumMediaSubscriptionNotificationBuilderTest {
 
   private static final String FR = "fr";

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
@@ -23,7 +23,7 @@ package org.silverpeas.components.kmelia;
 import org.silverpeas.components.kmelia.model.KmeliaRuntimeException;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
@@ -364,7 +364,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
         if (!node.haveRights()) {
           objectAvailable = true;
         } else {
-          objectAvailable = controller.isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+          objectAvailable = controller.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
               nodePK.getInstanceId(), userId);
         }
       } else {
@@ -393,7 +393,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
             lProfiles.addAll(Arrays.asList(getAppProfiles(userId, pubPK.getInstanceId())));
           } else {
             lProfiles.addAll(Arrays.asList(controller.getUserProfiles(userId,
-                pubPK.getInstanceId(), node.getRightsDependsOn(), ObjectType.NODE)));
+                pubPK.getInstanceId(), node.getRightsDependsOn(), ProfiledObjectType.NODE)));
           }
         }
       }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
@@ -23,7 +23,7 @@ package org.silverpeas.components.kmelia;
 import org.silverpeas.components.kmelia.model.KmeliaRuntimeException;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
@@ -364,8 +364,9 @@ public class KmeliaAuthorization implements ComponentAuthorization {
         if (!node.haveRights()) {
           objectAvailable = true;
         } else {
-          objectAvailable = controller.isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
-              nodePK.getInstanceId(), userId);
+          objectAvailable =
+              controller.isObjectAvailable(ProfiledObjectId.fromNode(node.getRightsDependsOn()),
+                  nodePK.getInstanceId(), userId);
         }
       } else {
         objectAvailable = false;
@@ -392,8 +393,8 @@ public class KmeliaAuthorization implements ComponentAuthorization {
           if (!node.haveRights()) {
             lProfiles.addAll(Arrays.asList(getAppProfiles(userId, pubPK.getInstanceId())));
           } else {
-            lProfiles.addAll(Arrays.asList(controller.getUserProfiles(userId,
-                pubPK.getInstanceId(), node.getRightsDependsOn(), ProfiledObjectType.NODE)));
+            lProfiles.addAll(Arrays.asList(controller.getUserProfiles(userId, pubPK.getInstanceId(),
+                ProfiledObjectId.fromNode(node.getRightsDependsOn()))));
           }
         }
       }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaAuthorization.java
@@ -251,7 +251,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
       return fromCache.get();
     }
 
-    boolean available = controller.isComponentAvailable(componentId, userId);
+    boolean available = controller.isComponentAvailableToUser(componentId, userId);
     writeInCache(componentId, available);
     return available;
   }
@@ -365,7 +365,7 @@ public class KmeliaAuthorization implements ComponentAuthorization {
           objectAvailable = true;
         } else {
           objectAvailable =
-              controller.isObjectAvailable(ProfiledObjectId.fromNode(node.getRightsDependsOn()),
+              controller.isObjectAvailableToUser(ProfiledObjectId.fromNode(node.getRightsDependsOn()),
                   nodePK.getInstanceId(), userId);
         }
       } else {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaInstanceManualUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaInstanceManualUserNotification.java
@@ -25,7 +25,7 @@
 package org.silverpeas.components.kmelia.notification;
 
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -99,6 +99,6 @@ public class KmeliaInstanceManualUserNotification extends
   }
 
   private String asResourceId(final int folderId) {
-    return ObjectType.NODE.getCode() + folderId;
+    return ProfiledObjectType.NODE.getCode() + folderId;
   }
 }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -31,7 +31,7 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationBehavior;
 import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.subscription.constant.SubscriberType;
-import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
+import org.silverpeas.core.subscription.constant.SubscriptionResourceType;
 import org.silverpeas.core.subscription.service.ResourceSubscriptionProvider;
 import org.silverpeas.core.subscription.util.SubscriptionSubscriberMapBySubscriberType;
 
@@ -62,8 +62,13 @@ public class KmeliaSubscriptionPublicationUserNotification
     // Subscribers
     // ###########
 
-    subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
-        .getSubscribersOfSubscriptionResource(NodeSubscriptionResource.from(getNodePK())));
+    if (getNodePK().isRoot()) {
+      subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
+          .getSubscribersOfComponent(getComponentInstanceId()));
+    } else {
+      subscriberIdsByTypes.addAll(ResourceSubscriptionProvider
+          .getSubscribersOfComponentAndTypedResource(getComponentInstanceId(), SubscriptionResourceType.NODE, getNodePK().getId()));
+    }
 
     Collection<String> allUserSubscriberIds = subscriberIdsByTypes.getAllUserIds();
     if (!allUserSubscriberIds.isEmpty()) {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -77,8 +77,8 @@ public class KmeliaSubscriptionPublicationUserNotification
       // Get only subscribers who have sufficient rights to read pubDetail
       final NodeDetail node = getNodeHeader(getNodePK());
       for (final String userId : allUserSubscriberIds) {
-        if (!orgaController.isComponentAvailable(getNodePK().getInstanceId(), userId) || (node.
-            haveRights() && !orgaController.isObjectAvailable(
+        if (!orgaController.isComponentAvailableToUser(getNodePK().getInstanceId(), userId) || (node.
+            haveRights() && !orgaController.isObjectAvailableToUser(
             ProfiledObjectId.fromNode(node.getRightsDependsOn()), getNodePK().getInstanceId(),
             userId))) {
           userIdsToExcludeFromNotifying.add(userId);

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -23,17 +23,17 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
+import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.contribution.publication.model.PublicationDetail;
+import org.silverpeas.core.node.model.NodeDetail;
+import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationBehavior;
+import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.subscription.constant.SubscriberType;
 import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.subscription.service.ResourceSubscriptionProvider;
 import org.silverpeas.core.subscription.util.SubscriptionSubscriberMapBySubscriberType;
-import org.silverpeas.core.notification.user.client.constant.NotifAction;
-import org.silverpeas.core.admin.ObjectType;
-import org.silverpeas.core.node.model.NodeDetail;
-import org.silverpeas.core.node.model.NodePK;
-import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.admin.service.OrganizationController;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -74,7 +74,7 @@ public class KmeliaSubscriptionPublicationUserNotification
       for (final String userId : allUserSubscriberIds) {
         if (!orgaController.isComponentAvailable(getNodePK().getInstanceId(), userId) || (node.
             haveRights() && !orgaController
-            .isObjectAvailable(node.getRightsDependsOn(), ObjectType.NODE,
+            .isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
                 getNodePK().getInstanceId(), userId))) {
           userIdsToExcludeFromNotifying.add(userId);
         }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
-import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -78,9 +78,9 @@ public class KmeliaSubscriptionPublicationUserNotification
       final NodeDetail node = getNodeHeader(getNodePK());
       for (final String userId : allUserSubscriberIds) {
         if (!orgaController.isComponentAvailable(getNodePK().getInstanceId(), userId) || (node.
-            haveRights() && !orgaController
-            .isObjectAvailable(node.getRightsDependsOn(), ProfiledObjectType.NODE,
-                getNodePK().getInstanceId(), userId))) {
+            haveRights() && !orgaController.isObjectAvailable(
+            ProfiledObjectId.fromNode(node.getRightsDependsOn()), getNodePK().getInstanceId(),
+            userId))) {
           userIdsToExcludeFromNotifying.add(userId);
         }
       }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
-import org.silverpeas.core.admin.ProfiledObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -91,11 +91,11 @@ public class KmeliaTopicUserNotification extends AbstractKmeliaFolderUserNotific
       profileNames.add("user");
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
+              ProfiledObjectId.fromNode(rightsDependOn), profileNames);
     } else if (alertType.equals("Publisher")) {
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
+              ProfiledObjectId.fromNode(rightsDependOn), profileNames);
     } else {
       users = null;
     }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaTopicUserNotification.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.notification;
 
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -91,11 +91,11 @@ public class KmeliaTopicUserNotification extends AbstractKmeliaFolderUserNotific
       profileNames.add("user");
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ObjectType.NODE, profileNames);
+              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
     } else if (alertType.equals("Publisher")) {
       users =
           getOrganisationController().getUsersIdsByRoleNames(getComponentInstanceId(),
-              String.valueOf(rightsDependOn), ObjectType.NODE, profileNames);
+              String.valueOf(rightsDependOn), ProfiledObjectType.NODE, profileNames);
     } else {
       users = null;
     }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -230,7 +230,7 @@ public class DefaultKmeliaService implements KmeliaService {
       if (isRightsOnTopicsUsed) {
         OrganizationController orga = getOrganisationController();
         if (nodeDetail.haveRights() &&
-            !orga.isObjectAvailable(ProfiledObjectId.fromNode(nodeDetail.getRightsDependsOn()),
+            !orga.isObjectAvailableToUser(ProfiledObjectId.fromNode(nodeDetail.getRightsDependsOn()),
                 pk.getInstanceId(),
                 userId)) {
           nodeDetail.setUserRole("noRights");
@@ -332,9 +332,8 @@ public class DefaultKmeliaService implements KmeliaService {
       final List<NodeDetail> availableChildren, final NodeDetail child) {
     int rightsDependsOn = child.getRightsDependsOn();
     boolean nodeAvailable =
-        getOrganisationController().isObjectAvailable(ProfiledObjectId.fromNode(rightsDependsOn),
-            pk.
-            getInstanceId(), userId);
+        getOrganisationController().isObjectAvailableToUser(ProfiledObjectId.fromNode(rightsDependsOn),
+            pk.getInstanceId(), userId);
     if (nodeAvailable) {
       availableChildren.add(child);
     } else { // check if at least one descendant is available
@@ -350,7 +349,7 @@ public class DefaultKmeliaService implements KmeliaService {
     while (!childAllowed && descendants.hasNext()) {
       NodeDetail descendant = descendants.next();
       if (descendant.getRightsDependsOn() != rightsDependsOn &&
-          getOrganisationController().isObjectAvailable(
+          getOrganisationController().isObjectAvailableToUser(
               ProfiledObjectId.fromNode(descendant.getRightsDependsOn()), pk.
                   getInstanceId(), userId)) {
         // different rights of father check if it is available

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -229,8 +229,9 @@ public class DefaultKmeliaService implements KmeliaService {
       nodeDetail = nodeService.getDetail(pk);
       if (isRightsOnTopicsUsed) {
         OrganizationController orga = getOrganisationController();
-        if (nodeDetail.haveRights() && !orga.isObjectAvailableToUser(
-            ProfiledObjectId.fromNode(nodeDetail.getRightsDependsOn()), pk.getInstanceId(),
+        if (nodeDetail.haveRights() &&
+            !orga.isObjectAvailable(ProfiledObjectId.fromNode(nodeDetail.getRightsDependsOn()),
+                pk.getInstanceId(),
                 userId)) {
           nodeDetail.setUserRole("noRights");
         }
@@ -330,8 +331,10 @@ public class DefaultKmeliaService implements KmeliaService {
   private void addAccordingToRights(final String userId, final NodePK pk,
       final List<NodeDetail> availableChildren, final NodeDetail child) {
     int rightsDependsOn = child.getRightsDependsOn();
-    boolean nodeAvailable = getOrganisationController().isObjectAvailableToUser(
-        ProfiledObjectId.fromNode(rightsDependsOn), pk.getInstanceId(), userId);
+    boolean nodeAvailable =
+        getOrganisationController().isObjectAvailable(ProfiledObjectId.fromNode(rightsDependsOn),
+            pk.
+            getInstanceId(), userId);
     if (nodeAvailable) {
       availableChildren.add(child);
     } else { // check if at least one descendant is available
@@ -347,9 +350,9 @@ public class DefaultKmeliaService implements KmeliaService {
     while (!childAllowed && descendants.hasNext()) {
       NodeDetail descendant = descendants.next();
       if (descendant.getRightsDependsOn() != rightsDependsOn &&
-          getOrganisationController().isObjectAvailableToUser(
-              ProfiledObjectId.fromNode(descendant.getRightsDependsOn()), pk.getInstanceId(),
-              userId)) {
+          getOrganisationController().isObjectAvailable(
+              ProfiledObjectId.fromNode(descendant.getRightsDependsOn()), pk.
+                  getInstanceId(), userId)) {
         // different rights of father check if it is available
         childAllowed = true;
         if (!availableChildren.contains(child)) {
@@ -1028,8 +1031,10 @@ public class DefaultKmeliaService implements KmeliaService {
     if (isRightsOnTopicsEnabled(nodePK.getInstanceId())) {
       NodeDetail topic = nodeService.getHeader(nodePK);
       if (topic.haveRights()) {
-        profile = KmeliaHelper.getProfile(orgCtrl.getUserProfiles(userId, nodePK.getInstanceId(),
-            ProfiledObjectId.fromNode(topic.getRightsDependsOn())));
+        ProfiledObjectId nodeId =
+            ProfiledObjectId.fromNode(topic.getRightsDependsOn());
+        profile = KmeliaHelper.getProfile(
+            orgCtrl.getUserProfiles(userId, nodePK.getInstanceId(), nodeId));
       } else {
         profile = KmeliaHelper.getProfile(getUserRoles(nodePK.getInstanceId(), userId));
       }
@@ -4010,8 +4015,7 @@ public class DefaultKmeliaService implements KmeliaService {
         if (descendant.haveLocalRights()) {
           // check if user is admin, publisher or writer on this topic
           String[] profiles = adminController.getProfilesByObjectAndUserId(
-              ProfiledObjectId.fromNode(descendant.getId()),
-                  componentId, userId);
+              ProfiledObjectId.fromNode(descendant.getNodePK().getId()), componentId, userId);
           if (profiles != null && profiles.length > 0) {
             userProfile = SilverpeasRole.from(KmeliaHelper.getProfile(profiles));
             checked = userProfile.isInRole(roles);

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilter.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilter.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.components.kmelia.service;
 
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
@@ -173,7 +173,7 @@ class KmeliaUserTreeViewFilter {
    */
   private String[] getNodeUserRoles(Integer nodeId) {
     if (nodeUserRoles == null) {
-      nodeUserRoles = orga.getUserObjectProfiles(userId, instanceId, ObjectType.NODE);
+      nodeUserRoles = orga.getUserObjectProfiles(userId, instanceId, ProfiledObjectType.NODE);
     }
     List<String> roles = nodeUserRoles.get(nodeId);
     return (roles != null) ? roles.toArray(new String[roles.size()]) : new String[0];

--- a/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilterTest.java
+++ b/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaUserTreeViewFilterTest.java
@@ -26,8 +26,7 @@ package org.silverpeas.components.kmelia.service;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.node.model.NodeDetail;
@@ -231,7 +230,7 @@ public class KmeliaUserTreeViewFilterTest {
     assertThat(node_AAB.haveRights(), is(true));
     assertThat(node_AAB.getChildrenDetails(), empty());
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_AAB_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -278,7 +277,7 @@ public class KmeliaUserTreeViewFilterTest {
       node.setRightsDependsOnMe();
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_AAA_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -299,7 +298,7 @@ public class KmeliaUserTreeViewFilterTest {
       node.setRightsDependsOnMe();
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_BA_ID, READER_ROLE, WRITER_ROLE));
 
     KmeliaUserTreeViewFilter
@@ -359,7 +358,7 @@ public class KmeliaUserTreeViewFilterTest {
       }
     }
 
-    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ObjectType.NODE))
+    when(organisationController.getUserObjectProfiles(USER_ID, INSTANCE_ID, ProfiledObjectType.NODE))
         .thenReturn(UserNodeRoleMapping.from(NODE_A_ID, ADMIN_ROLE, WRITER_ROLE)
             .put(NODE_AA_ID, WRITER_ROLE));
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/SearchContext.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/SearchContext.java
@@ -23,7 +23,9 @@
  */
 package org.silverpeas.components.kmelia;
 
-public class SearchContext {
+import java.io.Serializable;
+
+public class SearchContext implements Serializable {
 
   public static final int NONE = 0;
   public static final int GLOBAL = 1;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -646,7 +646,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       if (node.haveRights()) {
         int rightsDependsOn = node.getRightsDependsOn();
         ProfiledObjectId nodeRef = ProfiledObjectId.fromNode(rightsDependsOn);
-        return getOrganisationController().isObjectAvailable(nodeRef, getComponentId(), getUserId());
+        return getOrganisationController().isObjectAvailableToUser(nodeRef, getComponentId(), getUserId());
       }
     }
     return true;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -40,7 +40,8 @@ import org.silverpeas.components.kmelia.search.KmeliaSearchServiceProvider;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.ProfiledObjectId;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.component.model.ComponentInst;
 import org.silverpeas.core.admin.component.model.GlobalContext;
 import org.silverpeas.core.admin.service.AdminController;
@@ -643,8 +644,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       NodeDetail node = getNodeHeader(getCurrentFolderId());
       if (node.haveRights()) {
         int rightsDependsOn = node.getRightsDependsOn();
-        return getOrganisationController()
-            .isObjectAvailable(rightsDependsOn, ObjectType.NODE, getComponentId(), getUserId());
+        return getOrganisationController().isObjectAvailable(rightsDependsOn,
+            ProfiledObjectType.NODE, getComponentId(), getUserId());
       }
     }
     return true;
@@ -1650,7 +1651,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     }
     boolean haveRights = isRightsOnTopicsEnabled() && node.haveRights();
     if (haveRights) {
-      sug.setObjectId(ObjectType.NODE.getCode() + node.getRightsDependsOn());
+      sug.setObjectId(ProfiledObjectType.NODE.getCode() + node.getRightsDependsOn());
     }
     sug.setProfileNames(profiles);
 
@@ -2140,7 +2141,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     sel.setHtmlFormName("dummy");
 
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(nodeId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(nodeId, ProfiledObjectType.NODE.getCode(), getComponentId());
     ProfileInst topicProfile = getProfile(profiles, role);
 
     SelectionUsersGroups sug = new SelectionUsersGroups();
@@ -2181,9 +2182,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     topic.setRightsDependsOnMe();
     getNodeService().updateRightsDependency(topic);
 
-    profile.removeAllGroups();
-    profile.removeAllUsers();
-    profile.setGroupsAndUsers(groupIds, userIds);
+    profile.setUsers(Arrays.asList(userIds));
+    profile.setGroups(Arrays.asList(groupIds));
 
     if (StringUtil.isDefined(profile.getId())) {
       if (profile.isEmpty()) {
@@ -2193,8 +2193,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
         getAdmin().updateProfileInst(profile);
       }
     } else {
-      profile.setObjectId(Integer.parseInt(nodeId));
-      profile.setObjectType(ObjectType.NODE.getCode());
+      profile.setObjectId(new ProfiledObjectId(ProfiledObjectType.NODE, nodeId));
       profile.setComponentFatherId(getComponentId());
       // Create the profile
       getAdmin().addProfileInst(profile);
@@ -2203,7 +2202,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
 
   public ProfileInst getTopicProfile(String role, String topicId) {
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(topicId, ObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(topicId, ProfiledObjectType.NODE.getCode(),
+            getComponentId());
     for (ProfileInst profile: profiles) {
       if (profile.getName().equals(role)) {
         return profile;
@@ -2235,11 +2235,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       return inheritedProfile;
     } else {
       // merge des profiles
-      ProfileInst newProfile = (ProfileInst) profile.clone();
-      newProfile.setObjectFatherId(profile.getObjectFatherId());
-      newProfile.setObjectType(profile.getObjectType());
-      newProfile.setInherited(profile.isInherited());
-
+      ProfileInst newProfile = profile.copy();
       newProfile.addGroups(inheritedProfile.getAllGroups());
       newProfile.addUsers(inheritedProfile.getAllUsers());
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -114,6 +114,7 @@ import org.silverpeas.core.security.authorization.NodeAccessController;
 import org.silverpeas.core.security.authorization.PublicationAccessController;
 import org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail;
 import org.silverpeas.core.silverstatistics.access.service.StatisticService;
+import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
 import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.template.SilverpeasTemplateFactory;
@@ -3142,11 +3143,15 @@ public class KmeliaSessionController extends AbstractComponentSessionController
   }
 
   public String manageSubscriptions() {
-    SubscriptionContext subscriptionContext = getSubscriptionContext();
-    List<NodeDetail> nodePath = getTopicPath(getCurrentFolderId());
-    nodePath.remove(0);
-    subscriptionContext
-        .initializeFromNode(NodeSubscriptionResource.from(getCurrentFolderPK()), nodePath);
+    final SubscriptionContext subscriptionContext = getSubscriptionContext();
+    if (getCurrentFolder().getNodePK().isRoot()) {
+      subscriptionContext.initialize(ComponentSubscriptionResource.from(getComponentId()));
+    } else {
+      List<NodeDetail> nodePath = getTopicPath(getCurrentFolderId());
+      nodePath.remove(0);
+      subscriptionContext.initializeFromNode(NodeSubscriptionResource.from(getCurrentFolderPK()),
+          nodePath);
+    }
     return subscriptionContext.getDestinationUrl();
   }
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -645,8 +645,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
       NodeDetail node = getNodeHeader(getCurrentFolderId());
       if (node.haveRights()) {
         int rightsDependsOn = node.getRightsDependsOn();
-        return getOrganisationController().isObjectAvailable(rightsDependsOn,
-            ProfiledObjectType.NODE, getComponentId(), getUserId());
+        ProfiledObjectId nodeRef = ProfiledObjectId.fromNode(rightsDependsOn);
+        return getOrganisationController().isObjectAvailable(nodeRef, getComponentId(), getUserId());
       }
     }
     return true;
@@ -2142,7 +2142,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     sel.setHtmlFormName("dummy");
 
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(nodeId, ProfiledObjectType.NODE.getCode(), getComponentId());
+        getAdmin().getProfilesByObject(ProfiledObjectId.fromNode(nodeId), getComponentId());
     ProfileInst topicProfile = getProfile(profiles, role);
 
     SelectionUsersGroups sug = new SelectionUsersGroups();
@@ -2203,8 +2203,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
 
   public ProfileInst getTopicProfile(String role, String topicId) {
     List<ProfileInst> profiles =
-        getAdmin().getProfilesByObject(topicId, ProfiledObjectType.NODE.getCode(),
-            getComponentId());
+        getAdmin().getProfilesByObject(ProfiledObjectId.fromNode(topicId), getComponentId());
     for (ProfileInst profile: profiles) {
       if (profile.getName().equals(role)) {
         return profile;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
@@ -23,6 +23,7 @@ package org.silverpeas.components.kmelia.importexport;
 import org.silverpeas.components.kmelia.KmeliaException;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
+import org.silverpeas.core.admin.ProfiledObjectId;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.UserDetail;
@@ -33,7 +34,6 @@ import org.silverpeas.core.importexport.control.GEDImportExport;
 import org.silverpeas.core.importexport.model.ImportExportException;
 import org.silverpeas.core.importexport.report.MassiveReport;
 import org.silverpeas.core.importexport.report.UnitReport;
-import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.util.ServiceProvider;
@@ -108,8 +108,8 @@ public class KmeliaImportExport extends GEDImportExport {
           .getInstanceId(), "rightsOnTopics"))) {
         NodeDetail topic = getNodeService().getHeader(topicPK);
         if (topic.haveRights()) {
-          profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
-              .getId(), topicPK.getInstanceId(), topic.getRightsDependsOn(), ProfiledObjectType.NODE));
+          profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail.getId(),
+              topicPK.getInstanceId(), ProfiledObjectId.fromNode(topic.getRightsDependsOn())));
         } else {
           profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
               .getId(), topicPK.getInstanceId()));

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/importexport/KmeliaImportExport.java
@@ -23,7 +23,6 @@ package org.silverpeas.components.kmelia.importexport;
 import org.silverpeas.components.kmelia.KmeliaException;
 import org.silverpeas.components.kmelia.service.KmeliaHelper;
 import org.silverpeas.components.kmelia.service.KmeliaService;
-import org.silverpeas.core.admin.ObjectType;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.UserDetail;
@@ -34,6 +33,7 @@ import org.silverpeas.core.importexport.control.GEDImportExport;
 import org.silverpeas.core.importexport.model.ImportExportException;
 import org.silverpeas.core.importexport.report.MassiveReport;
 import org.silverpeas.core.importexport.report.UnitReport;
+import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.util.ServiceProvider;
@@ -109,7 +109,7 @@ public class KmeliaImportExport extends GEDImportExport {
         NodeDetail topic = getNodeService().getHeader(topicPK);
         if (topic.haveRights()) {
           profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
-              .getId(), topicPK.getInstanceId(), topic.getRightsDependsOn(), ObjectType.NODE));
+              .getId(), topicPK.getInstanceId(), topic.getRightsDependsOn(), ProfiledObjectType.NODE));
         } else {
           profile = KmeliaHelper.getProfile(orgnaisationController.getUserProfiles(userDetail
               .getId(), topicPK.getInstanceId()));

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxServlet.java
@@ -90,7 +90,7 @@ public class AjaxServlet extends HttpServlet {
         MainSessionController.MAIN_SESSION_CONTROLLER_ATT);
     if (msc != null) {
       ComponentContext componentContext = msc.createComponentContext(null, componentId);
-      if (organizationController.isComponentAvailable(componentId, msc.getUserId())) {
+      if (organizationController.isComponentAvailableToUser(componentId, msc.getUserId())) {
         return new KmeliaSessionController(msc, componentContext);
       }
     }

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/JSONServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/JSONServlet.java
@@ -144,7 +144,8 @@ public class JSONServlet extends HttpServlet {
 
         operations.put("exportSelection", !user.isAnonymous());
         operations.put("manageSubscriptions", isAdmin);
-        operations.put("subscriptions", !user.isAnonymous());
+        operations.put("subscriptions", isRoot && !user.isAnonymous());
+        operations.put("topicSubscriptions", !isRoot && !user.isAnonymous());
         operations.put("favorites", !isRoot && !user.isAnonymous());
         if (isRoot && canShowStats) {
           operations.put("statistics", true);

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -395,6 +395,13 @@ function initOperations(id, op) {
   }
 
   if (op.subscriptions) {
+    label = getString('GML.subscribe');
+    url = "javascript:onclick=addSubscription()";
+    menuItem = new YAHOO.widget.MenuItem(label, {url: url});
+    oMenu.addItem(menuItem, groupIndex);
+    groupEmpty = false;
+    //addCreationItem(url, icons["operation.subscribe"], label);
+  } else if (op.topicSubscriptions) {
     label = getString('SubscriptionsAdd');
     url = "javascript:onclick=addSubscription()";
     menuItem = new YAHOO.widget.MenuItem(label, {url: url});
@@ -402,6 +409,7 @@ function initOperations(id, op) {
     groupEmpty = false;
     //addCreationItem(url, icons["operation.subscribe"], label);
   }
+
   if (op.favorites) {
     label = getString('FavoritesAdd1') + ' ' + getString('FavoritesAdd2');
     url = "javascript:onclick=addCurrentNodeAsFavorite()";

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/simpleListOfPublications.jsp
@@ -73,9 +73,10 @@ boolean userCanSeeStats = kmeliaScc.isStatisticAllowed();
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.kmelia">
+<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.kmelia" xml:lang="<%=language%>">
 <head>
 <view:looknfeel/>
+	<title></title>
 <view:includePlugin name="popup"/>
 <view:includePlugin name="preview"/>
 <view:includePlugin name="rating" />
@@ -199,7 +200,7 @@ $(document).ready(function() {
 
     	if (!isGuest) {
     	  	operationPane.addOperation("useless", resources.getString("kmelia.operation.exportSelection"), "javascript:onclick=exportPublications()");
-    		operationPane.addOperation("useless", resources.getString("kmelia.folderSubscription"), "javascript:onClick=addSubscription()");
+    		operationPane.addOperation("useless", resources.getString("GML.subscribe"), "javascript:onClick=addSubscription()");
       		operationPane.addOperation("useless", resources.getString("FavoritesAdd1")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+
               WebEncodeHelper.javaStringToHtmlString(WebEncodeHelper.javaStringToJsString(namePath))+"','','"+urlTopic+"')");
     	}
@@ -223,7 +224,8 @@ $(document).ready(function() {
 						Button searchButton = gef.getFormButton(resources.getString("GML.search"), "javascript:onClick=searchInTopic();", false); %>
 						<div id="searchZone">
 						<view:board>
-						<table id="searchLine">
+						<table id="searchLine"  aria-describedby="search">
+							<th id="searchHeader"></th>
 						<tr><td><div id="searchLabel"><%=resources.getString("kmelia.SearchInTopics") %></div>&nbsp;<input type="text" id="topicQuery" size="50" value="<%=query%>" onkeydown="checkSubmitToSearch(event)"/></td><td><%=searchButton.print() %></td></tr>
 						</table>
 						</view:board>
@@ -236,8 +238,8 @@ $(document).ready(function() {
               <br/>
               <view:board>
                 <br/>
-                <center><%=resources.getString("kmelia.inProgressPublications") %>
-                  <br/><br/><img src="<%=resources.getIcon("kmelia.progress") %>"/></center>
+                <span text-align="center"><%=resources.getString("kmelia.inProgressPublications") %>
+                  <br/><br/><img alt="progress..." src="<%=resources.getIcon("kmelia.progress") %>"/></span>
                 <br/>
               </view:board>
             </div>

--- a/projectManager/projectManager-war/src/main/java/org/silverpeas/components/projectmanager/servlets/ProjectManagerRequestRouter.java
+++ b/projectManager/projectManager-war/src/main/java/org/silverpeas/components/projectmanager/servlets/ProjectManagerRequestRouter.java
@@ -387,9 +387,9 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
     if ("admin".equals(projectManagerSC.getRole())) {
       task.setResponsableId(Integer.parseInt(request.getParameter("ResponsableId")));
       task.setNom(request.getParameter("Nom"));
-      task.setCharge(StringUtil.convertFloat(request.getParameter("Charge")));
-      task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-      task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+      task.setCharge(StringUtil.asFloat(request.getParameter("Charge")));
+      task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+      task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
       task.setStatut(Integer.valueOf(request.getParameter("Statut")));
       task.setDescription(request.getParameter("Description"));
       task.setDateDebut(projectManagerSC.uiDate2Date(request.getParameter("DateDebut")));
@@ -398,8 +398,8 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
 
       task.setResources(request2Resources(request));
     } else if ("responsable".equals(projectManagerSC.getRole())) {
-      task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-      task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+      task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+      task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
       task.setStatut(Integer.valueOf(request.getParameter("Statut")));
       task.setResources(request2Resources(request));
     }
@@ -425,9 +425,9 @@ public class ProjectManagerRequestRouter extends ComponentRequestRouter<ProjectM
     }
 
     task.setNom(request.getParameter("Nom"));
-    task.setCharge(StringUtil.convertFloat(request.getParameter("Charge")));
-    task.setConsomme(StringUtil.convertFloat(request.getParameter("Consomme")));
-    task.setRaf(StringUtil.convertFloat(request.getParameter("Raf")));
+    task.setCharge(StringUtil.asFloat(request.getParameter("Charge")));
+    task.setConsomme(StringUtil.asFloat(request.getParameter("Consomme")));
+    task.setRaf(StringUtil.asFloat(request.getParameter("Raf")));
     task.setStatut(Integer.parseInt(request.getParameter("Statut")));
     task.setDescription(request.getParameter("Description"));
     task.setDateDebut(projectManagerSC.uiDate2Date(request.getParameter("DateDebut")));

--- a/silverCrawler/silverCrawler-war/src/main/java/org/silverpeas/components/silvercrawler/servlets/SilverCrawlerFileServer.java
+++ b/silverCrawler/silverCrawler-war/src/main/java/org/silverpeas/components/silvercrawler/servlets/SilverCrawlerFileServer.java
@@ -97,7 +97,7 @@ public class SilverCrawlerFileServer extends SilverpeasAuthenticatedHttpServlet 
 
     // Check user rights on identified component
     if (!OrganizationControllerProvider.getOrganisationController()
-        .isComponentAvailable(componentId, userId)) {
+        .isComponentAvailableToUser(componentId, userId)) {
       throwHttpForbiddenError();
     }
 

--- a/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/DefaultSuggestionBoxService.java
+++ b/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/model/DefaultSuggestionBoxService.java
@@ -30,8 +30,6 @@ import org.silverpeas.core.comment.service.CommentService;
 import org.silverpeas.core.contribution.attachment.AttachmentService;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.rating.service.RatingService;
-import org.silverpeas.core.subscription.SubscriptionServiceProvider;
-import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.SettingBundle;
 
@@ -88,10 +86,6 @@ public class DefaultSuggestionBoxService implements SuggestionBoxService {
     // Deletion of all attachments, WYSIWYG comprised.
     AttachmentService attachmentService = AttachmentServiceProvider.getAttachmentService();
     attachmentService.deleteAllAttachments(box.getComponentInstanceId());
-
-    // Deleting all component subscriptions
-    SubscriptionServiceProvider.getSubscribeService()
-        .unsubscribeByResource(ComponentSubscriptionResource.from(box.getComponentInstanceId()));
 
     // Deleting all user ratings
     RatingService.get().deleteComponentRatings(box.getComponentInstanceId());

--- a/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
+++ b/survey/survey-war/src/main/java/org/silverpeas/components/survey/control/SurveySessionController.java
@@ -211,7 +211,7 @@ public class SurveySessionController extends AbstractComponentSessionController 
 
     UserDetail user = getUserDetail();
     if (user.isAnonymous() && (getComponentId() != null &&
-        getOrganisationController().isComponentAvailable(getComponentId(), user.getId()))) {
+        getOrganisationController().isComponentAvailableToUser(getComponentId(), user.getId()))) {
       userIsAnonymous = true;
     }
     return userIsAnonymous;


### PR DESCRIPTION
Don't forget to take into account before PR https://github.com/Silverpeas/Silverpeas-Core/pull/1008
    
    Up to now, subscriptions in Kmelia was managed as they were only done on a
    folder. In this behaviour, the subscription in a whole Kmelia application
    instance was done like it is a subscription on the root folder of the Kmelia
    instance. This brokes the coherence with others Silverpeas applications in
    which the subscription on an application instance is different than a
    subscription on a resource managed by the application instance.
    So, to keep the same behaviour in the subscriptions in Kmelia than in others
    applications, the way the subscriptions are managed in Kmelia is changed:
    the subscription on the whole Kmelia instance (that is considered in Kmelia as
    a subscription on the root folder) is performed as such in the subscription
    service like any others applications and thus the subscriptions are fetched

    Update some Silverpeas components (aka applications) with some changes in
    Silverpeas-Core: the main change is to structure the objects concerned by a
    right access profile into an object: ProfiledObjectId. This object is an
    identifier to a given resource in Silverpeas and that is convered directly by a
    right profile. AS the referred object can be any type, its type is indicated
    by the enum ProfiledObjectType and it's embodied in the ProfileObjectId.

    Take into account the changes in the Admin and OrganizationController API
    (mainly the checking a user can access a component instance or a resource of a
    component instance).