### PR TITLE
Bug #8487

### DIFF
--- a/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/model/predicates/Like.java
+++ b/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/model/predicates/Like.java
@@ -45,7 +45,7 @@ public class Like extends AbstractColumnValuePredicate {
 
   @Override
   public JdbcSqlQuery apply(final JdbcSqlQuery query) {
-    return query.where(getColumn().getName() + " like ?", getNormalizedValue());
+    return query.where("lower(" + getColumn().getName() + ") like lower(?)", getNormalizedValue());
   }
 }
   


### PR DESCRIPTION
Now, in MyDB, when requesting some tuples matching a given criterion with the
like operator, the LOWER() function is applied both in the field and in the
criterion value to perform an insensitive case search in the database.