### PR TITLE
Bug #8896

### DIFF
--- a/webPages/webPages-configuration/src/main/config/xmlcomponents/webPages.xml
+++ b/webPages/webPages-configuration/src/main/config/xmlcomponents/webPages.xml
@@ -77,6 +77,8 @@
   </profiles>
   <parameters>
     <parameter>
+      <!-- the name of the parameter is defined by the ResourceSubscriptionService interface as it
+      is used to automatically listen any value change of this parameter -->
       <name>useSubscription</name>
       <label>
         <message lang="fr">Gestion de l'abonnement</message>

--- a/webPages/webPages-library/src/main/java/org/silverpeas/components/webpages/WebPagesWysiwygEventListener.java
+++ b/webPages/webPages-library/src/main/java/org/silverpeas/components/webpages/WebPagesWysiwygEventListener.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.contribution.model.WysiwygContent;
 import org.silverpeas.core.contribution.content.wysiwyg.notification.WysiwygEvent;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.core.subscription.ResourceSubscriptionService;
 
 import javax.inject.Inject;
 
@@ -56,8 +57,8 @@ public class WebPagesWysiwygEventListener extends CDIResourceEventListener<Wysiw
     String componentId = content.getContribution().getContributionId().getComponentInstanceId();
 
     // If parameter useSubscription is used
-    if ("yes".equals(
-        organisationController.getComponentParameterValue(componentId, "useSubscription"))) {
+    if ("yes".equals(organisationController.getComponentParameterValue(componentId,
+        ResourceSubscriptionService.Constants.SUBSCRIPTION_PARAMETER))) {
       if (isAboutWebPage(content)) {
         WebPagesUserNotifier.notify(new NodePK("0", componentId), userId);
       }

--- a/webPages/webPages-war/src/main/java/org/silverpeas/components/webpages/control/WebPagesSessionController.java
+++ b/webPages/webPages-war/src/main/java/org/silverpeas/components/webpages/control/WebPagesSessionController.java
@@ -41,6 +41,7 @@ import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.index.indexing.model.FullIndexEntry;
 import org.silverpeas.core.index.indexing.model.IndexEngineProxy;
 import org.silverpeas.core.node.model.NodePK;
+import org.silverpeas.core.subscription.ResourceSubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionService;
 import org.silverpeas.core.subscription.SubscriptionServiceProvider;
 import org.silverpeas.core.subscription.service.ComponentSubscription;
@@ -122,7 +123,8 @@ public class WebPagesSessionController extends AbstractComponentSessionControlle
    * @return boolean
    */
   public boolean isSubscriptionUsed() {
-    return StringUtil.getBooleanValue(getComponentParameterValue("useSubscription"));
+    return StringUtil.getBooleanValue(
+        getComponentParameterValue(ResourceSubscriptionService.Constants.SUBSCRIPTION_PARAMETER));
   }
 
   /*


### PR DESCRIPTION
The name of the subscription activation parameter is now a constant defined in
the ResourceSubscriptionService. Any components that supports such a parameter
have to use it instead of its own parameter name. With such a constant, the
management of subscriptions related to this parameter can be done automatically
by the subscription service.

Don't forget to merge before https://github.com/Silverpeas/Silverpeas-Core/pull/1016