### PR TITLE
Bug #11109

### DIFF
--- a/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/model/DbColumn.java
+++ b/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/model/DbColumn.java
@@ -149,7 +149,7 @@ public class DbColumn {
    * @return true if a default value is defined for this column, false otherwise.
    */
   public boolean isDefaultValueDefined() {
-    return getDefaultValue() != null;
+    return this.descriptor.getDefaultValue().isDefined();
   }
 
   /**
@@ -158,7 +158,7 @@ public class DbColumn {
    * @return as a {@link String} the default value of this column.
    */
   public String getDefaultValue() {
-    return this.descriptor.getDefaultValue();
+    return this.descriptor.getDefaultValue().get();
   }
 
   /**

--- a/mydb/mydb-war/src/main/webapp/myDB/jsp/mydb.jsp
+++ b/mydb/mydb-war/src/main/webapp/myDB/jsp/mydb.jsp
@@ -247,15 +247,19 @@
     /**
      * Open the specified table to select a row as foreign key when inserting a new row in the
      * current table. This function is invoked by the JSP rendered into the popup of row adding.
+     * The HTML input id is specified to set its value with the selected value of the given column
+     * in the specified table.
      */
-    function openForeignKey(refTableName, refColumnName) {
-      jsonFkRowId = sp.element.querySelectorAll('.field-fk-reftable-' + refTableName)
+    function openForeignKey(inputId, refTableName, refColumnName) {
+      jsonFkRowId = sp.element.querySelectorAll('#' + inputId)
           .map(function(i) {
             return {
               'f' : i.getAttribute('rel').replace(/field-fk-refcolumn-(.+)/gi, '$1'),
               'v' : i.value
             }
           });
+      console.log('input id is ', inputId);
+      console.log('json fk row id is ', jsonFkRowId);
       sp.ajaxRequest('ViewTargetTable')
           .withParam('${tableView}', refTableName)
           .withParam('${foreignKeyTarget}', refColumnName)
@@ -263,9 +267,7 @@
         function(response) {
           renderRowForm(refTableName, response, function(row) {
             jsonFkRowId.forEach(function(fieldValue) {
-              sp.element.querySelector(".field-fk-reftable-" +
-                  refTableName + "[rel='field-fk-refcolumn-" +
-                  fieldValue.f + "']").value = fieldValue.v;
+              sp.element.querySelector('#' + inputId).value = fieldValue.v;
             });
           });
         });

--- a/mydb/mydb-war/src/main/webapp/myDB/jsp/rowForm.jsp
+++ b/mydb/mydb-war/src/main/webapp/myDB/jsp/rowForm.jsp
@@ -110,7 +110,7 @@
                 </c:choose>
                 <c:if test="${field.foreignKey}">
                   <c:set var="readOnlyAttr" value="readonly"/>
-                  <c:set var="foreignKeyOpening" value="window.openForeignKey('${field.referencedTable}', '${field.referencedColumn}')"/>
+                  <c:set var="foreignKeyOpening" value="window.openForeignKey('${fieldInputId}', '${field.referencedTable}', '${field.referencedColumn}')"/>
                   <c:set var="displayForeignKeyLegend" value="true"/>
                   <c:set var="fieldClass" value="${fieldClass} foreign-key-value field-fk-reftable-${field.referencedTable}"/>
                   <c:set var="fieldRefColumn" value="field-fk-refcolumn-${field.referencedColumn}"/>


### PR DESCRIPTION
Fix bug #11109. In MyDB, several foreign keys on the same table can be now set
when updating or inserting a new row.

Fix another discovered bug: simple default value of fields in MyDB weren't
taken into account.

Add a new feature: computed default value of fields are now taken in charge:
MyDB asks for the database to compute it. As some default value computation
depends on the context on which they are invoked, the default value is now
figuring out on the demand.