### PR TITLE
Feature #10260: creating standard and synchronized calendars from an Almanach instance (without using aggregation).

### DIFF
--- a/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach.properties
+++ b/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach.properties
@@ -98,7 +98,6 @@ almanach.dialog.update = Modifier un \u00e9v\u00e9nement
 almanach.dialog.delete = Supprimer un \u00e9v\u00e9nement
 
 almanach.exportInProgress = Exportation en cours ...
-almanach.exportToIcal = Exporter au format iCal
 almanach.export.ical.success = Exportation r\u00e9ussie ...
 almanach.export.ical.empty=Le calendrier est vide. Aucun \u00e9l\u00e9ment \u00e0 exporter.
 almanach.export.ical.failure=L'exportation du calendrier au format iCal a \u00e9chou\u00e9 !

--- a/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_de.properties
+++ b/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_de.properties
@@ -106,7 +106,6 @@ almanach.popup = (surfen\u00eatre)
 almanach.browsebar.yearEvents = Ereignisse des Jahres
 almanach.browsebar.monthEvents = Ereignisse des laufenden Monates
 almanach.exportInProgress = Export wird ausgef\u00fchrt...
-almanach.exportToIcal = Export im iCal Format
 almanach.export.ical.success = Exporte erfolgreich ausgef\u00fchrt !
 almanach.export.ical.empty=Der Kalender ist leer. Nichts zu exportieren.
 almanach.export.ical.failure=Der Export des Kalenders im iCal Format ist gescheitert !

--- a/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_en.properties
+++ b/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_en.properties
@@ -106,7 +106,6 @@ almanach.browsebar.yearEvents = events of the year
 almanach.browsebar.monthEvents = events of the month
 
 almanach.exportInProgress = Export in progress...
-almanach.exportToIcal = Export to iCal format
 almanach.export.ical.success = Successful export ...
 almanach.export.ical.empty=The calendar is empty. No events to export.
 almanach.export.ical.failure = Export failed!

--- a/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_fr.properties
+++ b/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/multilang/almanach_fr.properties
@@ -108,7 +108,6 @@ almanach.browsebar.yearEvents = \u00e9v\u00e9nements de l'ann\u00e9e
 almanach.browsebar.monthEvents = \u00e9v\u00e9nements du mois courant
 
 almanach.exportInProgress = Exportation en cours...
-almanach.exportToIcal = Exporter au format iCal
 almanach.export.ical.success = Exportation r\u00e9ussie !
 almanach.export.ical.empty=Le calendrier est vide. Aucun \u00e9l\u00e9ment \u00e0 exporter.
 almanach.export.ical.failure=L'exportation du calendrier au format iCal a \u00e9chou\u00e9 !

--- a/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/settings/almanachIcons.properties
+++ b/almanach/almanach-configuration/src/main/config/properties/org/silverpeas/almanach/settings/almanachIcons.properties
@@ -21,4 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 almanach.icons.addEvent=/util/icons/create-action/add-event.png
+almanach.icons.addCalendar=/util/icons/create-action/add-table.png
+almanach.icons.addSynchronizedCalendar=/util/icons/create-action/add-remote-calendar.png
 almanach.icons.paramPdc=/pdcPeas/jsp/icons/pdcPeas_paramPdc.gif

--- a/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/services/AlmanachWebManager.java
+++ b/almanach/almanach-war/src/main/java/org/silverpeas/components/almanach/services/AlmanachWebManager.java
@@ -50,7 +50,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.silverpeas.components.almanach.AlmanachSettings.*;
 import static org.silverpeas.core.admin.service.OrganizationControllerProvider.getOrganisationController;
 import static org.silverpeas.core.util.StringUtil.getBooleanValue;
@@ -67,11 +68,6 @@ public class AlmanachWebManager extends CalendarWebManager {
   private ComponentAccessControl componentAccessController;
 
   protected AlmanachWebManager() {
-  }
-
-  @Override
-  public List<Calendar> getCalendarsHandledBy(final String componentInstanceId) {
-    return getCalendarsHandledBy(singleton(componentInstanceId));
   }
 
   @Override

--- a/almanach/almanach-war/src/main/webapp/almanach/jsp/almanach.jsp
+++ b/almanach/almanach-war/src/main/webapp/almanach/jsp/almanach.jsp
@@ -58,21 +58,19 @@
 <fmt:message key="GML.PDCParam" var="classifyLabel"/>
 <fmt:message key="GML.print" var="printLabel" bundle="${calendarBundle}"/>
 <fmt:message key="calendar.menu.item.event.add" var="addEventLabel" bundle="${calendarBundle}"/>
-<fmt:message key="almanach.exportToIcal" var="exportEventLabel"/>
 <fmt:message key="almanach.menu.item.calendar.see.mine" var="viewMyCalendarLabel" bundle="${calendarBundle}"/>
+<fmt:message key="calendar.menu.item.calendar.create" var="createCalendarLabel" bundle="${calendarBundle}"/>
+<fmt:message key="calendar.menu.item.calendar.synchronized.create" var="createSynchronizedCalendarLabel" bundle="${calendarBundle}"/>
+<fmt:message key="calendar.menu.item.event.import" var="importEventLabel" bundle="${calendarBundle}"/>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.almanachcalendar" xml:lang="${currentUserLanguage}">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <view:looknfeel/>
-  <title></title>
+<view:sp-page angularJsAppName="silverpeas.almanachcalendar" angularJsAppInitializedManually="true">
+<view:sp-head-part>
   <view:includePlugin name="calendar"/>
   <view:includePlugin name="toggle"/>
   <view:script src="/almanach/jsp/javaScript/angularjs/services/almanachcalendar.js"/>
   <view:script src="/almanach/jsp/javaScript/angularjs/almanachcalendar.js"/>
-</head>
-<body ng-controller="calendarController">
+</view:sp-head-part>
+<view:sp-body-part ngController="calendarController">
 <view:operationPane>
   <view:operation action="javascript:print()" altText="${printLabel}"/>
   <c:if test="${canCreateEvent}">
@@ -88,10 +86,23 @@
     <c:url var="opIcon" value="${opIcon}"/>
     <view:operationOfCreation action="angularjs:newEvent()"
                               altText="${addEventLabel}" icon="${opIcon}"/>
+    <c:if test='${highestUserRole.isGreaterThanOrEquals(adminRole)}'>
+      <silverpeas-calendar-management api="calMng"
+                                      on-created="almanachCalendar.addCalendar(calendar)"
+                                      on-imported-events="almanachCalendar.refetchCalendars()"></silverpeas-calendar-management>
+      <fmt:message key="almanach.icons.addCalendar" var="opIcon" bundle="${icons}"/>
+      <c:url var="opIcon" value="${opIcon}"/>
+      <view:operationOfCreation action="angularjs:calMng.add()"
+                                altText="${createCalendarLabel}" icon="${opIcon}"/>
+      <fmt:message key="almanach.icons.addSynchronizedCalendar" var="opIcon" bundle="${icons}"/>
+      <c:url var="opIcon" value="${opIcon}"/>
+      <view:operationOfCreation action="angularjs:calMng.add(true)"
+                                altText="${createSynchronizedCalendarLabel}" icon="${opIcon}"/>
+    </c:if>
   </c:if>
-  <view:operationSeparator/>
-  <view:operation action="${mainCalendar.getURI()}/export/ical"
-                  altText="${exportEventLabel}"/>
+  <view:operationSeparator />
+  <view:operation action="angularjs:calMng.importICalEvents(almanachCalendar.getCalendars())"
+                  altText="${importEventLabel}"/>
   <view:operationSeparator/>
   <view:operation action="angularjs:viewMyCalendar()"
                   altText="${viewMyCalendarLabel}"/>
@@ -103,7 +114,8 @@
   <view:frame>
     <view:componentInstanceIntro componentId="${componentId}" language="${currentUserLanguage}"/>
     <view:areaOfOperationOfCreation/>
-    <silverpeas-calendar participation-user-ids="participationIds"
+    <silverpeas-calendar api="almanachCalendar"
+                         participation-user-ids="participationIds"
                          filter-on-pdc="${filterOnPdc}"
                          on-day-click="${canCreateEvent ? 'newEvent(startMoment)' : ''}"
                          on-event-occurrence-view="viewEventOccurrence(occurrence)"
@@ -123,5 +135,5 @@
     limit : ${nextEventViewLimit}
   });
 </script>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>


### PR DESCRIPTION
- adding the new creation actions into the main menu
- adding the possibility to import event from an ICal file
- removing export menu action which was targeting the main calendar only
- cleaning some code

Linked to PR: https://github.com/Silverpeas/Silverpeas-Core/pull/1081

Checking the integration with https://easybacklog.com/accounts/4659/backlogs/355925