### PR TITLE
Feature #11581 : Contacts with custom form on root

### DIFF
--- a/yellowpages/yellowpages-configuration/src/main/config/xmlcomponents/yellowpages.xml
+++ b/yellowpages/yellowpages-configuration/src/main/config/xmlcomponents/yellowpages.xml
@@ -120,5 +120,23 @@
         <message lang="en">Allows to quickly access to others 'Contacts' applications</message>
       </help>
     </parameter>
+    <parameter>
+      <name>xmlTemplate</name>
+      <label>
+        <message lang="fr">Formulaire</message>
+        <message lang="en">Custom form</message>
+        <message lang="de">Benutzerdefiniertes Formular</message>
+      </label>
+      <order>2</order>
+      <mandatory>false</mandatory>
+      <value/>
+      <type>xmltemplates</type>
+      <updatable>creation</updatable>
+      <help>
+        <message lang="fr">Permet d'utiliser un formulaire pour les contacts hors rubriques</message>
+        <message lang="en">Allows you to use a form for contacts outside the headings</message>
+        <message lang="de">Ermöglicht die Verwendung eines Formulars für Kontakte außerhalb der Überschriften</message>
+      </help>
+    </parameter>
   </parameters>
 </WAComponent>

--- a/yellowpages/yellowpages-library/src/main/java/org/silverpeas/components/yellowpages/YellowpagesInstancePostConstruction.java
+++ b/yellowpages/yellowpages-library/src/main/java/org/silverpeas/components/yellowpages/YellowpagesInstancePostConstruction.java
@@ -24,10 +24,12 @@
 package org.silverpeas.components.yellowpages;
 
 import org.silverpeas.core.admin.component.ComponentInstancePostConstruction;
+import org.silverpeas.core.admin.service.AdministrationServiceProvider;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
+import org.silverpeas.core.util.StringUtil;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -64,6 +66,13 @@ public class YellowpagesInstancePostConstruction implements ComponentInstancePos
     root.setDescription("");
     root.setCreatorId(UserDetail.getCurrentRequester().getId());
     root.setLevel(1);
+
+    String xmlFilename = AdministrationServiceProvider.getAdminService()
+          .getComponentParameterValue(componentInstanceId, "xmlTemplate");
+    if (StringUtil.isDefined(xmlFilename)) {
+      root.setModelId(xmlFilename);
+    }
+
     return root;
   }
 

--- a/yellowpages/yellowpages-war/src/main/java/org/silverpeas/components/yellowpages/servlets/YellowpagesRequestRouter.java
+++ b/yellowpages/yellowpages-war/src/main/java/org/silverpeas/components/yellowpages/servlets/YellowpagesRequestRouter.java
@@ -153,7 +153,7 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
         }
 
         request.setAttribute("Contacts", contacts);
-        request.setAttribute("PortletMode", scc.isPortletMode());
+        setCommonAttributesOfMainPage(scc, request);
 
         scc.setCurrentContacts(contacts);
 
@@ -205,7 +205,7 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
 
           request.setAttribute("Contacts", scc.getListContactFather(listContact, true));
           request.setAttribute("CurrentTopic", currentTopic);
-          request.setAttribute("PortletMode", scc.isPortletMode());
+          setCommonAttributesOfMainPage(scc, request);
 
           destination = "/yellowpages/jsp/annuaire.jsp?Action=SearchResults&Profile=" + flag;
         } else if ("Node".equals(type)) {
@@ -223,8 +223,8 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
 
         request.setAttribute("Contacts", searchResults);
         request.setAttribute("CurrentTopic", currentTopic);
-        request.setAttribute("PortletMode", scc.isPortletMode());
         request.setAttribute("SearchCriteria", searchCriteria);
+        setCommonAttributesOfMainPage(scc, request);
 
         destination = "/yellowpages/jsp/annuaire.jsp?Action=SearchResults&Profile=" + flag;
       } else if ("ToAddFolder".equals(function)) {
@@ -330,8 +330,7 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
       } else if ("ImportCSV".equals(function)) {
         List<FileItem> parameters = request.getFileItems();
         FileItem fileItem = FileUploadUtil.getFile(parameters);
-        String modelId = scc.getCurrentTopic().getNodeDetail().getModelId();
-        request.setAttribute("Result", scc.importCSV(fileItem, modelId));
+        request.setAttribute("Result", scc.importCSV(fileItem));
         destination = rootDestination + "importCSV.jsp";
       } else {
         destination = "/yellowpages/jsp/" + function;
@@ -394,13 +393,13 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
       request.setAttribute("Contact", contact);
       return "/yellowpages/jsp/contact.jsp";
     } else if ("ContactNew".equals(function)) {
-      String modelId = ysc.getCurrentTopic().getNodeDetail().getModelId();
+      String modelId = ysc.getCurrentModel();
       CompleteContact contact = new CompleteContact(ysc.getComponentId(), modelId);
       setPageContext(null, request, ysc);
       request.setAttribute("Contact", contact);
       return "/yellowpages/jsp/contactManager.jsp";
     } else if ("ContactNewFromUser".equals(function)) {
-      String modelId = ysc.getCurrentTopic().getNodeDetail().getModelId();
+      String modelId = ysc.getCurrentModel();
       ysc.getCurrentContact().setModelId(modelId);
       setPageContext(null, request, ysc);
       request.setAttribute("Contact", ysc.getCurrentContact());
@@ -424,7 +423,7 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
       return "/yellowpages/jsp/contactManager.jsp";
     } else if ("ContactSave".equals(function)) {
       List<FileItem> items = request.getFileItems();
-      String modelId = ysc.getCurrentTopic().getNodeDetail().getModelId();
+      String modelId = ysc.getCurrentModel();
       String contactId = FileUploadUtil.getParameter(items, "ContactId");
       ContactDetail contact = request2ContactDetail(items);
       CompleteContact fullContact = new CompleteContact(contact, modelId);
@@ -481,5 +480,11 @@ public class YellowpagesRequestRouter extends ComponentRequestRouter<Yellowpages
     context.setObjectId(contactId);
 
     request.setAttribute("PagesContext", context);
+  }
+
+  private void setCommonAttributesOfMainPage(YellowpagesSessionController scc,
+      HttpServletRequest request) {
+    request.setAttribute("PortletMode", scc.isPortletMode());
+    request.setAttribute("Tree", scc.getTree());
   }
 }

--- a/yellowpages/yellowpages-war/src/main/webapp/yellowpages/jsp/annuaire.jsp
+++ b/yellowpages/yellowpages-war/src/main/webapp/yellowpages/jsp/annuaire.jsp
@@ -48,37 +48,27 @@
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
 <%@ include file="checkYellowpages.jsp" %>
 <%!
-  private String afficheArbo(String idNodeSelected, YellowpagesSessionController yellowpagesScc,
-      int nbEsp) throws Exception {
+  private String afficheArbo(List<NodeDetail> tree, String idNodeSelected,
+      YellowpagesSessionController yellowpagesScc) {
     StringBuffer resultat = new StringBuffer();
-    List<NodeDetail> tree = yellowpagesScc.getTree();
-    StringBuffer espace = new StringBuffer();
-
-    NodeDetail nodeDetail = null;
-    String nodeId = null;
-    int nodeLevel = 0;
-    for (int i = 0; i < tree.size(); i++) {
-      nodeDetail = (NodeDetail) tree.get(i);
-      nodeId = nodeDetail.getNodePK().getId();
-      if (nodeId.equals("1") || nodeId.equals("2")) {
-        //on affiche pas ces deux rubriques
+    StringBuffer espace;
+    for (NodeDetail nodeDetail : tree) {
+      String nodeId = nodeDetail.getNodePK().getId();
+      if (nodeDetail.isRoot()) {
+        resultat.append("<option value=\"").append(nodeId).append("\">")
+            .append(yellowpagesScc.getComponentLabel()).append("</option>");
       } else {
-        if (i == 0) {
-          resultat.append("<option value=\"").append(nodeId).append("\">")
-              .append(yellowpagesScc.getComponentLabel()).append("</option>");
-        } else {
-          nodeLevel = nodeDetail.getLevel();
-          espace = new StringBuffer();
-          for (int j = 0; j < nodeLevel - 1; j++) {
-            espace.append("&nbsp;&nbsp;&nbsp;");
-          }
-          resultat.append("<option value=\"").append(nodeId).append("\"");
-          if (idNodeSelected.equals(nodeId)) {
-            resultat.append("selected");
-          }
-          resultat.append(">").append(espace.toString()).append(nodeDetail.getName())
-              .append("</option>");
+        int nodeLevel = nodeDetail.getLevel();
+        espace = new StringBuffer();
+        for (int j = 0; j < nodeLevel - 1; j++) {
+          espace.append("&nbsp;&nbsp;&nbsp;");
         }
+        resultat.append("<option value=\"").append(nodeId).append("\"");
+        if (idNodeSelected.equals(nodeId)) {
+          resultat.append("selected");
+        }
+        resultat.append(">").append(espace.toString()).append(nodeDetail.getName())
+            .append("</option>");
       }
     }
     return resultat.toString();
@@ -94,6 +84,7 @@
 
   String profile = request.getParameter("Profile");
   String action = request.getParameter("Action");
+  List<NodeDetail> tree = (List<NodeDetail>) request.getAttribute("Tree");
 
   if (action == null) {
     action = "GoTo";
@@ -287,20 +278,15 @@
           </tr>
         </table>
         <!--***************************--></td>
-      <%
-        }
-      %>
+      <% } %>
+      <% if (tree.size() > 1) { %>
       <td><!--Acces aux categories-->
-        <table cellpadding="2" cellspacing="1" border="0" width="100%">
-          <tr>
-            <td align="center" nowrap="nowrap" width="100%" height="24"><span
-                class="selectNS"> <select name="selectTopic"
+          <span class="selectNS"> <select name="selectTopic"
                                           onchange="topicGoToSelected()">
-					<%=afficheArbo(id, yellowpagesScc, 0)%>
-				</select> </span></td>
-          </tr>
-        </table>
+					<%=afficheArbo(tree, id, yellowpagesScc)%>
+				</select> </span>
         <!--***************************--></td>
+      <% } %>
       <td width="100%">&nbsp;</td>
     </tr>
   </table>


### PR DESCRIPTION
- on component creation, a form can be specified relative to contacts outside folders
- So, contacts can be created on root and with a custom form
- If component does not manage folders, the empty list is no more displayed
- CSV import : separator is now ';' (to be homogeneous with centralized export)

Do not forget https://github.com/Silverpeas/Silverpeas-Core/pull/1093