### PR TITLE
Feature #9047: indicating that last publications can be also retrieved from aliases.

### DIFF
--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -285,23 +285,37 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    * given user. If the main location of the publication isn't accessible by the user, then the
    * first accessible alias of the publication is returned. If no aliases are accessible or defined,
    * the the details of the root topic is returned.
+   * <p>
+   *  The component instance set to given {@link PublicationPK} gives the priority of the
+   *  resulting {@link TopicDetail}. For example, into case of a main publication on instance A with
+   *  aliases on instance B, if component instance id set to given {@link PublicationPK} is the B
+   *  one, then {@link TopicDetail} result is about the best father PK (the best location) on
+   *  instance B (so an alias in that case).
+   * </p>
    * @param pubPK the unique identifier of the publication.
    * @param isTreeStructureUsed is the tree view of the topics enabled?
    * @param userId the unique identifier of a user.
    * @return the details of the topic in which the publication is accessible by the given user.
    */
-  TopicDetail getPublicationFather(PublicationPK pubPK, boolean isTreeStructureUsed, String userId);
+  TopicDetail getBestTopicDetailOfPublicationForUser(PublicationPK pubPK, boolean isTreeStructureUsed, String userId);
 
   /**
    * Gets the father of the specified publication according to the rights of the user. If the main
    * location of the publication isn't accessible by the user, then the first accessible alias of
    * the publication is returned. If no aliases are accessible or defined, the the root topic is
    * returned.
+   * <p>
+   *  The component instance set to given {@link PublicationPK} gives the priority of the
+   *  resulting {@link NodePK}. For example, into case of a main publication on instance A with
+   *  aliases on instance B, if component instance id set to given {@link PublicationPK} is the B
+   *  one, then the best father PK (the best location) on instance B is returned (so an alias in
+   *  that case).
+   * </p>
    * @param pubPK the unique identifier of the publication
    * @param userId the unique identifier of a user.
    * @return a topic in which the publication is accessible by the given user.
    */
-  NodePK getPublicationFatherPK(PublicationPK pubPK, String userId);
+  NodePK getBestLocationOfPublicationForUser(PublicationPK pubPK, String userId);
 
   /**
    * gets a list of PublicationDetail corresponding to the links parameter

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/KmeliaTransversal.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/KmeliaTransversal.java
@@ -89,6 +89,7 @@ public class KmeliaTransversal implements PublicationHelper {
           .excludingTrashNodeOnComponentInstanceIds(componentIds)
           .ofStatus(PublicationDetail.VALID_STATUS)
           .visibleAt(OffsetDateTime.now())
+          .takingAliasesIntoAccount()
           .orderByDescendingBeginDate()
           .limitTo(nbPublis));
     } catch (Exception e) {
@@ -117,6 +118,7 @@ public class KmeliaTransversal implements PublicationHelper {
           .ofStatus(PublicationDetail.VALID_STATUS)
           .visibleAt(OffsetDateTime.now())
           .lastUpdatedSince(OffsetDateTime.ofInstant(since.toInstant(), ZoneId.systemDefault()))
+          .takingAliasesIntoAccount()
           .orderByDescendingLastUpdateDate()
           .limitTo(nbPublis));
     } catch (Exception e) {
@@ -150,6 +152,7 @@ public class KmeliaTransversal implements PublicationHelper {
         .excludingTrashNodeOnComponentInstanceIds(componentId)
         .ofStatus(PublicationDetail.VALID_STATUS)
         .visibleAt(OffsetDateTime.now())
+        .takingAliasesIntoAccount()
         .orderByDescendingLastUpdateDate());
   }
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -717,9 +717,9 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     }
   }
 
-  public synchronized TopicDetail getPublicationTopic(String pubId) {
-    TopicDetail currentTopic = getKmeliaService()
-        .getPublicationFather(getPublicationPK(pubId), isTreeStructure(), getUserId());
+  public synchronized TopicDetail getBestTopicDetailsOfPublication(String pubId) {
+    final TopicDetail currentTopic = getKmeliaService()
+        .getBestTopicDetailOfPublicationForUser(getPublicationPK(pubId), isTreeStructure(), getUserId());
     setSessionTopic(currentTopic);
     applyVisibilityFilter();
     return currentTopic;
@@ -812,8 +812,8 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     return getKmeliaService().getPathList(pk);
   }
 
-  public NodePK getAllowedPublicationFather(String pubId) {
-    return getKmeliaService().getPublicationFatherPK(getPublicationPK(pubId), getUserId());
+  public NodePK getBestAllowedPublicationFather(String pubId) {
+    return getKmeliaService().getBestLocationOfPublicationForUser(getPublicationPK(pubId), getUserId());
   }
 
   public synchronized String createPublication(PublicationDetail pubDetail,

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/export/ODTDocumentBuilder.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/export/ODTDocumentBuilder.java
@@ -470,7 +470,7 @@ public class ODTDocumentBuilder {
     String theTopicId = this.topicIdToConsider;
     if (theTopicId == null) {
       NodePK pk = getKmeliaService().
-          getPublicationFatherPK(publication.getPk(), getUser().getId());
+          getBestLocationOfPublicationForUser(publication.getPk(), getUser().getId());
       theTopicId = pk.getId();
     }
     return theTopicId;

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/AjaxPublicationsListServlet.java
@@ -1095,9 +1095,8 @@ public class AjaxPublicationsListServlet extends HttpServlet {
         }
 
         writer.write("<li>");
-        writer.write("<div class=\"publication-name line1\"><a href=\"javascript:onClick=publicationGoToFromMain('" + pub.getPK().
-              getId() + "')\">" + Encode.forHtml(pub.getName(language)) + "</a>" + shortcut +
-              "</div>");
+        writer.write("<div class=\"publication-name line1\"><a class=\"sp-permalink\"" +
+            " href=\"" + pub.getPermalink() +"\">" + Encode.forHtml(pub.getName(language)) + "</a>" + shortcut + "</div>");
 
         if (kmeliaScc.showUserNameInList()) {
           writer.write("<span class=\"publication-user\">");

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -1005,18 +1005,16 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
 
         destination = rootDestination + "publicationPaths.jsp";
       } else if (function.equals("SetPath")) {
-        String[] topics = request.getParameterValues("topicChoice");
-        String loadedComponentIds = request.getParameter("LoadedComponentIds");
-
-        Location location;
-        List<Location> locations = new ArrayList<>();
+        final String[] topics = request.getParameterValues("topicChoice");
+        final List<String> loadedComponentIds = request.getParameterAsList("LoadedComponentIds");
+        final List<Location> locations = new ArrayList<>();
         for (int i = 0; topics != null && i < topics.length; i++) {
           String topicId = topics[i];
           StringTokenizer tokenizer = new StringTokenizer(topicId, ",");
           String nodeId = tokenizer.nextToken();
           String instanceId = tokenizer.nextToken();
 
-          location = new Location(nodeId, instanceId);
+          Location location = new Location(nodeId, instanceId);
           location.setAsAlias(kmelia.getUserId());
           locations.add(location);
         }
@@ -1810,12 +1808,13 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
       if (!StringUtil.isDefined(id)) {
         pk = kmeliaSC.getCurrentFolderPK();
       } else {
-        // get publication parent
-        pk = kmeliaSC.getAllowedPublicationFather(id);
+        // get best location on the component instance
+        pk = kmeliaSC.getBestAllowedPublicationFather(id);
         if (!pk.getInstanceId().equals(kmeliaSC.getComponentId())) {
+          // the user is not allowed to access the publication on this instance even as an alias
           throw new AliasOnOtherKmeliaException(id, pk);
         }
-        kmeliaSC.getPublicationTopic(id);
+        kmeliaSC.getBestTopicDetailsOfPublication(id);
       }
 
       Collection<NodeDetail> pathColl = kmeliaSC.getTopicPath(pk.getId());

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
@@ -59,7 +59,7 @@ response.setDateHeader ("Expires",-1); //prevents caching at the proxy server
   String user_id = kmeliaScc.getUserId();
 
   //Calcul du chemin de la publication
-  currentTopic = kmeliaScc.getPublicationTopic(id);
+  currentTopic = kmeliaScc.getBestTopicDetailsOfPublication(id);
   Collection pathColl = currentTopic.getPath();
   pathString = displayPath(pathColl, false, 3);
 


### PR DESCRIPTION
Refactoring/renaming services in order to get a right behavior about accessing a publication from the best location.
Fixing a technical problem on alias save which was inducing sometimes aliases loss.

Linked to PR: https://github.com/Silverpeas/Silverpeas-Core/pull/1120