### PR TITLE
Bug #12479

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/copyApplicationDialog.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/copyApplicationDialog.jsp
@@ -11,6 +11,7 @@
 <input type="checkbox" id="<%=KmeliaCopyDetail.PUBLICATION_HEADER%>" name="<%=KmeliaCopyDetail.PUBLICATION_HEADER%>" value="true" checked="checked" onclick="javascript:checkHeaderClick(this)" /> <fmt:message key="kmelia.app.copy.option.header"/><br/>
 <input type="checkbox" id="<%=KmeliaCopyDetail.PUBLICATION_CONTENT%>" name="<%=KmeliaCopyDetail.PUBLICATION_CONTENT%>" value="true" checked="checked" onclick="javascript:checkClick(this)" /> <fmt:message key="kmelia.app.copy.option.content"/><br />
 <input type="checkbox" id="<%=KmeliaCopyDetail.PUBLICATION_FILES%>" name="<%=KmeliaCopyDetail.PUBLICATION_FILES%>" value="true" checked="checked" onclick="javascript:checkClick(this)" /> <fmt:message key="kmelia.app.copy.option.files"/>
+<input type="hidden" id="<%=KmeliaCopyDetail.PUBLICATION_PDC%>" name="<%=KmeliaCopyDetail.PUBLICATION_PDC%>" value="true"/>
 </p>
 
 <script type="text/javascript">


### PR DESCRIPTION
Now, when a Kmelia instance is duplicated, both its default
classification (for the instance itself as well as for each of
the nodes) and its PdC utilization are also duplicated.

Update copyApplicationDialog.jsp to set the property of copying the
classification onto the PdC of the publications. So, all specific
classification positions of each publication will be duplicated. This
property is always set at true but it is taken into account only when
the publications are duplicated, that is to say if the property of
copying the publication headers is set at true.

Don't forget to merge before PR https://github.com/Silverpeas/Silverpeas-Core/pull/1153