### PR TITLE
Feature #12035: wiring the modification popins on massive publication update.

### DIFF
--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/notification/KmeliaSubscriptionPublicationUserNotification.java
@@ -31,12 +31,12 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationBehavior;
 import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.subscription.constant.SubscriberType;
-import org.silverpeas.core.subscription.service.NodeSubscriptionResource;
 import org.silverpeas.core.subscription.util.SubscriptionSubscriberMapBySubscriberType;
 
 import java.util.Collection;
 
 import static org.silverpeas.core.subscription.service.ResourceSubscriptionProvider.getSubscribersOfSubscriptionResource;
+import static org.silverpeas.core.subscription.service.ResourceSubscriptionProvider.getSubscribersOfSubscriptionResourceOnLocation;
 
 /**
  * @author Yohann Chastagnier
@@ -51,12 +51,9 @@ public class KmeliaSubscriptionPublicationUserNotification
       final PublicationDetail resource, final NotifAction action) {
     super(nodePK, resource, action);
     if (getResource().isAlias()) {
-      subscriberIdsByTypes = getSubscribersOfSubscriptionResource(
+      subscriberIdsByTypes = getSubscribersOfSubscriptionResourceOnLocation(
           PublicationAliasSubscriptionResource.from(new PublicationPK(resource.getId(),
-              getNodePK().getComponentInstanceId()))).indexBySubscriberType();
-      // In case of alias, parent subscriptions MUST be retrieved manually
-      subscriberIdsByTypes.addAll(getSubscribersOfSubscriptionResource(
-          NodeSubscriptionResource.from(getNodePK())).indexBySubscriberType());
+              getNodePK().getComponentInstanceId())), getNodePK().getLocalId()).indexBySubscriberType();
     } else {
       subscriberIdsByTypes = getSubscribersOfSubscriptionResource(
           PublicationSubscriptionResource.from(resource.getPK())).indexBySubscriberType();

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -39,8 +39,8 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.pdc.pdc.model.PdcClassification;
 import org.silverpeas.core.reminder.Reminder;
-import org.silverpeas.core.security.authorization.AccessControlContext;
 import org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail;
+import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.ServiceProvider;
 
 import java.util.Collection;
@@ -320,10 +320,10 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
 
   /**
    * gets a list of PublicationDetail corresponding to the links parameter
-   * @param links list of publication (componentID + publicationId)
+   * @param references list of publication (componentID + publicationId)
    * @return a list of PublicationDetail
    */
-  <T extends ResourceReference> List<PublicationDetail> getPublicationDetails(List<T> links);
+  <T extends ResourceReference> List<PublicationDetail> getPublicationDetails(List<T> references);
 
   /**
    * Gets a list of publications with optional control access filtering.
@@ -333,14 +333,36 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    * @param references list of publication represented as {@link ResourceReference} instances.
    * @param userId identifier User. allow to check if the publication is accessible for current
    * user
-   * @param accessControlContext optional access control context to filter the publication
-   * according user rights. If not specified, no filtering is performed.
    * @param contextFolder optional folder that represents if specified the folder into which the
    * given references are retrieved. It is MANDATORY to determinate alias status.
+   * @param accessControlFiltering true to filter the publication according user rights.
    * @return a collection of Kmelia publications
    */
   <T extends ResourceReference> List<KmeliaPublication> getPublications(List<T> references,
-      String userId, AccessControlContext accessControlContext, final NodePK contextFolder);
+      String userId, final NodePK contextFolder, boolean accessControlFiltering);
+
+  /**
+   * Gets a list of {@link Pair} of {@link KmeliaPublication} instances into context of
+   * modification by a user represented by the given user id.
+   * On the left of a {@link Pair} instance, there is a publication that can not be a null value.
+   * On the right, there is the clone of the publication if any, and so, it can be null if the
+   * publication has got no clone.
+   * <p>
+   * The main location is computed for each publication (and clone) by taking care about
+   * performances.
+   * </p>
+   * <p>
+   * This service guarantees that the returned {@link KmeliaPublication} instances each aims the
+   * main location.
+   * </p>
+   * @param references list of publication represented as {@link ResourceReference} instances.
+   * @param userId identifier User. allow to check if the publication is accessible for current
+   * user
+   * @return a list of {@link Pair} of {@link KmeliaPublication} instances. A pair represents on
+   * the left the publication and the eventual corresponding clone on the right if it exists.
+   */
+  <T extends ResourceReference> List<Pair<KmeliaPublication, KmeliaPublication>> getPublicationsForModification(
+      List<T> references, String userId);
 
   /**
    * Gets the publications linked with the specified one and for which the specified user is

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -39,6 +39,7 @@ import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.pdc.pdc.model.PdcClassification;
 import org.silverpeas.core.reminder.Reminder;
+import org.silverpeas.core.security.authorization.AccessControlContext;
 import org.silverpeas.core.silverstatistics.access.model.HistoryObjectDetail;
 import org.silverpeas.core.util.ServiceProvider;
 
@@ -322,18 +323,24 @@ public interface KmeliaService extends ApplicationService<KmeliaPublication> {
    * @param links list of publication (componentID + publicationId)
    * @return a list of PublicationDetail
    */
-  List<PublicationDetail> getPublicationDetails(List<ResourceReference> links);
+  <T extends ResourceReference> List<PublicationDetail> getPublicationDetails(List<T> links);
 
   /**
-   * Gets a list of publications with optional control access filtering
-   * @param links list of publication defined by his id and component id
+   * Gets a list of publications with optional control access filtering.
+   * <p>
+   * When a folder is given as context, then the ALIAS information is computed on each publication.
+   * </p>
+   * @param references list of publication represented as {@link ResourceReference} instances.
    * @param userId identifier User. allow to check if the publication is accessible for current
    * user
-   * @param accessControlFiltering true to filter the publication according user rights.
+   * @param accessControlContext optional access control context to filter the publication
+   * according user rights. If not specified, no filtering is performed.
+   * @param contextFolder optional folder that represents if specified the folder into which the
+   * given references are retrieved. It is MANDATORY to determinate alias status.
    * @return a collection of Kmelia publications
    */
-  List<KmeliaPublication> getPublications(List<ResourceReference> links, String userId,
-      boolean accessControlFiltering);
+  <T extends ResourceReference> List<KmeliaPublication> getPublications(List<T> references,
+      String userId, AccessControlContext accessControlContext, final NodePK contextFolder);
 
   /**
    * Gets the publications linked with the specified one and for which the specified user is

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -55,6 +55,7 @@ import org.silverpeas.core.contribution.template.publication.PublicationTemplate
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateException;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateImpl;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
+import org.silverpeas.core.contribution.util.ContributionBatchManagementContext;
 import org.silverpeas.core.contribution.util.ContributionManagementContext;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.importexport.report.ImportReport;
@@ -95,7 +96,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import static org.silverpeas.core.contribution.model.CoreContributionType.NODE;
 
@@ -1524,12 +1527,21 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
         kmelia.setPublicationValidator(userIds);
         destination = getDestination("ViewPublication", kmelia, request);
       } else if ("ToUpdatePublications".equals(function)) {
-        String selectedIds = request.getParameter("SelectedIds");
-        String notSelectedIds = request.getParameter("NotSelectedIds");
-        List<PublicationPK> pks = kmelia.processSelectedPublicationIds(selectedIds, notSelectedIds);
+        final String selectedIds = request.getParameter("SelectedIds");
+        final String notSelectedIds = request.getParameter("NotSelectedIds");
+        final List<PublicationDetail> authorizedPublications = kmelia.getPublicationsForModification(
+            kmelia.processSelectedPublicationIds(selectedIds, notSelectedIds))
+            .stream()
+            .map(p -> p.getSecond() != null ? p.getSecond() : p.getFirst())
+            .filter(p -> Objects.equals(p.getComponentInstanceId(), kmelia.getComponentId()))
+            .map(KmeliaPublication::getDetail)
+            .collect(Collectors.toList());
+        setupRequestForContributionBatchManagementContext(request,
+            highestSilverpeasUserRoleOnCurrentTopic, kmelia.getCurrentFolderPK(),
+            authorizedPublications);
         request.setAttribute("Form", kmelia.getXmlFormForPublications());
         request.setAttribute("Language", kmelia.getLanguage());
-        request.setAttribute("NumberOfSelectedPublications", pks.size());
+        request.setAttribute("NumberOfSelectedPublications", authorizedPublications.size());
         destination = rootDestination + "updatePublicationsContent.jsp";
       } else if ("UpdatePublications".equals(function)) {
         List<FileItem> items = request.getFileItems();
@@ -1970,7 +1982,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
   }
 
   /**
-   * Setup the request to manager some behaviors around subscription notification sending.
+   * Setup the request to manager some behaviors around validation of modifications.
    * @param request the current request.
    * @param highestSilverpeasUserRoleOnCurrentTopic the highest role the user has on the current
    * folder.
@@ -1986,15 +1998,45 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     if (highestSilverpeasUserRoleOnCurrentTopic.isGreaterThanOrEquals(SilverpeasRole.PUBLISHER)) {
       statusAfterSave = ContributionStatus.VALIDATED;
     }
-    final PublicationPK publicationPK = new PublicationPK(publication.getId(),
-        currentFolderPK.getComponentInstanceId());
+    final String componentInstanceId = currentFolderPK.getComponentInstanceId();
+    final PublicationPK publicationPK = new PublicationPK(publication.getId(), componentInstanceId);
     final SubscriptionResource resource = publication.isAlias() ?
         PublicationAliasSubscriptionResource.from(publicationPK) :
         PublicationSubscriptionResource.from(publicationPK);
     request.setAttribute("contributionManagementContext", ContributionManagementContext
         .on(publication)
         .aboutSubscriptionResource(resource)
+        .atLocation(new Location(currentFolderPK.getId(), componentInstanceId))
         .forPersistenceAction(statusBeforeSave, ActionType.UPDATE, statusAfterSave));
+  }
+
+  /**
+   * Setup the request to manager some behaviors around validation of modifications.
+   * @param request the current request.
+   * @param highestSilverpeasUserRoleOnCurrentTopic the highest role the user has on the current
+   * folder.
+   * @param currentFolderPK the primary key of the current folder.
+   * @param publications the current handled publications.
+   */
+  private void setupRequestForContributionBatchManagementContext(HttpRequest request,
+      SilverpeasRole highestSilverpeasUserRoleOnCurrentTopic, NodePK currentFolderPK,
+      List<PublicationDetail> publications) {
+    if (highestSilverpeasUserRoleOnCurrentTopic != null &&
+        highestSilverpeasUserRoleOnCurrentTopic.isGreaterThanOrEquals(SilverpeasRole.PUBLISHER)) {
+      final ContributionBatchManagementContext context = ContributionBatchManagementContext
+          .initialize()
+          .forPersistenceAction(ActionType.UPDATE);
+      publications.stream().forEach(p -> {
+        final String componentInstanceId = currentFolderPK.getComponentInstanceId();
+        final PublicationPK publicationPK = new PublicationPK(p.getId(), componentInstanceId);
+        final SubscriptionResource resource = p.isAlias() ?
+            PublicationAliasSubscriptionResource.from(publicationPK) :
+            PublicationSubscriptionResource.from(publicationPK);
+        context.addContributionContext(p, p.getContributionStatus(),
+            new Location(currentFolderPK.getId(), componentInstanceId), resource);
+      });
+      request.setAttribute("contributionBatchManagementContext", context);
+    }
   }
 
   /**
@@ -2013,7 +2055,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     return pks;
   }
 
-  private class AliasOnOtherKmeliaException extends Exception {
+  private static class AliasOnOtherKmeliaException extends Exception {
+    private static final long serialVersionUID = 2594081198295164318L;
+
     private final String pubId;
     private final NodePK aliasLocation;
 

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -83,11 +83,8 @@ function refreshPublications()
   var nodeId = getCurrentNodeId();
   var ieFix = new Date().getTime();
   var componentId = getComponentId();
-  $.get(getWebContext() + '/RAjaxPublicationsListServlet', {Id: nodeId, ComponentId: componentId, IEFix: ieFix},
-  function(data) {
-    updateHtmlContainingAngularDirectives($('#pubList'), data);
-      activateUserZoom();
-  }, "html");
+  $.get(getWebContext() + '/RAjaxPublicationsListServlet',
+      {Id : nodeId, ComponentId : componentId, IEFix : ieFix}, __updateDataAndUI, "html");
 }
 
 function validatePublicationClassification(s)
@@ -108,6 +105,12 @@ function publicationGoTo(id) {
   document.pubForm.submit();
 }
 
+const __updateDataAndUI = function(data) {
+  updateHtmlContainingAngularDirectives($('#pubList'), data);
+  activateUserZoom();
+  showPublicationCheckedBoxes();
+}
+
 function sortGoTo(selectedIndex) {
   closeWindows();
   if (selectedIndex !== 0 && selectedIndex !== 1) {
@@ -115,12 +118,9 @@ function sortGoTo(selectedIndex) {
     var sort = document.publicationsForm.sortBy[selectedIndex].value;
     var ieFix = new Date().getTime();
     var componentId = getComponentId();
-    $.get(getWebContext() + '/RAjaxPublicationsListServlet', {Index: 0, Sort: sort, ComponentId: componentId, Query: topicQuery, IEFix: ieFix},
-    function(data) {
-      //$('#pubList').html(data);
-      updateHtmlContainingAngularDirectives($('#pubList'), data);
-      activateUserZoom();
-    }, "html");
+    $.get(getWebContext() + '/RAjaxPublicationsListServlet',
+        {Index : 0, Sort : sort, ComponentId : componentId, Query : topicQuery, IEFix : ieFix},
+        __updateDataAndUI, "html");
     return;
   }
 }
@@ -129,11 +129,9 @@ function resetSort() {
   jQuery.popup.confirm(getString('kmelia.sort.manual.reset.confirm'), function() {
     var ieFix = new Date().getTime();
     var componentId = getComponentId();
-    $.get(getWebContext() + '/RAjaxPublicationsListServlet', {Index: 0, ResetManualSort: true, ComponentId: componentId, IEFix: ieFix},
-        function(data) {
-          updateHtmlContainingAngularDirectives($('#pubList'), data);
-          activateUserZoom();
-        }, "html");
+    $.get(getWebContext() + '/RAjaxPublicationsListServlet',
+        {Index : 0, ResetManualSort : true, ComponentId : componentId, IEFix : ieFix},
+        __updateDataAndUI, "html");
   });
 }
 
@@ -160,9 +158,7 @@ function displayPublications(id) {
     $.get(url, {
       Id : id, ComponentId : componentId, PubIdToHighlight : pubIdToHighlight, IEFix : ieFix
     }, function(data) {
-      //$('#pubList').html(data);
-      updateHtmlContainingAngularDirectives($('#pubList'), data);
-      activateUserZoom();
+      __updateDataAndUI(data);
       resolve();
     }, "html");
   });
@@ -892,10 +888,7 @@ function doPagination(index, nbItemsPerPage) {
   var url = getWebContext() + '/RAjaxPublicationsListServlet';
   $.get(url, {Index: index, NbItemsPerPage: nbItemsPerPage, ComponentId: componentId, Query: topicQuery, SelectedPubIds: selectedPublicationIds, NotSelectedPubIds: notSelectedPublicationIds, IEFix: ieFix},
   function(data) {
-    //$('#pubList').html(data);
-	updateHtmlContainingAngularDirectives($('#pubList'), data);
-    activateUserZoom();
-    showPublicationCheckedBoxes();
+    __updateDataAndUI(data);
     location.href = "#pubList";
   }, "html");
 }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
@@ -813,7 +813,8 @@
                       jsValidationCallbackMethodName="isCorrectHeaderForm"
                       subscriptionResourceType="${contributionManagementContext.linkedSubscriptionResource.type}"
                       subscriptionResourceId="${contributionManagementContext.linkedSubscriptionResource.id}"
-                      contributionIndexable="<%=pubDetail.isIndexable()%>"/>
+                      contributionIndexable="<%=pubDetail.isIndexable()%>"
+                      location="${contributionManagementContext.location}"/>
 
                 </c:if>
               </c:if>

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/updatePublicationsContent.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/updatePublicationsContent.jsp
@@ -48,11 +48,8 @@
 
       String linkedPathString = kmeliaScc.getSessionPath();
 %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="<%=currentLang%>">
-  <head>
-  	<title></title>
-    <view:looknfeel/>
+<view:sp-page>
+  <view:sp-head-part>
     <view:includePlugin name="wysiwyg"/>
     <% formUpdate.displayScripts(out, context);%>
     <script type="text/javascript">
@@ -79,41 +76,41 @@
         location.href = "GoToCurrentTopic";
       }
     </script>
-  </head>
-  <body class="yui-skin-sam">
-    <%
-          Window window = gef.getWindow();
-
-          BrowseBar browseBar = window.getBrowseBar();
-          browseBar.setPath(linkedPathString);
-
-          out.println(window.printBefore());
-    %>
-    <view:frame>
-      <div class="inlineMessage">
-        <%=resources.getStringWithParams("kmelia.publications.batch.update", Integer.toString(nbPublis))%>
-      </div>
-    <view:board>
-    <form name="myForm" method="post" action="UpdatePublications" enctype="multipart/form-data" accept-charset="UTF-8">
-      <%
-            formUpdate.display(out, context);
-      %>
-      <input type="hidden" name="KmeliaPubFormName" value="<%=formUpdate.getFormName()%>"/>
-    </form>
-    </view:board>
-    <view:buttonPane>
-      <c:set var="saveLabel"><%=resources.getString("GML.validate")%></c:set>
-      <c:set var="cancelLabel"><%=resources.getString("GML.cancel")%></c:set>
-      <view:button label="${saveLabel}" action="javascript:onClick=B_VALIDER_ONCLICK();"/>
-      <view:button label="${cancelLabel}" action="javascript:onClick=B_ANNULER_ONCLICK();"/>
-    </view:buttonPane>
-    </view:frame>
-    <%
-          out.println(window.printAfter());%>
-	<script type="text/javascript">
-    	document.myForm.elements[1].focus();
-  	</script>
-  <view:progressMessage/>
-  
-  </body>
-</html>
+  </view:sp-head-part>
+  <view:sp-body-part cssClass="yui-skin-sam">
+    <view:browseBar componentId="<%=componentId%>" path="<%=linkedPathString%>" />
+    <view:window>
+      <view:frame>
+        <div class="inlineMessage">
+          <%=resources.getStringWithParams("kmelia.publications.batch.update", Integer.toString(nbPublis))%>
+        </div>
+      <view:board>
+      <form name="myForm" method="post" action="UpdatePublications" enctype="multipart/form-data" accept-charset="UTF-8">
+        <% formUpdate.display(out, context);%>
+        <input type="hidden" name="KmeliaPubFormName" value="<%=formUpdate.getFormName()%>"/>
+      </form>
+      </view:board>
+      <view:buttonPane>
+        <c:set var="saveLabel"><%=resources.getString("GML.validate")%></c:set>
+        <c:set var="cancelLabel"><%=resources.getString("GML.cancel")%></c:set>
+        <view:button label="${saveLabel}" action="javascript:onClick=B_VALIDER_ONCLICK();">
+          <c:set var="contributionBatchManagementContext" value="${requestScope.contributionBatchManagementContext}"/>
+          <c:if test="${not empty contributionBatchManagementContext}">
+            <jsp:useBean id="contributionBatchManagementContext" type="org.silverpeas.core.contribution.util.ContributionBatchManagementContext"/>
+            <c:if test="${contributionBatchManagementContext.entityPersistenceAction.update}">
+              <view:handleContributionBatchManagementContext
+                  context="${contributionBatchManagementContext}"
+                  jsValidationCallbackMethodName="isCorrectForm"/>
+            </c:if>
+          </c:if>
+        </view:button>
+        <view:button label="${cancelLabel}" action="javascript:onClick=B_ANNULER_ONCLICK();"/>
+      </view:buttonPane>
+      </view:frame>
+    </view:window>
+    <script type="text/javascript">
+      document.myForm.elements[1].focus();
+    </script>
+    <view:progressMessage/>
+  </view:sp-body-part>
+</view:sp-page>

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/xmlForm.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/xmlForm.jsp
@@ -170,7 +170,8 @@
                       jsValidationCallbackMethodName="isCorrectForm"
                       subscriptionResourceType="${contributionManagementContext.linkedSubscriptionResource.type}"
                       subscriptionResourceId="${contributionManagementContext.linkedSubscriptionResource.id}"
-                      contributionIndexable="<%=pubDetail.isIndexable()%>"/>
+                      contributionIndexable="<%=pubDetail.isIndexable()%>"
+                      location="${contributionManagementContext.location}"/>
 
                 </c:if>
               </c:if>


### PR DESCRIPTION

Fixing the fact that a user can modify a contribution for which he has no right!

Fixing the selected checkboxes which was hidden on publication list.

Fixing into KmeliaSessionController the visibility filter performing which was executed before the list of publication was loaded.

Fixing the modification of always visible publicaton into draft status which was not well handled. The valid publication was updated instead of the clone ones.

Linked to PR: https://github.com/Silverpeas/Silverpeas-Core/pull/1155