### PR TITLE
Feature #13706

### DIFF
--- a/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityAppIT.java
+++ b/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityAppIT.java
@@ -38,8 +38,8 @@ import org.silverpeas.core.admin.service.Administration;
 import org.silverpeas.core.admin.space.SpaceHomePageType;
 import org.silverpeas.core.admin.space.SpaceInst;
 import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
-import org.silverpeas.core.cache.service.SessionCacheService;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
 import org.silverpeas.core.test.integration.rule.DbSetupRule;
 
 import java.util.ArrayList;
@@ -76,9 +76,9 @@ public class CommunityAppIT {
 
   @Before
   public void initCurrentRequester() {
-    SessionCacheService sessionCacheService =
-        (SessionCacheService) CacheServiceProvider.getSessionCacheService();
-    sessionCacheService.newSessionCache(User.getById("0"));
+    SessionCacheAccessor sessionCacheAccessor =
+        (SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor();
+    sessionCacheAccessor.newSessionCache(User.getById("0"));
   }
 
   @Test

--- a/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityManagementIT.java
+++ b/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityManagementIT.java
@@ -43,8 +43,8 @@ import org.silverpeas.core.admin.space.SpaceInst;
 import org.silverpeas.core.admin.space.SpaceProfileInst;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
-import org.silverpeas.core.cache.service.SessionCacheService;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
 import org.silverpeas.core.persistence.Transaction;
 import org.silverpeas.core.test.integration.rule.DbSetupRule;
 import org.silverpeas.core.util.Pair;
@@ -90,9 +90,9 @@ public class CommunityManagementIT {
 
   @Before
   public void initCurrentRequester() {
-    SessionCacheService sessionCacheService =
-        (SessionCacheService) CacheServiceProvider.getSessionCacheService();
-    sessionCacheService.newSessionCache(User.getById("0"));
+    SessionCacheAccessor sessionCacheAccessor =
+        (SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor();
+    sessionCacheAccessor.newSessionCache(User.getById("0"));
   }
 
   @SuppressWarnings("unchecked")

--- a/community/community-library/src/test/java/org/silverpeas/components/community/CommunityOfUsersTest.java
+++ b/community/community-library/src/test/java/org/silverpeas/components/community/CommunityOfUsersTest.java
@@ -42,8 +42,8 @@ import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.admin.user.service.UserProvider;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
-import org.silverpeas.core.cache.service.SessionCacheService;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
 import org.silverpeas.core.persistence.Transaction;
 import org.silverpeas.core.persistence.datasource.OperationContext;
 import org.silverpeas.core.persistence.datasource.model.identifier.UuidIdentifier;
@@ -135,9 +135,9 @@ class CommunityOfUsersTest {
     when(organizationController.getUserDetail(anyString())).thenAnswer(userAnswer);
 
     // for the current requester
-    SessionCacheService sessionCacheService =
-        (SessionCacheService) CacheServiceProvider.getSessionCacheService();
-    sessionCacheService.newSessionCache(User.getById(USER_ID));
+    SessionCacheAccessor sessionCacheAccessor =
+        (SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor();
+    sessionCacheAccessor.newSessionCache(User.getById(USER_ID));
 
     // get a mocked space instance with all the roles initialized with a set of users
     when(organizationController.getSpaceInstById(anyString())).thenAnswer(i -> {

--- a/community/community-war/src/main/java/org/silverpeas/components/community/CommunityWebManager.java
+++ b/community/community-war/src/main/java/org/silverpeas/components/community/CommunityWebManager.java
@@ -38,7 +38,7 @@ import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.annotation.Service;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.SilverpeasList;
 import org.silverpeas.core.web.mvc.webcomponent.WebMessager;
@@ -269,7 +269,7 @@ public class CommunityWebManager {
 
   private <T> T requestCache(final String type, final String id, Class<T> classType,
       Supplier<T> supplier) {
-    return CacheServiceProvider.getRequestCacheService()
+    return CacheAccessorProvider.getThreadCacheAccessor()
         .getCache()
         .computeIfAbsent(CACHE_KEY_PREFIX + type + ":" + id, classType, supplier);
   }

--- a/formsOnline/formsOnline-library/src/main/java/org/silverpeas/components/formsonline/model/DefaultFormsOnlineService.java
+++ b/formsOnline/formsOnline-library/src/main/java/org/silverpeas/components/formsonline/model/DefaultFormsOnlineService.java
@@ -39,7 +39,7 @@ import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.admin.user.model.UserFull;
 import org.silverpeas.core.annotation.Service;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.contribution.ContributionStatus;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
@@ -947,7 +947,7 @@ public class DefaultFormsOnlineService implements FormsOnlineService, Initializa
     private final Map<String, String> cache = new HashMap<>();
 
     public static HierarchicalValidatorCacheManager get() {
-      return CacheServiceProvider.getThreadCacheService()
+      return CacheAccessorProvider.getThreadCacheAccessor()
           .getCache()
           .computeIfAbsent(CACHE_KEY, HierarchicalValidatorCacheManager.class,
               HierarchicalValidatorCacheManager::new);

--- a/gallery/gallery-library/src/integration-test/java/org/silverpeas/components/gallery/BaseGalleryIT.java
+++ b/gallery/gallery-library/src/integration-test/java/org/silverpeas/components/gallery/BaseGalleryIT.java
@@ -38,7 +38,7 @@ import org.silverpeas.core.admin.user.constant.UserAccessLevel;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.annotation.Service;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.test.integration.DataSetTest;
 
 import javax.annotation.Priority;
@@ -152,7 +152,7 @@ public abstract class BaseGalleryIT extends DataSetTest {
 
     @After
     public void tearDown() {
-        CacheServiceProvider.clearAllThreadCaches();
+        CacheAccessorProvider.getThreadCacheAccessor().getCache().clear();
     }
 
     /**

--- a/gallery/gallery-library/src/integration-test/java/org/silverpeas/components/gallery/dao/MediaDaoIT.java
+++ b/gallery/gallery-library/src/integration-test/java/org/silverpeas/components/gallery/dao/MediaDaoIT.java
@@ -38,8 +38,8 @@ import org.silverpeas.components.gallery.model.Photo;
 import org.silverpeas.components.gallery.model.Sound;
 import org.silverpeas.components.gallery.model.Streaming;
 import org.silverpeas.components.gallery.model.Video;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
-import org.silverpeas.core.cache.service.SessionCacheService;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
 import org.silverpeas.core.date.period.Period;
 import org.silverpeas.core.io.media.Definition;
 import org.silverpeas.core.media.streaming.StreamingProvider;
@@ -282,7 +282,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertThat(media.get(0).getId(), is("stream_2"));
 
     // Simulating a connected publisher user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(publisherUser);
 
     media = MediaDAO
@@ -291,7 +291,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertMediaType(media, MediaType.Streaming, Streaming.class);
 
     // Simulating a connected writer user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(writerUser);
 
     media = MediaDAO
@@ -321,7 +321,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertThat(media.get(0).getId(), is("stream_2"));
 
     // Simulating a connected publisher user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(publisherUser);
 
     media = MediaDAO.findByCriteria(
@@ -361,7 +361,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertThat(nbMedia, is(1L));
 
     // Simulating a connected publisher user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(publisherUser);
 
     nbMedia = MediaDAO
@@ -369,7 +369,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertThat(nbMedia, is(2L));
 
     // Simulating a connected writer user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(writerUser);
 
     nbMedia = MediaDAO
@@ -392,7 +392,7 @@ public class MediaDaoIT extends BaseGalleryIT {
     assertThat(nbMedia, is(1L));
 
     // Simulating a connected publisher user
-    ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
+    ((SessionCacheAccessor) CacheAccessorProvider.getSessionCacheAccessor())
         .newSessionCache(publisherUser);
 
     nbMedia = MediaDAO.countByCriteria(

--- a/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/control/GallerySessionController.java
+++ b/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/control/GallerySessionController.java
@@ -102,7 +102,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getSessionCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getSessionCacheAccessor;
 
 public final class GallerySessionController extends AbstractComponentSessionController {
 
@@ -1343,7 +1343,7 @@ public final class GallerySessionController extends AbstractComponentSessionCont
           fileName.substring(fileName.indexOf('/') + 1, fileName.indexOf('.'));
       String registerId = getComponentId() + ":" + xmlFormShortName;
       final String sessionCacheKey = this.getClass().getName() + registerId;
-      SimpleCache sessionCache = getSessionCacheService().getCache();
+      SimpleCache sessionCache = getSessionCacheAccessor().getCache();
       if (sessionCache.get(sessionCacheKey) == null) {
         getPublicationTemplateManager().addDynamicPublicationTemplate(registerId, fileName);
         sessionCache.put(sessionCacheKey, registerId);

--- a/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/servlets/GalleryRequestRouter.java
+++ b/gallery/gallery-war/src/main/java/org/silverpeas/components/gallery/servlets/GalleryRequestRouter.java
@@ -75,7 +75,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getSessionCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getSessionCacheAccessor;
 import static org.silverpeas.core.persistence.jdbc.sql.JdbcSqlQuery.isSqlDefined;
 import static org.silverpeas.core.util.JSONCodec.encodeObject;
 import static org.silverpeas.core.web.http.FileResponse.DOWNLOAD_CONTEXT_PARAM;
@@ -1118,7 +1118,7 @@ public class GalleryRequestRouter extends ComponentRequestRouter<GallerySessionC
           // retour à la demande
           destination = getDestination(ORDER_VIEW_PAGIN_FUNC, gallerySC, request);
         } else if ("OrderDownloadMedia".equals(function)) {
-          final SimpleCache cache = getSessionCacheService().getCache();
+          final SimpleCache cache = getSessionCacheAccessor().getCache();
           destination = Optional.ofNullable(request.getParameter("downloadId"))
               .filter(StringUtil::isDefined)
               .map(d -> Optional.ofNullable(cache.remove(d, String.class))

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -146,7 +146,7 @@ import static org.silverpeas.components.kmelia.service.KmeliaOperationContext.Op
 import static org.silverpeas.components.kmelia.service.KmeliaServiceContext.*;
 import static org.silverpeas.core.admin.component.model.ComponentInst.getComponentLocalId;
 import static org.silverpeas.core.admin.service.OrganizationControllerProvider.getOrganisationController;
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getRequestCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getThreadCacheAccessor;
 import static org.silverpeas.core.contribution.attachment.AttachmentService.VERSION_MODE;
 import static org.silverpeas.core.contribution.attachment.AttachmentServiceProvider.getAttachmentService;
 import static org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController.deleteWysiwygAttachmentsOnly;
@@ -302,7 +302,7 @@ public class DefaultKmeliaService implements KmeliaService {
   public List<KmeliaPublication> getLatestAuthorizedPublications(String instanceId, String userId,
       int limit) {
     final long start = System.currentTimeMillis();
-    final List<KmeliaPublication> result = getRequestCacheService().getCache()
+    final List<KmeliaPublication> result = getThreadCacheAccessor().getCache()
         .computeIfAbsent(
             "KmeliaService:getLatestAuthorizedPublications:" + instanceId + ":" + userId + ":" +
                 limit, List.class, () -> {
@@ -1535,7 +1535,7 @@ public class DefaultKmeliaService implements KmeliaService {
       }
 
       // Subscriptions related to aliases
-      Collection<Location> locations = (Collection<Location>) getRequestCacheService().getCache()
+      Collection<Location> locations = (Collection<Location>) getThreadCacheAccessor().getCache()
           .get(ALIASES_CACHE_KEY);
       if (locations == null) {
         locations = getAliases(pubDetail.getPK());
@@ -3367,7 +3367,7 @@ public class DefaultKmeliaService implements KmeliaService {
         locations);
 
     // Send subscriptions to aliases subscribers
-    getRequestCacheService().getCache().put(ALIASES_CACHE_KEY, result.getFirst());
+    getThreadCacheAccessor().getCache().put(ALIASES_CACHE_KEY, result.getFirst());
     PublicationDetail pubDetail = getPublicationDetail(pubPK);
     sendSubscriptionsNotification(pubDetail, NotifAction.PUBLISHED, true);
   }

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaOperationContext.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaOperationContext.java
@@ -25,7 +25,7 @@
 package org.silverpeas.components.kmelia.service;
 
 import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.persistence.datasource.OperationContext;
 
 import java.util.Optional;
@@ -46,7 +46,7 @@ public class KmeliaOperationContext {
    * @return optionally the current operation context if any.
    */
   public static Optional<KmeliaOperationContext> current() {
-    return Optional.ofNullable(CacheServiceProvider.getRequestCacheService()
+    return Optional.ofNullable(CacheAccessorProvider.getThreadCacheAccessor()
         .getCache()
         .get(cacheKey, KmeliaOperationContext.class));
   }
@@ -57,7 +57,7 @@ public class KmeliaOperationContext {
    */
   public static void about(final OperationType type) {
     KmeliaOperationContext context = new KmeliaOperationContext(type);
-    CacheServiceProvider.getRequestCacheService().getCache().put(cacheKey, context);
+    CacheAccessorProvider.getThreadCacheAccessor().getCache().put(cacheKey, context);
   }
 
   private KmeliaOperationContext(final OperationType type) {

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaServiceContext.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaServiceContext.java
@@ -25,7 +25,7 @@ package org.silverpeas.components.kmelia.service;
 
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getRequestCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getThreadCacheAccessor;
 
 /**
  * This class permits to get the some flags about the Kmelia Service context.
@@ -39,7 +39,7 @@ class KmeliaServiceContext {
    */
   static void createdIntoRequestContext(final PublicationDetail publication) {
     String cacheKey = buildKey("publicationCreation", publication);
-    getRequestCacheService().getCache().put(cacheKey, Boolean.TRUE);
+    getThreadCacheAccessor().getCache().put(cacheKey, Boolean.TRUE);
   }
 
   /**
@@ -49,7 +49,7 @@ class KmeliaServiceContext {
    */
   static boolean hasPublicationBeenCreatedFromRequestContext(PublicationDetail publication) {
     String cacheKey = buildKey("publicationCreation", publication);
-    return Boolean.TRUE == getRequestCacheService().getCache().get(cacheKey, Boolean.class);
+    return Boolean.TRUE == getThreadCacheAccessor().getCache().get(cacheKey, Boolean.class);
   }
 
 
@@ -59,7 +59,7 @@ class KmeliaServiceContext {
    */
   static void updatedIntoRequestContext(final PublicationDetail publication) {
     String cacheKey = buildKey("publicationModification", publication);
-    getRequestCacheService().getCache().put(cacheKey, Boolean.TRUE);
+    getThreadCacheAccessor().getCache().put(cacheKey, Boolean.TRUE);
   }
 
   /**
@@ -69,7 +69,7 @@ class KmeliaServiceContext {
    */
   static boolean hasPublicationBeenUpdatedFromRequestContext(PublicationDetail publication) {
     String cacheKey = buildKey("publicationModification", publication);
-    return Boolean.TRUE == getRequestCacheService().getCache().get(cacheKey, Boolean.class);
+    return Boolean.TRUE == getThreadCacheAccessor().getCache().get(cacheKey, Boolean.class);
   }
 
   /**

--- a/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaServiceContextTest.java
+++ b/kmelia/kmelia-library/src/test/java/org/silverpeas/components/kmelia/service/KmeliaServiceContextTest.java
@@ -26,7 +26,7 @@ package org.silverpeas.components.kmelia.service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.test.unit.extention.EnableSilverTestEnv;
@@ -47,7 +47,7 @@ class KmeliaServiceContextTest {
 
   @BeforeEach
   public void setup() {
-    CacheServiceProvider.clearAllThreadCaches();
+    CacheAccessorProvider.getThreadCacheAccessor().getCache().clear();
     publication = PublicationDetail.builder()
         .setPk(new PublicationPK("id", "instanceId"))
         .build();
@@ -62,7 +62,7 @@ class KmeliaServiceContextTest {
 
   @AfterEach
   public void tearDown() {
-    CacheServiceProvider.getRequestCacheService().clearAllCaches();
+    CacheAccessorProvider.getThreadCacheAccessor().getCache().clear();
     assertClearedContext();
   }
 

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -163,7 +163,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.silverpeas.components.kmelia.control.KmeliaSessionController.CLIPBOARD_STATE.*;
 import static org.silverpeas.components.kmelia.export.KmeliaPublicationExporter.*;
 import static org.silverpeas.core.admin.component.model.ComponentInst.getComponentLocalId;
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getSessionCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getSessionCacheAccessor;
 import static org.silverpeas.core.cache.service.VolatileIdentifierProvider.newVolatileIntegerIdentifierOn;
 import static org.silverpeas.core.contribution.attachment.AttachmentService.VERSION_MODE;
 import static org.silverpeas.core.index.search.SearchEngineProvider.getSearchEngine;
@@ -1408,7 +1408,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
   }
 
   private void cacheDirectlyPublicationsListInSession(final List<KmeliaPublication> publications) {
-    getSessionCacheService().getCache().put(getPublicationListSessionCacheKey(), publications);
+    getSessionCacheAccessor().getCache().put(getPublicationListSessionCacheKey(), publications);
   }
 
   public void setSessionCombination(List<String> combination) {
@@ -1494,7 +1494,7 @@ public class KmeliaSessionController extends AbstractComponentSessionController
 
   @SuppressWarnings("unchecked")
   public List<KmeliaPublication> getSessionPublicationsList() {
-    return (List<KmeliaPublication>) getSessionCacheService().getCache().get(getPublicationListSessionCacheKey());
+    return (List<KmeliaPublication>) getSessionCacheAccessor().getCache().get(getPublicationListSessionCacheKey());
   }
 
   public List<String> getSessionCombination() {

--- a/mydb/mydb-war/src/main/java/org/silverpeas/components/mydb/web/MyDBMessageManager.java
+++ b/mydb/mydb-war/src/main/java/org/silverpeas/components/mydb/web/MyDBMessageManager.java
@@ -24,7 +24,7 @@
 
 package org.silverpeas.components.mydb.web;
 
-import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
 import org.silverpeas.core.util.Pair;
 
 import static org.silverpeas.core.util.StringUtil.EMPTY;
@@ -43,7 +43,7 @@ public class MyDBMessageManager {
 
   public static MyDBMessageManager get() {
     final Class<MyDBMessageManager> ownClass = MyDBMessageManager.class;
-    return CacheServiceProvider.getRequestCacheService()
+    return CacheAccessorProvider.getThreadCacheAccessor()
         .getCache()
         .computeIfAbsent(ownClass.getName(), ownClass, MyDBMessageManager::new);
   }

--- a/processManager/processManager-war/src/main/java/org/silverpeas/processmanager/ProcessManagerSessionController.java
+++ b/processManager/processManager-war/src/main/java/org/silverpeas/processmanager/ProcessManagerSessionController.java
@@ -101,7 +101,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static org.silverpeas.core.SilverpeasExceptionMessages.failureOnGetting;
-import static org.silverpeas.core.cache.service.CacheServiceProvider.getRequestCacheService;
+import static org.silverpeas.core.cache.service.CacheAccessorProvider.getThreadCacheAccessor;
 import static org.silverpeas.core.contribution.attachment.AttachmentService.VERSION_MODE;
 import static org.silverpeas.core.util.CollectionUtil.asList;
 import static org.silverpeas.core.util.StringUtil.isDefined;
@@ -728,7 +728,7 @@ public class ProcessManagerSessionController extends AbstractComponentSessionCon
    * Returns the user roles as a list of (name, label) pair.
    */
   public NamedValue[] getUserRoleLabels() {
-    return getRequestCacheService()
+    return getThreadCacheAccessor()
         .getCache()
         .computeIfAbsent("ProcessManagerSC.getUserRoleLabels" + getComponentId(),
             NamedValue[].class, () -> {


### PR DESCRIPTION
Take into account the change in Silverpeas-Core of the cache API: CacheService classes become CacheAccessor classes. CacheServiceProvider is renamed to CacheAccessorProvider. The request cache service isn't anymore provided; instead use the ThreadCacheAccessor and its ThreadCache.

Don't forget to merge before https://github.com/Silverpeas/Silverpeas-Core/pull/1291
Don't forget to merge after https://github.com/Silverpeas/Silverpeas-Looks/pull/76