### PR TITLE
Feature #14033

### DIFF
--- a/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityManagementIT.java
+++ b/community/community-library/src/integration-test/java/org/silverpeas/components/community/CommunityManagementIT.java
@@ -112,6 +112,16 @@ public class CommunityManagementIT {
   }
 
   @Test
+  public void getAllExistingCommunities() {
+    List<String> appIds = List.of("community1", "community2", "community3");
+    List<CommunityOfUsers> communities = CommunityOfUsers.getAll();
+    assertThat(communities.size(), is(3));
+    boolean matches =
+        communities.stream().allMatch(c -> appIds.contains(c.getComponentInstanceId()));
+    assertThat(matches, is(true));
+  }
+
+  @Test
   public void getANonExistingCommunity() {
     String instanceId = "community100";
     Optional<CommunityOfUsers> community = CommunityOfUsers.getByComponentInstanceId(instanceId);

--- a/community/community-library/src/integration-test/java/org/silverpeas/components/community/TestScope.java
+++ b/community/community-library/src/integration-test/java/org/silverpeas/components/community/TestScope.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2000 - 2024 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.com/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.community;
+
+import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.admin.user.model.User;
+
+import java.util.ArrayList;
+
+/**
+ * Scope of a running integration test. It provides useful and utility methods for tests.
+ * @author mmoquillon
+ */
+public class TestScope {
+
+  public static ComponentInst newCommunityAppInstance() {
+    ComponentInst componentInst = new ComponentInst();
+    componentInst.setDomainFatherId("WA4");
+    componentInst.setCreatorUserId(User.getCurrentUser().getId());
+    componentInst.setName("community");
+    componentInst.setLabel("WA4 Community");
+    componentInst.setDescription("Community of users for space WA4");
+    componentInst.setPublic(true);
+    componentInst.setHidden(false);
+    componentInst.setInheritanceBlocked(true);
+    componentInst.setParameters(new ArrayList<>());
+    return componentInst;
+  }
+}
+  

--- a/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePostConstruction.java
+++ b/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePostConstruction.java
@@ -24,7 +24,9 @@
 package org.silverpeas.components.community;
 
 import org.silverpeas.components.community.model.CommunityOfUsers;
+import org.silverpeas.components.community.notification.CommunityEventNotifier;
 import org.silverpeas.components.community.repository.CommunityOfUsersRepository;
+import org.silverpeas.core.notification.system.ResourceEvent;
 import org.silverpeas.kernel.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.component.ComponentInstancePostConstruction;
 import org.silverpeas.core.admin.component.model.ComponentInst;
@@ -54,6 +56,9 @@ public class CommunityInstancePostConstruction implements ComponentInstancePostC
   @Inject
   private CommunityOfUsersRepository repository;
 
+  @Inject
+  private CommunityEventNotifier notifier;
+
 
   @Transactional
   @Override
@@ -61,12 +66,14 @@ public class CommunityInstancePostConstruction implements ComponentInstancePostC
     ComponentInst instance = getComponentInst(componentInstanceId);
     SpaceInst spaceInst = getSpaceInst(instance.getSpaceId());
     CommunityOfUsers community = new CommunityOfUsers(instance.getId(), spaceInst.getId());
-    repository.save(community);
+    CommunityOfUsers savedCommunity = repository.save(community);
 
     spaceInst.setFirstPageExtraParam(componentInstanceId);
     spaceInst.setInheritanceBlocked(true);
     spaceInst.setFirstPageType(SpaceHomePageType.COMPONENT_INST.ordinal());
     updateSpaceInst(spaceInst);
+
+    notifier.notifyEventOn(ResourceEvent.Type.CREATION, savedCommunity);
   }
 
   private ComponentInst getComponentInst(final String instanceId) {

--- a/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePreDestruction.java
+++ b/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePreDestruction.java
@@ -23,11 +23,13 @@
  */
 package org.silverpeas.components.community;
 
+import org.silverpeas.components.community.notification.CommunityEventNotifier;
 import org.silverpeas.components.community.repository.CommunityMembershipRepository;
 import org.silverpeas.components.community.repository.CommunityOfUsersRepository;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.contribution.model.WysiwygContent;
+import org.silverpeas.core.notification.system.ResourceEvent;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -45,6 +47,8 @@ public class CommunityInstancePreDestruction implements ComponentInstancePreDest
   private CommunityOfUsersRepository communitiesRepository;
   @Inject
   private CommunityMembershipRepository membersRepository;
+  @Inject
+  private CommunityEventNotifier notifier;
 
   @Transactional
   @Override
@@ -58,6 +62,7 @@ public class CommunityInstancePreDestruction implements ComponentInstancePreDest
       membersRepository.getMembershipsTable(c).deleteAll();
       // delete finally the community of users
       c.delete();
+      notifier.notifyEventOn(ResourceEvent.Type.DELETION, c);
     });
   }
 }


### PR DESCRIPTION
Now the creation and the deletion of a community of users is notified. This can be used for external components to access the newly created commiunity of users in order to perform some post-processing with the community.

New CommunityOfUsers#getGroupOfMembers() method. This method returns the group of members in the community. If such a group doesn't yet exist, then it is created for the community of users. It is a way to get all the actual members of a community without having to filter the memberships by their status.

New CommunityOfUsers#getAll() static method to get all the existing community of users.