### PR TITLE
Bug #14471

### DIFF
--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaComponentAuthorization.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaComponentAuthorization.java
@@ -20,6 +20,7 @@
  */
 package org.silverpeas.components.kmelia;
 
+import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.security.authorization.AccessControlContext;
@@ -32,12 +33,10 @@ import org.silverpeas.core.util.MapUtil;
 import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Named;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.io.Serializable;
+import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.silverpeas.kernel.util.StringUtil.isDefined;
@@ -63,37 +62,42 @@ public class KmeliaComponentAuthorization implements ComponentAuthorization {
   public <T> Stream<T> filter(final Collection<T> resources,
       final Function<T, ComponentResourceReference> converter, final String userId,
       final AccessControlOperation... operations) {
-    final Map<PublicationPK, Set<ComponentResourceReference>> pubPks = new HashMap<>(resources.size());
-    final Map<NodePK, Set<ComponentResourceReference>> nodePks = new HashMap<>(resources.size());
-    final Map<String, Set<ComponentResourceReference>> instanceIds = new HashMap<>(resources.size());
+    final Map<ResourceRefHash, Set<ComponentResourceReference>> pubPks =
+        new HashMap<>(resources.size());
+    final Map<ResourceRefHash, Set<ComponentResourceReference>> nodePks =
+        new HashMap<>(resources.size());
+    final Map<String, Set<ComponentResourceReference>> instanceIds =
+        new HashMap<>(resources.size());
     final Set<ComponentResourceReference> authorized = new HashSet<>(resources.size());
     resources.forEach(r -> {
       final ComponentResourceReference resourceRef = converter.apply(r);
       final String resourceType = resourceRef.getType();
-        if (isHandledKmeliaResourceType(resourceType)) {
-          if (StringUtil.isLong(resourceRef.getLocalId())) {
-            MapUtil.putAddSet(pubPks,
-                new PublicationPK(resourceRef.getLocalId(), resourceRef.getInstanceId()),
-                resourceRef);
-          }
-        } else if (NODE_TYPE.equalsIgnoreCase(resourceType)) {
-          MapUtil
-              .putAddSet(nodePks, new NodePK(resourceRef.getLocalId(), resourceRef.getInstanceId()),
-                  resourceRef);
-        } else if (isDefined(resourceRef.getInstanceId())) {
-          MapUtil.putAddSet(instanceIds, resourceRef.getInstanceId(), resourceRef);
-        } else {
-          authorized.add(resourceRef);
+      if (isHandledKmeliaResourceType(resourceType)) {
+        if (StringUtil.isLong(resourceRef.getLocalId())) {
+          MapUtil.putAddSet(pubPks,
+              new ResourceRefHash(resourceRef.getLocalId(), resourceRef.getInstanceId()),
+              resourceRef);
         }
+      } else if (NODE_TYPE.equalsIgnoreCase(resourceType)) {
+        MapUtil.putAddSet(nodePks,
+            new ResourceRefHash(resourceRef.getLocalId(), resourceRef.getInstanceId()),
+            resourceRef);
+      } else if (isDefined(resourceRef.getInstanceId())) {
+        MapUtil.putAddSet(instanceIds, resourceRef.getInstanceId(), resourceRef);
+      } else {
+        authorized.add(resourceRef);
+      }
     });
-    PublicationAccessControl.get().filterAuthorizedByUser(pubPks.keySet(), userId, AccessControlContext
-        .init().onOperationsOf(operations))
-        .forEach(p -> authorized.addAll(pubPks.get(p)));
-    NodeAccessControl.get().filterAuthorizedByUser(nodePks.keySet(), userId, AccessControlContext
-        .init().onOperationsOf(operations))
-        .forEach(p -> authorized.addAll(nodePks.get(p)));
-    ComponentAccessControl.get().filterAuthorizedByUser(instanceIds.keySet(), userId, AccessControlContext
-        .init().onOperationsOf(operations))
+    PublicationAccessControl.get()
+        .filterAuthorizedByUser(ResourceRefHash.toPublicationPKs(pubPks.keySet()), userId,
+            AccessControlContext.init().onOperationsOf(operations))
+        .forEach(p -> authorized.addAll(pubPks.get(new ResourceRefHash(p))));
+    NodeAccessControl.get()
+        .filterAuthorizedByUser(ResourceRefHash.toNodePks(nodePks.keySet()), userId,
+            AccessControlContext.init().onOperationsOf(operations))
+        .forEach(p -> authorized.addAll(nodePks.get(new ResourceRefHash(p))));
+    ComponentAccessControl.get().filterAuthorizedByUser(instanceIds.keySet(), userId,
+            AccessControlContext.init().onOperationsOf(operations))
         .forEach(p -> authorized.addAll(instanceIds.get(p)));
     return resources.stream().filter(r -> authorized.contains(converter.apply(r)));
   }
@@ -101,5 +105,58 @@ public class KmeliaComponentAuthorization implements ComponentAuthorization {
   private boolean isHandledKmeliaResourceType(String objectType) {
     return objectType != null && (PUBLICATION_TYPE.equalsIgnoreCase(objectType)
         || objectType.startsWith(ATTACHMENT_TYPE) || objectType.startsWith(VERSION_TYPE));
+  }
+
+  /**
+   * Hash to use as key in Map. This class ensures the equality and hash computation is done on
+   * both the local identifier of a resource and on the identifier of the component instance the
+   * resource belongs to. Indeed, in the general case, a contribution is uniquely identified by
+   * its local id and by the component instance it belongs to, but some contributions can be
+   * located in several component instances and in such a case they are uniquely identifier by
+   * their local id (that is also, in this case, their global id).
+   */
+  private static class ResourceRefHash implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String localId;
+    private final String instanceId;
+
+    public static List<PublicationPK> toPublicationPKs(Collection<ResourceRefHash> hashes) {
+      return hashes.stream().map(ResourceRefHash::toPublicationPK).collect(Collectors.toList());
+    }
+
+    public static List<NodePK> toNodePks(Collection<ResourceRefHash> hashes) {
+      return hashes.stream().map(ResourceRefHash::toNodePK).collect(Collectors.toList());
+    }
+
+    public ResourceRefHash(String localId, String instanceId) {
+      this.localId = localId;
+      this.instanceId = instanceId;
+    }
+
+    public ResourceRefHash(ResourceReference resourceRef) {
+      this.localId = resourceRef.getLocalId();
+      this.instanceId = resourceRef.getInstanceId();
+    }
+
+    public PublicationPK toPublicationPK() {
+      return new PublicationPK(localId, instanceId);
+    }
+
+    public NodePK toNodePK() {
+      return new NodePK(localId, instanceId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      ResourceRefHash that = (ResourceRefHash) o;
+      return Objects.equals(localId, that.localId) && Objects.equals(instanceId, that.instanceId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(localId, instanceId);
+    }
   }
 }


### PR DESCRIPTION
A publication is a pueculiar contribution in Silverpeas as iti can be located in several locations in the same or in different component instances. In this case, we have the original publication along with its all aliases. This capability is used in the Kmelia application. As consequence, the publication is only referred uniquely by its local identifier (its local identifier is its global one), whereas the others types of contributions are identified uniquely by their global identifier that is made up of their local identifier and of the identifier of the application instance they belong to.

Despite this peculiarity, the authorization mechanism in Kmelia takes the publication by their local identifier and, in a such context, any access right validation can be incorrect on publication aliases located in a topic for which specific access rights have been set.

Now, the publications, whatever they are (original one or aliases) are taken in charge by both their local identifier and the identifier of the component instance they belong to.

This PR is based upon the following one: https://github.com/Silverpeas/Silverpeas-Core/pull/1358