### PR TITLE
Bug #14503

### DIFF
--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/javaScript/navigation.js
@@ -664,6 +664,7 @@ function showTranslation(lang) {
   }
   if (!found) {
     setDataInFolderDialog("", "");
+    $('select[name="I18NLanguage"] option:selected').val(lang + "_-1");
   }
 }
 


### PR DESCRIPTION
By testing the fix of the bug, I discovered a nasty hidden bug in js when adding a new translation for a given topic: when the properties of a topic is rendered, an HTML select element is updated with the translations of the node's properties. If we ask to see the properties of a topic for which its name and description were translated for all of the supported languages, the HTML select element is correctly updated. But, if after we ask to see the properties of another topic for which a translation is missed, then the HTML select element isn't correctly updated for the missed translation: instead of having for the missing translation an identifier of -1, it kept the id of the translation of the previous selected topic for the same language.

Fix this bug.

Related to the PR https://github.com/Silverpeas/Silverpeas-Core/pull/1361