### PR TITLE
Bug #14523

### DIFF
--- a/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/model/ClassifiedDetail.java
+++ b/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/model/ClassifiedDetail.java
@@ -279,6 +279,16 @@ public class ClassifiedDetail implements SilverpeasContent {
     return VALID.equals(getStatus());
   }
 
+  /**
+   * A classified is indexable only and only it has been validated. So, a classified in draft, or
+   * a classified in validation, or a removed classified isn't indexable.
+   * @return true if the classified is indexable, that is to say it is validated. False otherwise.
+   */
+  @Override
+  public boolean isIndexable() {
+    return isValid();
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/service/DefaultClassifiedService.java
+++ b/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/service/DefaultClassifiedService.java
@@ -207,7 +207,11 @@ public class DefaultClassifiedService implements ClassifiedService {
   public void updateClassified(ClassifiedDetail classified, boolean notify) {
     try (Connection con = openConnection()) {
       ClassifiedsDAO.updateClassified(con, classified);
-      createIndex(classified);
+      if (classified.isIndexable()) {
+        createIndex(classified);
+      } else {
+        deleteIndex(classified);
+      }
       if (notify) {
         sendAlertToSupervisors(classified);
       }
@@ -367,7 +371,7 @@ public class DefaultClassifiedService implements ClassifiedService {
 
   private void createIndex(ClassifiedDetail classified, PublicationTemplate template) {
     FullIndexEntry indexEntry;
-    if (classified != null) {
+    if (classified != null && classified.isIndexable()) {
       indexEntry = new FullIndexEntry(new IndexEntryKey(classified.getInstanceId(), CLASSIFIED_TYPE,
           Integer.toString(classified.getClassifiedId())));
       indexEntry.setTitle(classified.getTitle());


### PR DESCRIPTION
Now, when a classified ad isn't validated, it is not indexable. If a validated classified ad is put in draft (for modification), then its index is deleted. Index is created only for validated classfied ads.