### PR TITLE
Bug #14391

### DIFF
--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/control/KmeliaSessionController.java
@@ -741,6 +741,27 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     indexOfFirstPubToDisplay = 0;
   }
 
+  /**
+   * Update the specified topic. If the local rights of the topic are enabled, then from the
+   * inherited rights, only the admin ones are kept.
+   * @param topic the topic to update with the updated data
+   * @param alertType the type of notification: notify all the users ("All"), only the publishers
+   * ("publisher"), or nobody ("None").
+   */
+  public synchronized void updateTopic(NodeDetail topic, String alertType) {
+    NodeDetail previousTopic = getNodeHeader(topic.getId());
+    updateTopicHeader(topic, alertType);
+    if (!previousTopic.haveLocalRights() && topic.haveLocalRights()) {
+      initTopicSpecificAdminProfiles(topic.getNodePK(), topic.getFatherPK());
+    }
+  }
+
+  /**
+   * Update only header information about the specified topic.
+   * @param nd the topic to update with the updated data
+   * @param alertType the type of notification: notify all the users ("All"), only the publishers
+   * ("publisher"), or nobody ("None").
+   */
   public synchronized void updateTopicHeader(NodeDetail nd, String alertType) {
     nd.getNodePK().setSpace(getSpaceId());
     nd.getNodePK().setComponentName(getComponentId());
@@ -763,12 +784,19 @@ public class KmeliaSessionController extends AbstractComponentSessionController
     nd.getNodePK().setSpace(getSpaceId());
     nd.getNodePK().setComponentName(getComponentId());
     nd.setCreatorId(getUserId());
-    NodePK pk = getKmeliaService().addSubTopic(getNodePK(parentId), nd, alertType);
+    NodePK parentPk = getNodePK(parentId);
+    NodePK pk = getKmeliaService().addSubTopic(parentPk, nd, alertType);
+    initTopicSpecificAdminProfiles(pk, parentPk);
 
+    return pk;
+  }
+
+  private void initTopicSpecificAdminProfiles(NodePK pk, NodePK parentPk) {
     // by default, sets father's admin rights in the case of specific rights
     // to prevent no access to users having some rights with the father topic
-    NodeDetail created = getNodeHeader(pk.getId());
-    if (created.haveLocalRights()) {
+    NodeDetail node = getNodeHeader(pk.getId());
+    String parentId = parentPk.getId();
+    if (node.haveLocalRights()) {
       ProfileInst parentProfile;
       String profileAdmin = SilverpeasRole.ADMIN.getName();
       if (NodePK.ROOT_NODE_ID.equals(parentId)) {
@@ -782,8 +810,6 @@ public class KmeliaSessionController extends AbstractComponentSessionController
             parentProfile.getAllUsers().toArray(new String[0]));
       }
     }
-
-    return pk;
   }
 
   public synchronized String deleteTopic(String topicId) {

--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -135,7 +135,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     boolean kmaxMode = false;
     boolean toolboxMode;
     SilverpeasRole highestSilverpeasUserRoleOnCurrentTopic =
-        getHighestSilverpeasUserRoleOnCurrentTopic(kmelia, function);
+        getHighestSilverpeasUserRoleOnCurrentTopic(kmelia);
     try {
       if ("kmax".equals(kmelia.getComponentRootName())) {
         kmaxMode = true;
@@ -503,7 +503,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
             goToProfilesDefinition = true;
           }
         }
-        kmelia.updateTopicHeader(topic, alertType);
+        kmelia.updateTopic(topic, alertType);
 
         if (goToProfilesDefinition) {
           request.setAttribute("NodeId", id);
@@ -1487,7 +1487,7 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
 
   @NonNull
   private static SilverpeasRole getHighestSilverpeasUserRoleOnCurrentTopic(
-      KmeliaSessionController kmelia, String function) {
+      KmeliaSessionController kmelia) {
     return SilverpeasRole.fromString(kmelia.getUserTopicProfile(kmelia.getCurrentFolderId()));
   }
 


### PR DESCRIPTION
In Kmelia: when updating a folder within which the local rights are enabled, the admin specific rights of the folder are then initialized with the admin rights inherited from the parent folder. This behavior is then coherent with the creation of a new folder with specific rights.