### PR TITLE
Bug #14661

### DIFF
--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/renderers/PublicationsRenderer.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/renderers/PublicationsRenderer.java
@@ -557,11 +557,11 @@ public class PublicationsRenderer implements Renderer {
 
     writer.write(SCRIPT_START);
     writer.write("whenSilverpeasReady(function() {" +
-        "  document.querySelectorAll('a.pub-link').forEach(function(a) {\n" +
+        "  document.querySelectorAll('.publication-name a').forEach(function(a) {\n" +
         "    a.addEventListener('click', function(e) {\n" +
         "      e.preventDefault();\n" +
         "      e.stopPropagation();\n" +
-        "      const pubId = this.getAttribute('id').trim().slice(4);\n" +
+        "      const pubId = this.querySelector('span.jstree-draggable').getAttribute('id').trim().slice(4);\n" +
         "      publicationGoTo(pubId);\n" +
         "    });" +
         "  });" +
@@ -666,10 +666,9 @@ public class PublicationsRenderer implements Renderer {
       PublicationFragmentSettings fragmentSettings) throws IOException {
     writer.write("<div class=\"");
     writer.write(fragmentSettings.getPubColor());
-    writer.write("\"><a href=\"#\" class=\"pub-link\" id=\"pub-" + pub.getPK().getId());
-    writer.write("\"><span class=\"" + fragmentSettings.getHighlightClass() + "\">");
+    writer.write("\"><a href=\"#\"><span class=\"" + fragmentSettings.getHighlightClass() + "\">");
     if (fragmentSettings.isDraggable()) {
-      writer.write("<span class=\"jstree-draggable\">");
+      writer.write("<span class=\"jstree-draggable\" id=\"pub-" + pub.getPK().getId() + "\">");
       writer.write(name);
       writer.write(END_SPAN);
     } else {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/treeview.jsp
@@ -920,7 +920,7 @@
           'nodes' : [{id : $(this).attr('id'), text : $(this).text()}]
         },
         '<div id="jstree-dnd" class="jstree-default"><i class="jstree-icon jstree-er"></i>' +
-        $(this).text() + '</div>');
+        $(this).text().escapeHTML() + '</div>');
   });
 
   window.__spTreeviewDndContext = {


### PR DESCRIPTION
Fix the bug. The d&d handling was based upon the .jstree-draggable class. But since the refactoring within the fix of the bug 14478, the <span> with this CSS class didn't receive anymore the mouse event but its <a> parent because this one had a class attribute set. Without the class attribute in the <a> parent, the <span> element succeed to receive any mouse click down event on it. Nevertheless, in order the d&d mechanism works on publications, it was needed to move the id attribute from the <a> element to the <span class=".jstree-draggable> element because this publication identifier is fetched from this id on the dragged HTML node. So, the click event handler of the <a> node required to be refined to take into account of this (because the id attribute was also fetched to figure out the identifier of the publication to redirect the user to.