### PR TITLE
Bug #14678

### DIFF
--- a/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
+++ b/kmelia/kmelia-war/src/main/java/org/silverpeas/components/kmelia/servlets/KmeliaRequestRouter.java
@@ -1548,6 +1548,9 @@ public class KmeliaRequestRouter extends ComponentRequestRouter<KmeliaSessionCon
     String status = FileUploadUtil.getParameter(parameters, "KmeliaPubStatus");
     String name = FileUploadUtil.getParameter(parameters, "KmeliaPubName");
     String description = FileUploadUtil.getParameter(parameters, "KmeliaPubDescription");
+    if (StringUtil.isDefined(description)) {
+      description = description.trim();
+    }
     String keywords = FileUploadUtil.getParameter(parameters, "KmeliaPubKeywords");
     String beginDate = FileUploadUtil.getParameter(parameters, "KmeliaPubBeginDate");
     String endDate = FileUploadUtil.getParameter(parameters, "KmeliaPubEndDate");

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publication.jsp
@@ -56,6 +56,7 @@
 <%@ page import="org.silverpeas.core.contribution.publication.model.Location" %>
 <%@ page import="org.silverpeas.components.kmelia.model.ValidatorsList" %>
 <%@ page import="org.silverpeas.core.web.selection.BasketSelectionUI" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <c:set var="userLanguage" value="${requestScope.resources.language}"/>
 <c:set var="contentLanguage" value="${requestScope.Language}"/>
@@ -465,7 +466,8 @@
 
     function addFavorite() {
       var name = $("#breadCrumb").text();
-      var description = "<%=org.owasp.encoder.Encode.forHtml(pubDetail.getDescription(language))%>";
+      var description =
+              "<%=WebEncodeHelper.convertBlanksForHtml(Encode.forHtml(pubDetail.getDescription(language)))%>";
       var url = "<%=pubPermalink%>";
       postNewLink(name, url, description);
     }
@@ -827,7 +829,7 @@
 
     out.println("</h2>");
 
-    String description = WebEncodeHelper.convertBlanksForHtml(WebEncodeHelper.javaStringToHtmlString(pubDetail.getDescription(language)));
+    String description = WebEncodeHelper.javaStringToHtmlParagraphe(pubDetail.getDescription(language));
     if (StringUtil.isDefined(description)) {
       out.println("<p class=\"publiDesc text2\">" + description + "</p>");
     }

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationManager.jsp
@@ -157,7 +157,7 @@
       }
 
       name = WebEncodeHelper.javaStringToHtmlString(pubDetail.getName(language));
-      description = WebEncodeHelper.javaStringToHtmlString(StringUtil.defaultIfBlank(pubDetail.getDescription(language), ""));
+      description = Encode.forHtml(StringUtil.defaultIfBlank(pubDetail.getDescription(language), ""));
       creationDate = resources.getOutputDate(pubDetail.getCreationDate());
       if (pubDetail.getBeginDate() != null) {
         beginDate = resources.getInputDate(pubDetail.getBeginDate());
@@ -500,7 +500,7 @@
 	      	namePath = namePath + " > " + pathString;
 	      }
 		  operationPane.addOperation(favoriteAddSrc,
-                  resources.getString("FavoritesAddPublication")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+WebEncodeHelper.javaStringToJsString(namePath)+"','"+WebEncodeHelper.javaStringToHtmlString(pubDetail.getDescription(language))+"','"+urlPublication+"')");
+                  resources.getString("FavoritesAddPublication")+" "+kmeliaScc.getString("FavoritesAdd2"), "javaScript:addFavorite('"+WebEncodeHelper.javaStringToJsString(namePath)+"','"+WebEncodeHelper.javaStringToHtmlParagraphe(pubDetail.getDescription(language))+"','"+urlPublication+"')");
           operationPane.addLine();
 
           if (!"supervisor".equals(profile)) {

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationViewOnly.jsp
@@ -106,7 +106,7 @@ response.setDateHeader ("Expires",-1); //prevents caching at the proxy server
 		<tr>
 			<td align="left"<%=newCssClass%>><span class="txtnav publication-name"><strong><%=WebEncodeHelper.javaStringToHtmlString(detail.getName(kmeliaScc.getCurrentLanguage()))%></strong></span><BR>
 
-        <strong><%=WebEncodeHelper.javaStringToHtmlString(detail.getDescription(kmeliaScc.getCurrentLanguage()))%></strong>
+        <strong><%=WebEncodeHelper.javaStringToHtmlParagraphe(detail.getDescription(kmeliaScc.getCurrentLanguage()))%></strong>
 				<br />
 				<br /> 
 <%

--- a/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationsList.jsp
+++ b/kmelia/kmelia-war/src/main/webapp/kmelia/jsp/publicationsList.jsp
@@ -105,7 +105,7 @@ void displaySameSubjectPublications(Collection pubs, String publicationLabel, Km
 							out.println("<td width=\"1\">&nbsp;</td>");
 						out.println("<td width=\"1\">&nbsp;</td>");
 						out.println("<td colspan=\"3\">"+getUserName(kmeliaPub, kmeliaScc)+" - "+resources.getOutputDate(pub.getLastUpdateDate())+"<br/>");
-						out.println(WebEncodeHelper.javaStringToHtmlString(pub.getDescription(language))+"<br/><br/></td>");
+						out.println(WebEncodeHelper.javaStringToHtmlParagraphe(pub.getDescription(language))+"<br/><br/></td>");
 						out.println("</td></tr></table>");
 						out.println("</td>");
                       out.println("</tr>");


### PR DESCRIPTION
In Kmelia, take into account the publication description can be made up of several sentences. When rendering in HTML, the special characters (like line feed, tabulations, ...) are replaced by their HTML equivalent.