### PR TITLE
Bug #14595

### DIFF
--- a/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/AlmanachInstancePreDestruction.java
+++ b/almanach/almanach-library/src/main/java/org/silverpeas/components/almanach/AlmanachInstancePreDestruction.java
@@ -24,7 +24,9 @@
 package org.silverpeas.components.almanach;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -34,6 +36,8 @@ import java.util.List;
  * Before being deleted, remove all events in an almanach instance.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class AlmanachInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/ClassifiedsInstancePreDestruction.java
+++ b/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/ClassifiedsInstancePreDestruction.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.components.classifieds;
 
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.kernel.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.classifieds.service.ClassifiedService;
 import org.silverpeas.components.classifieds.service.ClassifiedServiceProvider;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -35,6 +37,8 @@ import javax.transaction.Transactional;
  * Deletes all the subscriptions and classifieds of the Classifieds instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class ClassifiedsInstancePreDestruction implements ComponentInstancePreDestruction {
   /**

--- a/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePreDestruction.java
+++ b/community/community-library/src/main/java/org/silverpeas/components/community/CommunityInstancePreDestruction.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.contribution.model.WysiwygContent;
 import org.silverpeas.core.notification.system.ResourceEvent;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -39,6 +40,7 @@ import java.util.Optional;
 /**
  * Wipe out for the spawned community instance the resources that were allocated to him.
  */
+@Technical
 @Bean
 @Named
 public class CommunityInstancePreDestruction implements ComponentInstancePreDestruction {

--- a/dataWarning/dataWarning-library/src/main/java/org/silverpeas/components/datawarning/DataWarningInstancePreDestruction.java
+++ b/dataWarning/dataWarning-library/src/main/java/org/silverpeas/components/datawarning/DataWarningInstancePreDestruction.java
@@ -23,10 +23,11 @@
  */
 package org.silverpeas.components.datawarning;
 
-import org.silverpeas.core.annotation.Service;
-import org.silverpeas.kernel.SilverpeasRuntimeException;
-import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.datawarning.model.DataWarningDataManager;
+import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -36,7 +37,8 @@ import javax.transaction.Transactional;
  * used by the instance.
  * @author mmoquillon
  */
-@Service
+@Technical
+@Bean
 @Named
 public class DataWarningInstancePreDestruction implements ComponentInstancePreDestruction {
   /**

--- a/formsOnline/formsOnline-library/src/main/java/org/silverpeas/components/formsonline/FormsOnlineInstancePreDestruction.java
+++ b/formsOnline/formsOnline-library/src/main/java/org/silverpeas/components/formsonline/FormsOnlineInstancePreDestruction.java
@@ -23,9 +23,11 @@
  */
 package org.silverpeas.components.formsonline;
 
-import org.silverpeas.kernel.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -39,6 +41,8 @@ import java.util.Arrays;
  * were managed by this instance.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class FormsOnlineInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/forums/forums-library/src/main/java/org/silverpeas/components/forums/ForumsInstancePreDestruction.java
+++ b/forums/forums-library/src/main/java/org/silverpeas/components/forums/ForumsInstancePreDestruction.java
@@ -25,6 +25,8 @@ package org.silverpeas.components.forums;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.forums.service.ForumService;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -35,6 +37,8 @@ import javax.transaction.Transactional;
  * deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class ForumsInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/GalleryInstancePreDestruction.java
+++ b/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/GalleryInstancePreDestruction.java
@@ -3,9 +3,11 @@ package org.silverpeas.components.gallery;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.gallery.service.MediaServiceProvider;
 import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.util.file.FileRepositoryManager;
 import org.silverpeas.core.util.file.FileUtil;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -14,6 +16,8 @@ import java.io.File;
 /**
  * @author Yohann Chastagnier
  */
+@Technical
+@Bean
 @Named
 public class GalleryInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/infoLetter/infoLetter-library/src/main/java/org/silverpeas/components/infoletter/InfoLetterInstancePreDestruction.java
+++ b/infoLetter/infoLetter-library/src/main/java/org/silverpeas/components/infoletter/InfoLetterInstancePreDestruction.java
@@ -25,6 +25,8 @@ package org.silverpeas.components.infoletter;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.infoletter.model.InfoLetterService;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -35,6 +37,8 @@ import javax.transaction.Transactional;
  * being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class InfoLetterInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/jdbcConnector/jdbcConnector-library/src/main/java/org/silverpeas/components/jdbcconnector/ConnecteurJDBCInstancePreDestruction.java
+++ b/jdbcConnector/jdbcConnector-library/src/main/java/org/silverpeas/components/jdbcconnector/ConnecteurJDBCInstancePreDestruction.java
@@ -25,6 +25,8 @@ package org.silverpeas.components.jdbcconnector;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.jdbcconnector.model.DataSourceConnectionInfo;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -34,6 +36,8 @@ import javax.transaction.Transactional;
  * deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class ConnecteurJDBCInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/mailinglist/mailinglist-library/src/main/java/org/silverpeas/components/mailinglist/MailinglistInstancePreDestruction.java
+++ b/mailinglist/mailinglist-library/src/main/java/org/silverpeas/components/mailinglist/MailinglistInstancePreDestruction.java
@@ -25,6 +25,8 @@ package org.silverpeas.components.mailinglist;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.mailinglist.service.MailingListServicesProvider;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -34,6 +36,8 @@ import javax.transaction.Transactional;
  * MailingList instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class MailinglistInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/MyDBInstancePreDestruction.java
+++ b/mydb/mydb-library/src/main/java/org/silverpeas/components/mydb/MyDBInstancePreDestruction.java
@@ -26,6 +26,7 @@ package org.silverpeas.components.mydb;
 import org.silverpeas.components.mydb.model.MyDBConnectionInfo;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -35,6 +36,7 @@ import javax.transaction.Transactional;
  * deleted.
  * @author mmoquillon
  */
+@Technical
 @Named
 @Bean
 public class MyDBInstancePreDestruction implements ComponentInstancePreDestruction {

--- a/processManager/processManager-library/src/main/java/org/silverpeas/processmanager/ProcessManagerInstancePreDestruction.java
+++ b/processManager/processManager-library/src/main/java/org/silverpeas/processmanager/ProcessManagerInstancePreDestruction.java
@@ -23,12 +23,14 @@
  */
 package org.silverpeas.processmanager;
 
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.kernel.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.core.workflow.api.UpdatableProcessInstanceManager;
 import org.silverpeas.core.workflow.api.Workflow;
 import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.instance.ProcessInstance;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import java.util.List;
@@ -41,6 +43,8 @@ import static org.silverpeas.core.admin.component.ComponentInstancePreDestructio
  * deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named(WORKFLOW_PRE_DESTRUCTION)
 public class ProcessManagerInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/projectManager/projectManager-library/src/main/java/org/silverpeas/components/projectmanager/ProjectManagerInstancePreDestruction.java
+++ b/projectManager/projectManager-library/src/main/java/org/silverpeas/components/projectmanager/ProjectManagerInstancePreDestruction.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.components.projectmanager;
 
-import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.projectmanager.model.ProjectManagerCalendarDAO;
 import org.silverpeas.components.projectmanager.model.ProjectManagerDAO;
+import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -38,6 +40,8 @@ import java.sql.SQLException;
  * the ProjectManager that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class ProjectManagerInstancePreDestruction implements ComponentInstancePreDestruction {
   /**

--- a/questionReply/questionReply-library/src/main/java/org/silverpeas/components/questionreply/QuestionReplyInstancePreDestruction.java
+++ b/questionReply/questionReply-library/src/main/java/org/silverpeas/components/questionreply/QuestionReplyInstancePreDestruction.java
@@ -24,7 +24,9 @@
 package org.silverpeas.components.questionreply;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Named;
 import javax.transaction.Transactional;
@@ -37,6 +39,8 @@ import java.sql.SQLException;
  * is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class QuestionReplyInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/QuickinfoInstancePreDestruction.java
+++ b/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/QuickinfoInstancePreDestruction.java
@@ -25,6 +25,8 @@ package org.silverpeas.components.quickinfo;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.quickinfo.repository.NewsRepository;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,6 +36,8 @@ import javax.transaction.Transactional;
  * Deletes the data associated with the Quickinfo instance that is being deleted.
  * @author Yohann Chastagnier
  */
+@Technical
+@Bean
 @Named
 public class QuickinfoInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/BaseEventListenerTest.java
+++ b/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/BaseEventListenerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.silverpeas.components.resourcesmanager.model.Resource;
+import org.silverpeas.core.admin.service.AdminException;
+import org.silverpeas.core.admin.user.ProfileInstManager;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Base class of all integration tests about the event listeners.
+ * @author mmoquillon
+ */
+public abstract class BaseEventListenerTest {
+
+  public static final String RESPONSIBLE_ROLE = "responsable";
+  public static final String READER_ROLE = "publisher";
+  public static final List<String> NO_IDS = List.of();
+  public static final String INSTANCE_ID = "resourcesManager42";
+
+  @Inject
+  private ProfileInstManager profileInstManager;
+
+  public ProfileInst getProfileInst(String roleName) {
+    String id;
+    switch (roleName) {
+      case "admin":
+        id = "1";
+        break;
+      case RESPONSIBLE_ROLE:
+        id = "2";
+        break;
+      default:
+        id = "3";
+        break;
+    }
+    return getProfileInstById(id);
+  }
+
+  public ProfileInst getProfileInstById(String id) {
+    return Transaction.performInOne(() -> {
+      try {
+        return profileInstManager.getProfileInst(id, false);
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+    });
+  }
+
+  public void updateProfileInst(ProfileInst profileInst) {
+    Transaction.performInOne(() -> {
+      try {
+        profileInstManager.updateProfileInst(profileInst);
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+      return null;
+    });
+  }
+
+  private String createProfileInst(ProfileInst profileInst) {
+    return Transaction.performInOne(() -> {
+      try {
+        return profileInstManager.createProfileInst(profileInst, profileInst.getComponentFatherId());
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+    });
+  }
+
+  public void setUpProfileInstWith(String profileName, List<String> users, List<String> groups) {
+    ProfileInst initialProfile = getProfileInst(profileName);
+    initialProfile.getAllUsers().addAll(users);
+    initialProfile.getAllGroups().addAll(groups);
+    updateProfileInst(initialProfile);
+  }
+
+  public String setUpInheritedProfileInstWith(String profileName, List<String> users,
+      List<String> groups) {
+    ProfileInst initialProfile = new ProfileInst();
+    initialProfile.setComponentFatherId(42);
+    initialProfile.setInherited(true);
+    initialProfile.setName(profileName);
+    initialProfile.setLabel(profileName);
+    initialProfile.getAllUsers().addAll(users);
+    initialProfile.getAllGroups().addAll(groups);
+    return createProfileInst(initialProfile);
+  }
+
+  public static void assertValidatorsEquality(List<Resource> actualResources,
+      List<Resource> expectedResources) {
+    actualResources.forEach(a ->
+        expectedResources.stream().filter(e -> a.getId().equals(e.getId())).findFirst()
+            .ifPresent(e ->
+                assertTrue(a.getManagers().containsAll(e.getManagers()))
+            )
+    );
+  }
+
+  public static void assertValidatorIsRemoved(int validatorId, List<Resource> actualResources) {
+    actualResources.forEach(r ->
+        assertTrue(r.getManagers().stream().
+            allMatch(m -> m.getManagerId() != validatorId)));
+  }
+}
+  

--- a/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/GroupMembershipChangeIT.java
+++ b/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/GroupMembershipChangeIT.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.components.resourcesmanager.model.Resource;
+import org.silverpeas.components.resourcesmanager.service.ResourceService;
+import org.silverpeas.components.resourcesmanager.test.WarBuilder4ResourcesManager;
+import org.silverpeas.core.admin.service.AdminController;
+import org.silverpeas.core.test.integration.rule.DbUnitLoadingRule;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Integration test on the behaviour of the Resources Manager when a user doesn't belong anymore
+ * to a group playing a role in some Resources Manager applications.
+ *
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class GroupMembershipChangeIT extends BaseEventListenerTest {
+
+  @Inject
+  private ResourceService resourceService;
+
+  @Inject
+  private AdminController admin;
+
+  @Rule
+  public DbUnitLoadingRule dbUnitLoadingRule =
+      new DbUnitLoadingRule("service/create-database.sql", "service/resources_dataset.xml");
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return WarBuilder4ResourcesManager.onWarForTestClass(ProfileInstChangeIT.class).build();
+  }
+
+  @Before
+  public void reloadCache() {
+    admin.reloadCaches();
+  }
+
+  /**
+   * Given a user is in a group G playing the manager role for some Resources Manager applications A
+   * and this user is a validator of some resources R in those applications A,
+   * When he's removed from the group G,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user is in a group G playing the reader role for some Resources Manager applications A,
+   * When he's removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aNonValidatorHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("11", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user is in a group G playing the reader role for some Resources Manager applications A
+   * and this user is also a validator of some resources R in those applications A,
+   * When he's removed from the group G,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromAGroupInReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, NO_IDS, List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing the manager role for some Resources Manager applications A,
+   * When a user is added into the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenAddedInAGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("2"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.addUserInGroup("1", "2");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user is in a subgroup G of a group playing the manager role for some Resources Manager
+   * applications A and this user is a validator of some resources R in those applications A,
+   * When he's removed from the subgroup G,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromASubGroupOfAGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("3"));
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a group G playing the publisher role for an applications other than Resources
+   * Manager and playing no role in any Resources Manager applications A,
+   * Given a user U being a validator for some resources in the applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aUserHasBeenRemovedFromAGroupInPublishersProfileInAnotherApplication() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to a
+   * subgroup S of G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromASubGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), List.of("3"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing by rights inheritance the manager role in a Resources Manager
+   * applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromAGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing by rights inheritance the manager role in a Resources Manager
+   * applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * subgroup S of the group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromASubGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("3"));
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing by inheritance the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInInheritedManagersProfileHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), NO_IDS);
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing by inheritance the manager role in the application A, belonging to the
+   * subgroup S of the group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInInheritedManagersProfileHasBeenRemovedFromASubGroupInManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, List.of("1"), NO_IDS);
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("3"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+}

--- a/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/ProfileInstChangeIT.java
+++ b/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/ProfileInstChangeIT.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.components.resourcesmanager.model.Resource;
+import org.silverpeas.components.resourcesmanager.service.ResourceService;
+import org.silverpeas.components.resourcesmanager.test.WarBuilder4ResourcesManager;
+import org.silverpeas.core.admin.service.Administration;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.test.integration.rule.DbUnitLoadingRule;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Integration test on the behaviour of the Resources Manager when a user or a group of a user has
+ * been remove from Manager role profile.
+ *
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class ProfileInstChangeIT extends BaseEventListenerTest {
+
+  @Inject
+  private ResourceService resourceService;
+  
+  @Inject
+  private Administration admin;
+
+  @Rule
+  public DbUnitLoadingRule dbUnitLoadingRule =
+      new DbUnitLoadingRule("service/create-database.sql", "service/resources_dataset.xml");
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return WarBuilder4ResourcesManager.onWarForTestClass(ProfileInstChangeIT.class).build();
+  }
+
+  @Before
+  public void reloadCache() {
+    admin.reloadCache();
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A
+   * and this user is a validator of some resources R in those applications A,
+   * When he's removed from manager role,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A
+   * and this user is a validator of some resources R in those applications A,
+   * When he's removed from manager role,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromInheritedManagersProfile() {
+    String profileId = setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"),
+        NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user is playing the reader role for some Resources Manager applications A
+   * and this user is also a validator of some resources R in those applications A,
+   * When he's removed from the reader role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(READER_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A
+   * and this user isn't a validator of any resources R in those applications A,
+   * When he's removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aNonValidatorHasBeenRemovedFromManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2", "11"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("11");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A
+   * and some users U in this group are also validators of some resources R in those applications A,
+   * When the group G is removed from the manager role,
+   * Then the users U should be also removed from the validators of resources R in the
+   * applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedFromManagersProfile() {
+    // user 1 belongs to the user group 1
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1", "2"));
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A
+   * and some users U in this group are also validators of some resources R in those applications A,
+   * When the group G is removed from the manager role,
+   * Then the users U should be also removed from the validators of resources R in the
+   * applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedFromInheritedManagersProfile() {
+    // user 1 belongs to the user group 1
+    String profileId = setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1", "2"));
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user group G is playing the reader role for some Resources Manager applications A
+   * and some users in the group G are also validators of resources R in those applications A,
+   * When the group G is removed from the reader role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithoutAnyValidatorHasBeenRemovedFromReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, NO_IDS, List.of("1", "2"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(READER_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A
+   * and no users in the group G are validators of resources R in those applications A,
+   * When the group G is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithoutAnyValidatorHasBeenRemovedFromManagersProfile() {
+    // group 4 has no validators
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("4", "5"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("5");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U belonging to the group G is also playing explicitly the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A,
+   * When the user U is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInGroupInManagersProfile() {
+    // user 1 belongs to user group 1
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing buy inheritance the manager role for some Resources Manager
+   * applications A,
+   * Given a user U belonging to the group G is also playing explicitly the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A,
+   * When the user U is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a subgroup G of a user group playing the manager role for some Resources Manager
+   * applications A,
+   * Given a user U belonging to the subgroup G is also playing explicitly the manager Role for
+   * those applications A and he's also validator of some resources R in those applications A,
+   * When the user U is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInSubGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), List.of("3"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U is playing the manager Role for those applications A and he doesn't belong
+   * to the group G and he's also validator of some resources R in those applications A,
+   * When the user U is removed from the manager role,
+   * Then the users U should be also removed from the validators of resources R in the
+   * applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedAndItIsNotInGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), List.of("5"));
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U is playing the manager Role for those applications A and he doesn't belong
+   * to the group G and he's also validator of some resources R in those applications A,
+   * When the user U is removed from the manager role,
+   * Then the users U should be also removed from the validators of resources R in the
+   * applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedAndItIsNotInGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("5"));
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> resources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, resources);
+  }
+
+  /**
+   * Given a group G is playing the manager role for some Resources Manager applications A and some
+   * users U in this group G are validators of some resources R in those applications A,
+   * When the group G is removed from the manager role for A,
+   * Then the users U should be also removed from the validators of R in the applications A.
+   */
+  @Test
+  public void aGroupInManagerProfileWithAValidatorHasBeenRemoved() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, actualResources);
+  }
+
+  /**
+   * Given a group G is playing the manager role for some Resources Manager applications A and some
+   * users U in this group G are validators of some resources R in those applications A,
+   * When the group G is removed from the manager role for A,
+   * Then the users U should be also removed from the validators of R in the applications A.
+   */
+  @Test
+  public void aGroupInInheritedManagerProfileWithAValidatorHasBeenRemoved() {
+    String profileId = setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorIsRemoved(1, actualResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to the group G is also playing explicitly the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A,
+   * When the group G is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to the group G is also playing by inheritance the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A,
+   * When the group G is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), NO_IDS);
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given two user groups are playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to these two groups is also validator of some resources R in those
+   * applications A,
+   * When only one of these two groups is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsAnotherGroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1", "4"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given two user groups G1 and G2 are playing the manager role for some Resources Manager
+   * applications A,
+   * Given a user is belonging to the group G1 and to a subgroup of G2, and he's also validator of
+   * some resources R in those applications A,
+   * When the group G1 is removed from the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInASubgroupInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, NO_IDS, List.of("1", "3"));
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A
+   * and this user is also a validator of some resources R in those applications A,
+   * When he's removed from the manager role whereas in the same time a group to which he belongs
+   * is added in the manager role,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButHeIsInSuperGroupAddedInManagersProfile() {
+    setUpProfileInstWith(RESPONSIBLE_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Resource> expectedResources = resourceService.getResources(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(RESPONSIBLE_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    profileToUpdate.getAllGroups().add("4");
+    updateProfileInst(profileToUpdate);
+
+    List<Resource> actualResources = resourceService.getResources(INSTANCE_ID);
+    assertValidatorsEquality(actualResources, expectedResources);
+  }
+}
+  

--- a/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/service/ResourceServiceIT.java
+++ b/resourcesManager/resourcesManager-library/src/integration-test/java/org/silverpeas/components/resourcesmanager/service/ResourceServiceIT.java
@@ -179,6 +179,13 @@ public class ResourceServiceIT {
     assertThat(result, hasSize(3));
   }
 
+  @Test
+  public void testGetResourcesOfGiveResourcesManager() {
+    List<Resource> result = service.getResources("resourcesManager42");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(3));
+  }
+
   /**
    * Test of getResource method, of class ResourceService.
    */

--- a/resourcesManager/resourcesManager-library/src/integration-test/resources/org/silverpeas/components/resourcesmanager/service/create-database.sql
+++ b/resourcesManager/resourcesManager-library/src/integration-test/resources/org/silverpeas/components/resourcesmanager/service/create-database.sql
@@ -1,99 +1,214 @@
+CREATE TABLE ST_User
+(
+    id                            INT                   NOT NULL,
+    domainId                      INT                   NOT NULL,
+    specificId                    VARCHAR(500)          NOT NULL,
+    firstName                     VARCHAR(100),
+    lastName                      VARCHAR(100)          NOT NULL,
+    email                         VARCHAR(100),
+    login                         VARCHAR(100)          NOT NULL,
+    loginMail                     VARCHAR(100),
+    accessLevel                   CHAR(1) DEFAULT 'U'   NOT NULL,
+    loginquestion                 VARCHAR(200),
+    loginanswer                   VARCHAR(200),
+    creationDate                  TIMESTAMP,
+    saveDate                      TIMESTAMP,
+    version                       INT     DEFAULT 0     NOT NULL,
+    tosAcceptanceDate             TIMESTAMP,
+    lastLoginDate                 TIMESTAMP,
+    nbSuccessfulLoginAttempts     INT     DEFAULT 0     NOT NULL,
+    lastLoginCredentialUpdateDate TIMESTAMP,
+    expirationDate                TIMESTAMP,
+    state                         VARCHAR(30)           NOT NULL,
+    stateSaveDate                 TIMESTAMP             NOT NULL,
+    notifManualReceiverLimit      INT,
+    sensitiveData                 BOOLEAN DEFAULT FALSE NOT NULL
+);
+
+CREATE TABLE ST_Group
+(
+    id            INT          NOT NULL,
+    domainId      INT          NOT NULL,
+    specificId    VARCHAR(500) NOT NULL,
+    superGroupId  INT,
+    name          VARCHAR(100) NOT NULL,
+    description   VARCHAR(400),
+    synchroRule   VARCHAR(100),
+    creationDate  timestamp,
+    saveDate      timestamp,
+    state         varchar(30)  NOT NULL,
+    stateSaveDate timestamp    NOT NULL,
+    CONSTRAINT PK_Group PRIMARY KEY (id),
+    CONSTRAINT UN_Group_1 UNIQUE (specificId, domainId),
+    CONSTRAINT UN_Group_2 UNIQUE (superGroupId, name, domainId),
+    CONSTRAINT FK_Group_1 FOREIGN KEY (superGroupId) REFERENCES ST_Group (id)
+);
+
+CREATE TABLE ST_Group_User_Rel
+(
+    groupId int NOT NULL,
+    userId  int NOT NULL
+);
+
+CREATE TABLE ST_UserRole
+(
+    id          int             NOT NULL,
+    instanceId  int             NOT NULL,
+    name        varchar(100)    NULL,
+    roleName    varchar(100)    NOT NULL,
+    description varchar(400),
+    isInherited int default (0) NOT NULL,
+    objectId    int,
+    objectType  varchar(50)
+);
+
+CREATE TABLE ST_UserRole_User_Rel
+(
+    userRoleId int NOT NULL,
+    userId     int NOT NULL
+);
+
+CREATE TABLE ST_UserRole_Group_Rel
+(
+    userRoleId int NOT NULL,
+    groupId    int NOT NULL
+);
+
+CREATE TABLE ST_ComponentInstance
+(
+    id                   int             NOT NULL,
+    spaceId              int             NOT NULL,
+    name                 varchar(100)    NOT NULL,
+    componentName        varchar(100)    NOT NULL,
+    description          varchar(400),
+    createdBy            int,
+    orderNum             int DEFAULT (0) NOT NULL,
+    createTime           varchar(20),
+    updateTime           varchar(20),
+    removeTime           varchar(20),
+    componentStatus      char(1),
+    updatedBy            int,
+    removedBy            int,
+    isPublic             int DEFAULT (0) NOT NULL,
+    isHidden             int DEFAULT (0) NOT NULL,
+    lang                 char(2),
+    isInheritanceBlocked int default (0) NOT NULL
+);
+
+CREATE TABLE ST_ComponentInstanceI18N
+(
+    id          int          NOT NULL,
+    componentId int          NOT NULL,
+    lang        char(2)      NOT NULL,
+    name        varchar(100) NOT NULL,
+    description varchar(400)
+);
+
+CREATE TABLE ST_Instance_Data
+(
+    id          int          NOT NULL,
+    componentId int          NOT NULL,
+    name        varchar(100) NOT NULL,
+    label       varchar(100) NOT NULL,
+    value       varchar(1000)
+);
+
 CREATE TABLE SC_Resources_Category
 (
-	id 				BIGINT 		NOT NULL,
-	instanceId 		VARCHAR(50) NOT NULL,
-	name 			VARCHAR(50) NOT NULL,
-	creationdate 	VARCHAR(20) NOT NULL,
-	updatedate 		VARCHAR(20) NOT NULL,
-	bookable 		INT,
-	form 			VARCHAR(50),
-	responsibleid 	INT,
-	createrid 		VARCHAR(50),
-	updaterid 		VARCHAR(50),
-	description 	VARCHAR(2000)
+    id            BIGINT      NOT NULL,
+    instanceId    VARCHAR(50) NOT NULL,
+    name          VARCHAR(50) NOT NULL,
+    creationdate  VARCHAR(20) NOT NULL,
+    updatedate    VARCHAR(20) NOT NULL,
+    bookable      INT,
+    form          VARCHAR(50),
+    responsibleid INT,
+    createrid     VARCHAR(50),
+    updaterid     VARCHAR(50),
+    description   VARCHAR(2000)
 )
 ;
 
 CREATE TABLE SC_Resources_Resource
 (
-	id 				BIGINT NOT NULL,
-	instanceId 		VARCHAR(50) NOT NULL,
-	categoryid  	BIGINT NOT NULL,
-	name 			VARCHAR(128) NOT NULL,
-	creationdate 	VARCHAR(20) NOT NULL,
-	updatedate 		VARCHAR(20) NOT NULL,
-	bookable 		INT,
-	responsibleid 	INT,
-	createrid 		VARCHAR(50),
-	updaterid 		VARCHAR(50),
-	description 	VARCHAR(2000)
+    id            BIGINT       NOT NULL,
+    instanceId    VARCHAR(50)  NOT NULL,
+    categoryid    BIGINT       NOT NULL,
+    name          VARCHAR(128) NOT NULL,
+    creationdate  VARCHAR(20)  NOT NULL,
+    updatedate    VARCHAR(20)  NOT NULL,
+    bookable      INT,
+    responsibleid INT,
+    createrid     VARCHAR(50),
+    updaterid     VARCHAR(50),
+    description   VARCHAR(2000)
 )
 ;
 
 CREATE TABLE SC_Resources_Reservation
 (
-	id 				BIGINT NOT NULL,
-	instanceId 		VARCHAR(50) NOT NULL,
-	evenement 		VARCHAR(128) NOT NULL,
-	userId 			INT NOT NULL,
-	creationdate 	VARCHAR(20) NOT NULL,
-	updatedate 		VARCHAR(20) NOT NULL,
-	begindate 		VARCHAR(20) NOT NULL,
-	enddate 		VARCHAR(20) NOT NULL,
-	reason			VARCHAR(2000),
-	place 			VARCHAR(128),
-	status          VARCHAR(50)	NULL
+    id           BIGINT       NOT NULL,
+    instanceId   VARCHAR(50)  NOT NULL,
+    evenement    VARCHAR(128) NOT NULL,
+    userId       INT          NOT NULL,
+    creationdate VARCHAR(20)  NOT NULL,
+    updatedate   VARCHAR(20)  NOT NULL,
+    begindate    VARCHAR(20)  NOT NULL,
+    enddate      VARCHAR(20)  NOT NULL,
+    reason       VARCHAR(2000),
+    place        VARCHAR(128),
+    status       VARCHAR(50)  NULL
 )
 ;
 
 CREATE TABLE SC_Resources_ReservedResource
 (
-	reservationId 	BIGINT NOT NULL,
-	resourceId 		BIGINT NOT NULL,
-	status          VARCHAR(50)	NULL
+    reservationId BIGINT      NOT NULL,
+    resourceId    BIGINT      NOT NULL,
+    status        VARCHAR(50) NULL
 )
 ;
 
 CREATE TABLE SC_Resources_Managers
 (
-	resourceId 	BIGINT	NOT NULL,
-	managerId	BIGINT	NOT NULL
+    resourceId BIGINT NOT NULL,
+    managerId  BIGINT NOT NULL
 )
 ;
 
 ALTER TABLE SC_Resources_Category
-ADD CONSTRAINT PK_Resources_Category PRIMARY KEY
-	(
-	id
-	)
+    ADD CONSTRAINT PK_Resources_Category PRIMARY KEY
+        (
+         id
+            )
 ;
 
 ALTER TABLE SC_Resources_Resource
-ADD CONSTRAINT PK_Resources_Resource PRIMARY KEY
-	(
-	id
-	)
+    ADD CONSTRAINT PK_Resources_Resource PRIMARY KEY
+        (
+         id
+            )
 ;
 
 ALTER TABLE SC_Resources_Reservation
-ADD CONSTRAINT PK_Resources_Reservation PRIMARY KEY
-	(
-	id
-	)
+    ADD CONSTRAINT PK_Resources_Reservation PRIMARY KEY
+        (
+         id
+            )
 ;
 
 ALTER TABLE SC_Resources_ReservedResource
-ADD CONSTRAINT PK_Resources_ReservedResource PRIMARY KEY
-	(
-	reservationId,
-	resourceId
-	)
+    ADD CONSTRAINT PK_Resources_ReservedResource PRIMARY KEY
+        (
+         reservationId,
+         resourceId
+            )
 ;
 
 ALTER TABLE SC_Resources_Managers
-ADD CONSTRAINT PK_Resources_Managers PRIMARY KEY
-	(
-	resourceId,
-	managerId
-	)
+    ADD CONSTRAINT PK_Resources_Managers PRIMARY KEY
+        (
+         resourceId,
+         managerId
+            )
 ;

--- a/resourcesManager/resourcesManager-library/src/integration-test/resources/org/silverpeas/components/resourcesmanager/service/resources_dataset.xml
+++ b/resourcesManager/resourcesManager-library/src/integration-test/resources/org/silverpeas/components/resourcesmanager/service/resources_dataset.xml
@@ -1,6 +1,115 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <dataset>
+
+  <st_componentinstance id="42" spaceId="0" name="Reservation" componentName="resourcesManager"
+                        description="[NULL]" createdBy="0" orderNum="1" createTime="1433237280246"
+                        updateTime="1443424995948" removeTime="[NULL]" componentStatus="[NULL]"
+                        isPublic="1" isHidden="0" lang="fr" isInheritanceBlocked="0"/>
+
+  <st_componentinstance id="666" spaceId="0" name="Documentation" componentName="kmelia"
+                        description="[NULL]" createdBy="0" orderNum="1" createTime="1433237280246"
+                        updateTime="1443424995948" removeTime="[NULL]" componentStatus="[NULL]"
+                        isPublic="1" isHidden="0" lang="fr" isInheritanceBlocked="0"/>
+
+  <st_instance_data id="143" componentId="42" name="defaultDisplay"
+                    label="By default, display" value="allReservations"/>
+  <st_instance_data id="144" componentId="42" name="comments"
+                    label="Comments" value="yes"/>
+  <st_instance_data id="145" componentId="42" name="weekendNotVisible"
+                    label="Hide week-ends" value="yes"/>
+
+  <st_instance_data id="666" componentId="666" name="Comments"
+                    label="Comments" value="true"/>
+
+  <st_group id="1" domainId="-1" specificId="1" supergroupId="[NULL]" name="Tartempion"
+            description="a Tartempion group"
+            synchrorule="[NULL]" creationDate="2023-12-12 17:12:30.031"
+            saveDate="2023-12-12 17:12:30.031" state="VALID"
+            stateSaveDate="2023-12-12 17:12:30.031"/>
+  <st_group id="2" domainId="-1" specificId="2" supergroupId="[NULL]" name="Bowling"
+            description="a bowling group"
+            synchrorule="[NULL]" creationDate="2023-12-12 17:12:30.031"
+            saveDate="2023-12-12 17:12:30.031" state="VALID"
+            stateSaveDate="2023-12-12 17:12:30.031"/>
+  <st_group id="3" domainId="-1" specificId="3" supergroupId="[NULL]" name="Coders"
+            description="a coders group"
+            synchrorule="[NULL]" creationDate="2023-12-12 17:12:30.031"
+            saveDate="2023-12-12 17:12:30.031" state="VALID"
+            stateSaveDate="2023-12-12 17:12:30.031"/>
+  <st_group id="4" domainId="-1" specificId="4" supergroupId="3" name="Junior Coders"
+            description="a junior coders group"
+            synchrorule="[NULL]" creationDate="2023-12-12 17:12:30.031"
+            saveDate="2023-12-12 17:12:30.031" state="VALID"
+            stateSaveDate="2023-12-12 17:12:30.031"/>
+  <st_group id="5" domainId="-1" specificId="5" supergroupId="3" name="Sys Coders"
+            description="a sys group"
+            synchrorule="[NULL]" creationDate="2023-12-12 17:12:30.031"
+            saveDate="2023-12-12 17:12:30.031" state="VALID"
+            stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_user id="0" domainId="0" specificId="0" firstName="Administrator" lastName="Administrator"
+           email="admin@silverpeas.org" login="SilverAdmin" loginMail="admin@silverpeas.org"
+           accessLevel="A" state="VALID"
+           loginQuestion="[NULL]" loginAnswer="[NULL]" creationDate="2023-12-12 17:12:30.031"
+           saveDate="2023-12-12 17:12:30.031" version="1" nbSuccessfulLoginAttempts="5"
+           stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_user id="1" domainId="0" specificId="1" firstName="John" lastName="Doo"
+           email="john.doo@silverpeas.org" login="jdoo" loginMail="john.doo@silverpeas.org"
+           accessLevel="U" state="VALID"
+           loginQuestion="[NULL]" loginAnswer="[NULL]" creationDate="2023-12-12 17:12:30.031"
+           saveDate="2023-12-12 17:12:30.031" version="1" nbSuccessfulLoginAttempts="5"
+           stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_user id="2" domainId="0" specificId="2" firstName="Jean" lastName="Dupont"
+           email="jean.dupont@silverpeas.org" login="jdupont" loginMail="jean.dupont@silverpeas.org"
+           accessLevel="U" state="VALID"
+           loginQuestion="[NULL]" loginAnswer="[NULL]" creationDate="2023-12-12 17:12:30.031"
+           saveDate="2023-12-12 17:12:30.031" version="1" nbSuccessfulLoginAttempts="5"
+           stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_user id="10" domainId="0" specificId="1" firstName="François" lastName="Dupond"
+           email="francois.dupond@silverpeas.org" login="fdupond"
+           loginMail="francois.dupond@silverpeas.org"
+           accessLevel="U" state="VALID"
+           loginQuestion="[NULL]" loginAnswer="[NULL]" creationDate="2023-12-12 17:12:30.031"
+           saveDate="2023-12-12 17:12:30.031" version="1" nbSuccessfulLoginAttempts="5"
+           stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_user id="11" domainId="0" specificId="1" firstName="Gustave" lastName="Eiffel"
+           email="gustave.eiffel@silverpeas.org" login="geijfel"
+           loginMail="gustave.eiffel@silverpeas.org" accessLevel="U" state="VALID"
+           loginQuestion="[NULL]" loginAnswer="[NULL]" creationDate="2023-12-12 17:12:30.031"
+           saveDate="2023-12-12 17:12:30.031" version="1" nbSuccessfulLoginAttempts="5"
+           stateSaveDate="2023-12-12 17:12:30.031"/>
+
+  <st_group_user_rel groupId="1" userId="1"/>
+  <st_group_user_rel groupId="1" userId="10"/>
+  <st_group_user_rel groupId="1" userId="11"/>
+  <st_group_user_rel groupId="2" userId="0"/>
+  <st_group_user_rel groupId="2" userId="11"/>
+  <st_group_user_rel groupId="4" userId="1"/>
+  <st_group_user_rel groupId="4" userId="2"/>
+  <st_group_user_rel groupId="5" userId="10"/>
+  <st_group_user_rel groupId="5" userId="11"/>
+
+  <st_userrole id="1" instanceId="42" name="Managers" roleName="admin"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+  <st_userrole id="2" instanceId="42" name="Responsibles" roleName="responsable"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+  <st_userrole id="3" instanceId="42" name="Readers" roleName="publisher"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+
+  <st_userrole id="101" instanceId="666" name="Managers" roleName="admin"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+  <st_userrole id="102" instanceId="666" name="Publishers" roleName="publisher"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+  <st_userrole id="103" instanceId="666" name="Readers" roleName="reader"
+               description="[NULL" isInherited="0" objectId="[NULL]" objectType="[NULL]"/>
+
+  <st_userrole_group_rel userroleid="102" groupid="1"/>
+
   <sc_resources_category id="1" instanceId="resourcesManager42" name="Salles"
                          creationdate="1315232752398" updatedate="1315232752398" bookable="1"
                          form="model1.xml"
@@ -27,18 +136,18 @@
                          creationdate="1315232852398" updatedate="1315232852398" bookable="1"
                          createrid="5" updaterid="5" description="Twingo verte 4 places 5 portes"/>
 
-  <sc_resources_reservedresource reservationid="3" resourceid="1" status="V" />
-  <sc_resources_reservedresource reservationid="3" resourceid="2" status="R" />
-  <sc_resources_reservedresource reservationid="3" resourceid="3" status="test" />
+  <sc_resources_reservedresource reservationid="3" resourceid="1" status="V"/>
+  <sc_resources_reservedresource reservationid="3" resourceid="2" status="R"/>
+  <sc_resources_reservedresource reservationid="3" resourceid="3" status="test"/>
   <sc_resources_reservation id="3" instanceId="resourcesManager42" evenement="Test de la Toussaint"
                             userId="2" creationdate="1319811924467" updatedate="1319811924467"
-                            begindate="1320134400000"  enddate="1320163200000"
-                            reason="To test" place="at work" status="test" />
-  <sc_resources_managers resourceid="1" managerid="0" />
-  <sc_resources_managers resourceid="1" managerid="1" />
-  <sc_resources_managers resourceid="1" managerid="2" />
-  <sc_resources_managers resourceid="2" managerid="0" />
-  <sc_resources_managers resourceid="3" managerid="0" />
+                            begindate="1320134400000" enddate="1320163200000"
+                            reason="To test" place="at work" status="test"/>
+  <sc_resources_managers resourceid="1" managerid="0"/>
+  <sc_resources_managers resourceid="1" managerid="1"/>
+  <sc_resources_managers resourceid="1" managerid="2"/>
+  <sc_resources_managers resourceid="2" managerid="0"/>
+  <sc_resources_managers resourceid="3" managerid="0"/>
 
   <uniqueId maxId="20" tablename="sc_resources_resource"/>
 

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/GroupUserLinkEventListener.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/GroupUserLinkEventListener.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.silverpeas.components.resourcesmanager.model.Resource;
+import org.silverpeas.components.resourcesmanager.service.ResourceService;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.notification.GroupUserLink;
+import org.silverpeas.core.admin.user.notification.GroupUserLinkEvent;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Listens for removing of users in groups in order to remove also them from the validators of all
+ * of the resources managed by the Resource Manager applications. The event is listening once the
+ * transaction within which the user is removed from the group has been successfully commited. This
+ * is to ensure the user doesn't belong anymore to a group or directly in the Manager role profile
+ * of the Resources Manager applications when checked.
+ *
+ * @author mmoquillon
+ */
+@Service
+public class GroupUserLinkEventListener extends CDIResourceEventListener<GroupUserLinkEvent> {
+
+  @Inject
+  private OrganizationController organization;
+  @Inject
+  private ResourceService resourceService;
+  @Inject
+  private ResourcesManagersSynchronizer synchronizer;
+
+  @Override
+  public void onDeletion(GroupUserLinkEvent event) {
+    GroupUserLink link = event.getTransition().getBefore();
+    Set<String> instancesIds =
+        getResourcesManagersInWhichUserIsManagerOnlyByGroup(link.getUserId(), link.getGroupId());
+    Set<String> userIdToRemove = Set.of(link.getUserId());
+    instancesIds.forEach(id -> synchronizer.synchronize(id, userIdToRemove));
+  }
+
+  private Set<String> getResourcesManagersInWhichUserIsManagerOnlyByGroup(String userId,
+      String groupId) {
+    return resourceService.getResources().stream()
+        .filter(r -> r.getManagers().stream()
+            .anyMatch(m -> m.getManagerId() == Integer.parseInt(userId)))
+        .map(Resource::getInstanceId)
+        .distinct()
+        .filter(id -> organization.getComponentInst(id).getAllProfilesInst().stream()
+            .filter(p -> p.getName().equalsIgnoreCase("responsable"))
+            .reduce(this::merge)
+            .filter(p -> !p.getAllUsers().contains(userId))
+            .filter(p -> isInGroups(groupId, p.getAllGroups()))
+            .filter(p -> isNotInOthersGroups(userId, groupId, p.getAllGroups()))
+            .isPresent())
+        .collect(Collectors.toSet());
+  }
+
+  private boolean isInGroups(String groupId, List<String> groups) {
+    return groups.contains(groupId)
+        || groups.stream()
+        .flatMap(g -> Stream.of(organization.getRecursivelyAllSubgroups(g)))
+        .map(Group.class::cast)
+        .anyMatch(g -> g.getId().equalsIgnoreCase(groupId));
+  }
+
+  private boolean isNotInOthersGroups(String userId, String groupId, List<String> groups) {
+    return groups.stream()
+        .filter(g -> !g.equalsIgnoreCase(groupId))
+        .map(g -> organization.getGroup(g))
+        .map(Group.class::cast)
+        .noneMatch(g -> List.of(g.getUserIds()).contains(userId));
+  }
+
+  // merge two similar profiles, one being specific to the Resources Manager app, the other
+  // inherited from the workspace
+  private ProfileInst merge(ProfileInst profileInst1, ProfileInst profileInst2) {
+    ProfileInst profileInst = new ProfileInst();
+    profileInst.setGroups(profileInst1.getAllGroups());
+    profileInst.addGroups(profileInst2.getAllGroups());
+    profileInst.setUsers(profileInst1.getAllUsers());
+    profileInst.addUsers(profileInst2.getAllUsers());
+    return profileInst;
+  }
+}

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ProfileInstEventListener.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ProfileInstEventListener.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.notification.ProfileInstEvent;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Listens for update or creation of a profile instances for the Resource Manager applications. Its
+ * goal is to be notified when a user doesn't play anymore the responsible role in a given Resource
+ * Manager application and hence cannot be a validator of reservable resources.
+ *
+ * @author mmoquillon
+ */
+@Service
+public class ProfileInstEventListener extends CDIResourceEventListener<ProfileInstEvent> {
+
+  private static final String COMPONENT_NAME = "resourcesManager";
+  private static final String MANAGER_ROLE_NAME = "responsable";
+
+  @Inject
+  private OrganizationController organization;
+  @Inject
+  private ResourcesManagersSynchronizer synchronizer;
+
+  /**
+   * one or more users have been removed, either directly or through groups removing, from the
+   * specified profile. Only the publisher and writer profiles are taken in charge as these profiles
+   * are those which feeds the responsible role in the application.
+   *
+   * @param event the event on the update of a resource.
+   */
+  @Override
+  @Transactional
+  public void onUpdate(ProfileInstEvent event) {
+    ProfileInst before = event.getTransition().getBefore();
+    ProfileInst after = event.getTransition().getAfter();
+    if (isOnResponsibleRole(before)) {
+      String instanceId = COMPONENT_NAME + after.getComponentFatherId();
+      Set<String> removedUsers = findRemovedUsersId(instanceId, before, after);
+      synchronizer.synchronize(instanceId, removedUsers);
+    }
+  }
+
+  /**
+   * Finds the users that were removed, either directly or through groups, from the specified role
+   * profile of the related Resources Manager application. The users or the groups that are removed
+   * by the profile instance update are those present in the role profile before the update and that
+   * aren't anymore present in the role profile after the update.
+   *
+   * @param instanceId the unique identifier of the Resources Manager application.
+   * @param before the state of the role profile before update.
+   * @param after the state of the role profile after update.
+   * @return a set with the unique identifiers of all of the users that were removed by the profile
+   * instance update.
+   */
+  private Set<String> findRemovedUsersId(String instanceId, ProfileInst before, ProfileInst after) {
+    List<String> usersAfter = after.getAllUsers();
+    List<String> groupsAfter = after.getAllGroups();
+    // get all the users directly removed from the profile instance and who's not anymore
+    // declared among the Manager role profile of the application
+    Stream<String> removedUsers = before.getAllUsers().stream()
+        .filter(user -> !usersAfter.contains(user))
+        .filter(u -> Stream.of(organization.getUserProfiles(u, instanceId))
+            .noneMatch(p -> p.equalsIgnoreCase(MANAGER_ROLE_NAME)));
+
+
+    // get all the users belonging to the groups removed from the profile instance and who's not
+    // anymore declared among the Manager role profile of the application
+    Stream<String> removedUsersInGroups = before.getAllGroups().stream()
+        .filter(group -> !groupsAfter.contains(group))
+        .map(g -> organization.getGroup(g))
+        .flatMap(g -> Stream.of(((Group) g).getUserIds()))
+        .distinct()
+        .filter(u -> Stream.of(organization.getUserProfiles(u, instanceId))
+            .noneMatch(p -> p.equalsIgnoreCase(MANAGER_ROLE_NAME)));
+
+    return Stream.concat(removedUsers, removedUsersInGroups).collect(Collectors.toSet());
+  }
+
+  private boolean isOnResponsibleRole(ProfileInst profileInst) {
+    return profileInst.getName().equalsIgnoreCase(MANAGER_ROLE_NAME);
+  }
+}
+  

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ResourcesManagerInstancePreDestruction.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ResourcesManagerInstancePreDestruction.java
@@ -29,6 +29,8 @@ import org.silverpeas.components.resourcesmanager.repository.CategoryRepository;
 import org.silverpeas.components.resourcesmanager.repository.ReservationRepository;
 import org.silverpeas.components.resourcesmanager.repository.ReservedResourceRepository;
 import org.silverpeas.components.resourcesmanager.repository.ResourceValidatorRepository;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -39,6 +41,8 @@ import javax.transaction.Transactional;
  * deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class ResourcesManagerInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ResourcesManagersSynchronizer.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/ResourcesManagersSynchronizer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.resourcesmanager;
+
+import org.silverpeas.components.resourcesmanager.model.Resource;
+import org.silverpeas.components.resourcesmanager.model.ResourceValidator;
+import org.silverpeas.components.resourcesmanager.service.ResourceService;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.kernel.annotation.Defined;
+import org.silverpeas.kernel.annotation.NonNull;
+import org.silverpeas.kernel.annotation.Technical;
+import org.silverpeas.kernel.util.StringUtil;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A synchronizer of the list of managers of all concerned resources with any modification of the
+ * Manager role profile for a Resources Manager application.
+ *
+ * @author mmoquillon
+ */
+@Technical
+@Service
+@Singleton
+public class ResourcesManagersSynchronizer {
+
+  @Inject
+  private ResourceService resourceService;
+
+  /**
+   * Synchronizes the list of managers of the resources managed by the specified Resources Manager
+   * application and by taking into account the given users have been removed from the Manager role
+   * profile for the application. The specified users could could have been explicitly removed or
+   * have been in a group that has been removed from the Manager role profile.
+   *
+   * @param instanceId the unique identifier of a Resource Managers application.
+   * @param removedUsersId a set with the unique identifiers of the removed users.
+   */
+  @Transactional
+  public void synchronize(@Defined String instanceId, @NonNull Set<String> removedUsersId) {
+    StringUtil.requireDefined(instanceId);
+    Objects.requireNonNull(removedUsersId);
+    List<Resource> resources = resourceService.getResources(instanceId);
+    updateValidators(resources, removedUsersId);
+  }
+
+  private void updateValidators(List<Resource> resources, Set<String> removedUsersId) {
+    resources.forEach(r -> {
+      List<ResourceValidator> managerIds = r.getManagers().stream()
+          .map(ResourceValidator::getManagerId)
+          .filter(m -> !removedUsersId.contains(String.valueOf(m)))
+          .map(m -> new ResourceValidator(r.getIdAsLong(), m))
+          .collect(Collectors.toList());
+      r.setManagers(managerIds);
+      resourceService.updateResource(r);
+    });
+  }
+}
+  

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/model/Resource.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/model/Resource.java
@@ -41,6 +41,9 @@ import java.util.List;
 @NamedQuery(name = "resource.findAllBookableResources",
     query = "SELECT resource FROM Resource resource WHERE resource.instanceId = :instanceId " +
         "AND resource.bookable = 1 AND resource.category.bookable = 1 ORDER BY resource.name")
+@NamedQuery(name = "resource.findAllResources",
+    query = "SELECT resource FROM Resource resource WHERE resource.instanceId = :instanceId " +
+        "ORDER BY resource.name")
 @NamedQuery(name = "resource.deleteResourcesFromCategory",
     query = "DELETE FROM Resource resource WHERE resource.category.id = :categoryId")
 public class Resource extends BasicJpaEntity<Resource, UniqueLongIdentifier> {
@@ -65,7 +68,8 @@ public class Resource extends BasicJpaEntity<Resource, UniqueLongIdentifier> {
   private String updaterId;
   @Column
   private String instanceId;
-  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "resource")
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "resource",
+      fetch = FetchType.EAGER)
   private List<ResourceValidator> managers = new ArrayList<>();
   @Transient
   private String status;
@@ -187,9 +191,9 @@ public class Resource extends BasicJpaEntity<Resource, UniqueLongIdentifier> {
     return managers;
   }
 
-  @SuppressWarnings("unused")
   public void setManagers(List<ResourceValidator> managers) {
-    this.managers = managers;
+    this.managers.clear();
+    this.managers.addAll(managers);
   }
 
   public void merge(Resource resource) {

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/repository/ResourceJpaRepository.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/repository/ResourceJpaRepository.java
@@ -50,6 +50,12 @@ public class ResourceJpaRepository extends BasicJpaEntityRepository<Resource>
   }
 
   @Override
+  public List<Resource> findAllResources(String instanceId) {
+    return listFromNamedQuery("resource.findAllResources",
+        newNamedParameters().add("instanceId", instanceId));
+  }
+
+  @Override
   public List<Resource> findAllResourcesForReservation(final Long reservationId) {
     return listFromNamedQuery("reservedResource.findAllResourcesForReservation",
         newNamedParameters().add("reservationId", reservationId));

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/repository/ResourceRepository.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/repository/ResourceRepository.java
@@ -35,6 +35,8 @@ public interface ResourceRepository extends EntityRepository<Resource>, WithSave
 
   List<Resource> findAllBookableResources(String instanceId);
 
+  List<Resource> findAllResources(String instanceId);
+
   List<Resource> findAllResourcesForReservation(Long reservationId);
 
   List<Resource> findAllReservedResources(Long reservationIdToSkip, List<Long> aimedResourceIds,

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/ResourceService.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/ResourceService.java
@@ -62,6 +62,14 @@ public class ResourceService {
     return repository.getAll();
   }
 
+  public List<Resource> getBookableResources(String componentId) {
+    return repository.findAllBookableResources(componentId);
+  }
+
+  public List<Resource> getResources(String componentId) {
+    return repository.findAllResources(componentId);
+  }
+
   public Resource getResource(long id) {
     return repository.getById(Long.toString(id));
   }

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/ResourcesManager.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/ResourcesManager.java
@@ -33,72 +33,76 @@ import java.util.Date;
 import java.util.List;
 
 /**
+ * Manager of the resources in a given Resource Manager application
+ *
  * @author ehugonnet
  */
 public interface ResourcesManager {
 
-  public List<Category> getCategories(String instanceId);
+  List<Category> getCategories(String instanceId);
 
-  public void createCategory(Category category);
+  void createCategory(Category category);
 
-  public void deleteCategory(Long id, String componentId);
+  void deleteCategory(Long id, String componentId);
 
-  public Category getCategory(Long id);
+  Category getCategory(Long id);
 
-  public void updateCategory(Category category);
+  void updateCategory(Category category);
 
-  public void createResource(Resource resource);
+  void createResource(Resource resource);
 
-  public List<Resource> getResourcesByCategory(Long categoryId);
+  List<Resource> getResourcesByCategory(Long categoryId);
 
-  public void deleteResource(Long id, String componentId);
+  List<Resource> getBookableResources(String componentId);
 
-  public Resource getResource(Long id);
+  void deleteResource(Long id, String componentId);
 
-  public void updateResource(Resource resource, List<Long> managerIds);
+  Resource getResource(Long id);
 
-  public List<Resource> getResourcesReservable(String instanceId, Date startDate, Date endDate);
+  void updateResource(Resource resource, List<Long> managerIds);
 
-  public List<Resource> getReservedResources(String instanceId, List<Long> resources,
+  List<Resource> getResourcesReservable(String instanceId, Date startDate, Date endDate);
+
+  List<Resource> getReservedResources(String instanceId, List<Long> resources,
       Date startDate, Date endDate);
 
-  public void saveReservation(Reservation reservation, List<Long> resourceIds);
+  void saveReservation(Reservation reservation, List<Long> resourceIds);
 
-  public List<Reservation> getReservations(String instanceId);
+  List<Reservation> getReservations(String instanceId);
 
-  public List<Resource> getResourcesOfReservation(String instanceId, Long reservationId);
+  List<Resource> getResourcesOfReservation(String instanceId, Long reservationId);
 
-  public void deleteReservation(Long id, String componentId);
+  void deleteReservation(Long id, String componentId);
 
-  public Reservation getReservation(String instanceId, Long reservationId);
+  Reservation getReservation(String instanceId, Long reservationId);
 
-  public void updateReservation(Reservation reservation, List<Long> resourceIds,
+  void updateReservation(Reservation reservation, List<Long> resourceIds,
       boolean updateDate);
 
-  public List<Resource> getReservedResources(String instanceId, List<Long> aimedResourceIds,
+  List<Resource> getReservedResources(String instanceId, List<Long> aimedResourceIds,
       Date startDate, Date endDate, Long reservationIdToSkip);
 
-  public List<Reservation> getUserReservations(String instanceId, String userId);
+  List<Reservation> getUserReservations(String instanceId, String userId);
 
-  public List<Reservation> getReservationOfUser(String instanceId, Integer userId,
+  List<Reservation> getReservationOfUser(String instanceId, Integer userId,
       final Period period);
 
-  public List<Reservation> getReservationForValidation(String instanceId, String userId,
+  List<Reservation> getReservationForValidation(String instanceId, String userId,
       final Period period);
 
-  public List<Reservation> getReservationWithResourcesOfCategory(final String instanceId,
+  List<Reservation> getReservationWithResourcesOfCategory(final String instanceId,
       Integer userId, final Period period, Long categoryId);
 
-  public List<Reservation> getReservationWithResource(final String instanceId, Integer userId,
+  List<Reservation> getReservationWithResource(final String instanceId, Integer userId,
       Period period, Long resourceId);
 
-  public void indexResourceManager(String instanceId);
+  void indexResourceManager(String instanceId);
 
-  public List<ResourceValidator> getManagers(long resourceId);
+  List<ResourceValidator> getManagers(long resourceId);
 
-  public String getResourceOfReservationStatus(Long resourceId, Long reservationId);
+  String getResourceOfReservationStatus(Long resourceId, Long reservationId);
 
-  public void updateReservedResourceStatus(long reservationId, long resourceId, String status);
+  void updateReservedResourceStatus(long reservationId, long resourceId, String status);
 
-  public boolean isManager(long userId, long resourceId);
+  boolean isManager(long userId, long resourceId);
 }

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/SimpleResourcesManager.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/service/SimpleResourcesManager.java
@@ -121,6 +121,11 @@ public class SimpleResourcesManager implements ResourcesManager, Serializable {
   }
 
   @Override
+  public List<Resource> getBookableResources(String componentId) {
+    return resourceService.getBookableResources(componentId);
+  }
+
+  @Override
   public void deleteResource(Long id, String componentId) {
     resourceService.deleteResource(id);
     deleteIndex(id, TYPE, componentId);

--- a/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/util/ResourceUtil.java
+++ b/resourcesManager/resourcesManager-library/src/main/java/org/silverpeas/components/resourcesmanager/util/ResourceUtil.java
@@ -36,10 +36,13 @@ import java.util.StringTokenizer;
  */
 public class ResourceUtil {
 
+  private ResourceUtil() {
+  }
+
   /**
    * Get a list of resource identifiers from a list of resource.
-   * @param resources
-   * @return
+   * @param resources a list of resources.
+   * @return a list of the resources' identifiers.
    */
   public static List<Long> toIdList(List<Resource> resources) {
     List<Long> result = new ArrayList<>();
@@ -54,8 +57,8 @@ public class ResourceUtil {
   /**
    * Get a list of resource identifiers from a string containing resource identifiers separated by
    * comma.
-   * @param stringOfIds
-   * @return
+   * @param stringOfIds a string encoding a comma-separator list of resources' identifiers.
+   * @return the list of the resources' identifiers.
    */
   public static List<Long> toIdList(String stringOfIds) {
     List<Long> result = new ArrayList<>();

--- a/rssAggregator/rssAggregator-library/src/main/java/org/silverpeas/components/rssaggregator/RssAgregatorInstancePreDestruction.java
+++ b/rssAggregator/rssAggregator-library/src/main/java/org/silverpeas/components/rssaggregator/RssAgregatorInstancePreDestruction.java
@@ -23,20 +23,23 @@
  */
 package org.silverpeas.components.rssaggregator;
 
-import org.silverpeas.components.rssaggregator.service.RssAggregator;
-import org.silverpeas.core.annotation.Service;
-import org.silverpeas.kernel.SilverpeasRuntimeException;
-import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.rssaggregator.model.RssAgregatorException;
+import org.silverpeas.components.rssaggregator.service.RssAggregator;
+import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 /**
  * Deletes all the RSS streams in the RssAgregrator instance that is being deleted.
+ *
  * @author mmoquillon
  */
-@Service
+@Technical
+@Bean
 @Named
 public class RssAgregatorInstancePreDestruction implements ComponentInstancePreDestruction {
 
@@ -45,6 +48,7 @@ public class RssAgregatorInstancePreDestruction implements ComponentInstancePreD
 
   /**
    * Performs pre destruction tasks in the behalf of the specified RssAgregrator instance.
+   *
    * @param componentInstanceId the unique identifier of the RssAgregrator instance.
    */
   @Override

--- a/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/SuggestionBoxInstancePreDestruction.java
+++ b/suggestionBox/suggestionBox-library/src/main/java/org/silverpeas/components/suggestionbox/SuggestionBoxInstancePreDestruction.java
@@ -26,6 +26,8 @@ package org.silverpeas.components.suggestionbox;
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.suggestionbox.model.SuggestionBox;
 import org.silverpeas.components.suggestionbox.model.SuggestionBoxService;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -35,6 +37,8 @@ import javax.transaction.Transactional;
  * Deletes the suggestion box associated with the SuggestionBox instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class SuggestionBoxInstancePreDestruction implements ComponentInstancePreDestruction {
 

--- a/webPages/webPages-library/src/main/java/org/silverpeas/components/webpages/WebPagesInstancePreDestruction.java
+++ b/webPages/webPages-library/src/main/java/org/silverpeas/components/webpages/WebPagesInstancePreDestruction.java
@@ -24,10 +24,13 @@
 package org.silverpeas.components.webpages;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateException;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.annotation.Technical;
 import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Named;
@@ -36,6 +39,8 @@ import javax.inject.Named;
  * Deletes all the web pages managed by the WebPages instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class WebPagesInstancePreDestruction implements ComponentInstancePreDestruction {
   /**
@@ -55,7 +60,7 @@ public class WebPagesInstancePreDestruction implements ComponentInstancePreDestr
         PublicationTemplateManager.getInstance()
             .removePublicationTemplate(componentInstanceId + ":" + xmlShortName);
       } catch (PublicationTemplateException e) {
-        throw new RuntimeException(e.getMessage(), e);
+        throw new SilverpeasRuntimeException(e.getMessage(), e);
       }
     }
   }

--- a/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/BookmarkInstancePreDestruction.java
+++ b/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/BookmarkInstancePreDestruction.java
@@ -23,12 +23,17 @@
  */
 package org.silverpeas.components.websites;
 
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.annotation.Technical;
+
 import javax.inject.Named;
 
 /**
  * Deletes all the web site links recorded into the Bookmark instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class BookmarkInstancePreDestruction extends WebSitesInstancePreDestruction {
 

--- a/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/WebSitesInstancePreDestruction.java
+++ b/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/WebSitesInstancePreDestruction.java
@@ -25,6 +25,9 @@ package org.silverpeas.components.websites;
 
 import org.silverpeas.core.admin.component.ComponentInstancePreDestruction;
 import org.silverpeas.components.websites.dao.SiteDAO;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.annotation.Technical;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 import org.silverpeas.kernel.bundle.SettingBundle;
 import org.silverpeas.core.util.file.FileFolderManager;
@@ -37,6 +40,8 @@ import java.io.File;
  * Deletes all the web site managed by the WebSites instance that is being deleted.
  * @author mmoquillon
  */
+@Technical
+@Bean
 @Named
 public class WebSitesInstancePreDestruction implements ComponentInstancePreDestruction {
   /**
@@ -51,12 +56,11 @@ public class WebSitesInstancePreDestruction implements ComponentInstancePreDestr
       siteDAO.deleteAllWebSites();
       deleteAttachmentsAndImagesDirectory(componentInstanceId);
     } catch (Exception e) {
-      throw new RuntimeException(e.getMessage(), e);
+      throw new SilverpeasRuntimeException(e.getMessage(), e);
     }
   }
 
-  private void deleteAttachmentsAndImagesDirectory(String componentId)
-      throws java.lang.Exception {
+  private void deleteAttachmentsAndImagesDirectory(String componentId) {
     final SettingBundle uploadSettings =
         ResourceLocator.getSettingBundle("org.silverpeas.webSites.settings.webSiteSettings");
     FileFolderManager.deleteFolder(uploadSettings.getString("uploadsPath") + File.separator +


### PR DESCRIPTION
This PR is related to https://github.com/Silverpeas/Silverpeas-Core/pull/1390

Adds specific lifecycle CDI stereotype to some beans in order to be able, in the futur, to enable the management of the beans by CDI for only those being annotated with CDI stereotype annotations.

Provide another solution to the fix of the bug based upon the system event notification mechanism. In ResourcesManager component:
- Add listeners of events related to the remove (directly or not) of users from the Manager profile instance (role name 'responsable').
- Add listeners of events related to the remove of a user from a group that is declared in the Manager profile (role name 'responsable').
- To allow to update the validators list of the resources managed by the component according to the events received by the listeners, the ResourceRepository and the ResourceService classes have been updated.
- Add integration tests to ensure the listeners work correctly.