### PR TITLE
Feature 10786

### DIFF
--- a/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
+++ b/blog/blog-library/src/main/java/org/silverpeas/components/blog/service/DefaultBlogService.java
@@ -273,7 +273,7 @@ public class DefaultBlogService implements BlogService, Initialization {
       // Delete wysiwyg content
       WysiwygController.deleteFileAndAttachment(instanceId, postId);
       // Delete publication
-      publicationService.removePublication(pubPK);
+      publicationService.deletePublication(pubPK);
       // Delete silverContent
       blogContentManager.deleteSilverContent(con, pubPK);
     } catch (Exception e) {
@@ -467,7 +467,7 @@ public class DefaultBlogService implements BlogService, Initialization {
             .getPK(), nodePk);
       }
       // suppression de la catégorie
-      nodeService.removeNode(nodePk);
+      nodeService.deleteNode(nodePk);
     } catch (Exception e) {
       throw new BlogRuntimeException(e);
     }

--- a/community/community-library/src/integration-test/resources/community-database.sql
+++ b/community/community-library/src/integration-test/resources/community-database.sql
@@ -225,6 +225,8 @@ CREATE TABLE IF NOT EXISTS sb_node_node
     orderNumber      int DEFAULT (0)  NULL,
     lang             char(2),
     rightsDependsOn  int default (-1) NOT NULL,
+    nodeRemovalDate  varchar (10)     NULL,
+    nodeRemoverId    varchar (100)    NULL,
     CONSTRAINT PK_Node_Node PRIMARY KEY (nodeId, instanceId)
 );
 
@@ -274,7 +276,9 @@ CREATE TABLE IF NOT EXISTS SB_Publication_Publi
     pubCloneId           int DEFAULT (-1),
     pubCloneStatus       varchar(50)     NULL,
     lang                 char(2)         NULL,
-    pubdraftoutdate      varchar(10)     NULL
+    pubdraftoutdate      varchar(10)     NULL,
+    pubRemovalDate       varchar(10)	 NULL,
+    pubRemoverId         varchar(100)	 NULL
 );
 
 CREATE TABLE IF NOT EXISTS SB_Publication_PubliI18N

--- a/forums/forums-library/src/main/java/org/silverpeas/components/forums/service/DefaultForumService.java
+++ b/forums/forums-library/src/main/java/org/silverpeas/components/forums/service/DefaultForumService.java
@@ -1043,7 +1043,7 @@ public class DefaultForumService implements ForumService {
       }
       // suppression de la categorie
       NodePK nodePk = new NodePK(categoryId, instanceId);
-      node.removeNode(nodePk);
+      node.deleteNode(nodePk);
     } catch (Exception e) {
       throw new ForumsRuntimeException(e);
     }

--- a/gallery/gallery-library/src/integration-test/resources/org/silverpeas/components/gallery/dao/create-media-database.sql
+++ b/gallery/gallery-library/src/integration-test/resources/org/silverpeas/components/gallery/dao/create-media-database.sql
@@ -89,5 +89,7 @@ CREATE TABLE sb_node_node
   type             VARCHAR(50)      NULL,
   orderNumber      INT DEFAULT (0)  NULL,
   lang             CHAR(2),
-  rightsDependsOn  INT DEFAULT (-1) NOT NULL
+  rightsDependsOn  INT DEFAULT (-1) NOT NULL,
+  nodeRemovalDate  VARCHAR (10)    NULL,
+  nodeRemoverId    VARCHAR (100)   NULL
 );

--- a/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/process/GalleryProcessManagement.java
+++ b/gallery/gallery-library/src/main/java/org/silverpeas/components/gallery/process/GalleryProcessManagement.java
@@ -325,7 +325,7 @@ public class GalleryProcessManagement {
     for (final NodeDetail node : childrens) {
       addDeleteAlbumProcesses(node.getNodePK());
     }
-    getNodeService().removeNode(albumPk);
+    getNodeService().deleteNode(albumPk);
   }
 
   /**

--- a/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/settings/kmeliaSettings.properties
+++ b/kmelia/kmelia-configuration/src/main/config/properties/org/silverpeas/kmelia/settings/kmeliaSettings.properties
@@ -111,3 +111,16 @@ publications.sort.default = 2
 kmelia.stats.enable=false
 # The maximum number of elements retrieve for statistics purpose
 kmelia.stats.most.interested.query.limit=10
+
+# The delay in days after which the topics and the publications in the bin of each kmelia instances
+# are definitively deleted. 0 to disable. If greater than 0, the automatic deletion has to be
+# then enabled for the bins to be clean out; for doing set a CRON value to the below property
+# kmelia.autoDeletionCron.
+kmelia.autoDeletionDelay = 0
+
+# Cron to schedule the automatic deletion of old topics and publications in the bin of each
+# Kmelia instances. Empty to disable the scheduling (and hence the automatic deletion of older
+# items in the bins). If scheduling, the automatic deletion will be performed only if the property
+# kmelia.autoDeletionDelay is greater than 0.
+# If DeleteRemovedApplicationsDelay=0, the JOB is deactivated.
+kmelia.autoDeletionCron =

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaPasteDetail.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/KmeliaPasteDetail.java
@@ -8,7 +8,7 @@ import org.silverpeas.core.node.model.NodePK;
 public class KmeliaPasteDetail {
 
   private String userId;
-  private NodePK toPK;
+  private final NodePK toPK;
   private NodePK fromPK;
   private String targetValidatorIds;
   private String status;

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/DefaultKmeliaService.java
@@ -173,7 +173,7 @@ import static org.silverpeas.kernel.util.StringUtil.*;
 @Singleton
 @Named("kmeliaService")
 @Transactional(Transactional.TxType.SUPPORTS)
-public class DefaultKmeliaService implements KmeliaService {
+public class DefaultKmeliaService implements KmeliaService, KmeliaDeleter {
 
   private static final String MESSAGES_PATH = "org.silverpeas.kmelia.multilang.kmeliaBundle";
   private static final String SETTINGS_PATH = "org.silverpeas.kmelia.settings.kmeliaSettings";
@@ -1382,7 +1382,8 @@ public class DefaultKmeliaService implements KmeliaService {
    *
    * @param pubPK the unique identifier of the publication to delete.
    */
-  private void deletePublication(PublicationPK pubPK) {
+  @Override
+  public void deletePublication(PublicationPK pubPK) {
     KmeliaOperationContext.about(DELETION);
     try {
       // remove form content
@@ -1424,7 +1425,7 @@ public class DefaultKmeliaService implements KmeliaService {
       }
 
       // remove all links between this publication and topics
-      publicationService.removeAllFathers(pubPK);
+      publicationService.removeAllFathe<>rs(pubPK);
       // add link between this publication and the basket topic
       publicationService.addFather(pubPK, new NodePK(NodePK.BIN_NODE_ID, pubPK));
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaBinsScheduledPurger.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaBinsScheduledPurger.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.kmelia.service;
+
+import org.silverpeas.core.admin.component.model.WAComponent;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.contribution.model.Contribution;
+import org.silverpeas.core.contribution.publication.service.PublicationService;
+import org.silverpeas.core.initialization.Initialization;
+import org.silverpeas.core.node.model.NodePK;
+import org.silverpeas.core.node.service.NodeService;
+import org.silverpeas.core.scheduler.Job;
+import org.silverpeas.core.scheduler.JobExecutionContext;
+import org.silverpeas.core.scheduler.Scheduler;
+import org.silverpeas.core.scheduler.SchedulerProvider;
+import org.silverpeas.core.scheduler.trigger.JobTrigger;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+import org.silverpeas.kernel.bundle.ResourceLocator;
+import org.silverpeas.kernel.bundle.SettingBundle;
+import org.silverpeas.kernel.logging.SilverLogger;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.Date;
+
+import static org.silverpeas.core.util.DateUtil.toLocalDate;
+
+/**
+ * A service scheduled in time to clean out periodically the bin in each Kmelia instances of the
+ * items (both topics and publications) that have been removed since a given number of days. The
+ * purge scheduling and the delay in days can be parameterized in the
+ * <code>org/silverpeas/kmelia/settings/kmeliaSettings.properties</code> configuration file.
+ *
+ * @author mmoquillon
+ */
+@Service
+public class KmeliaBinsScheduledPurger implements Initialization {
+
+  private static final String COMPONENT_NAME = "kmelia";
+  private static final String SETTINGS_NAME = "org.silverpeas.kmelia.settings.kmeliaSettings";
+  private static final String JOB_NAME = "OldBinItemsDeleter";
+
+  @Inject
+  private KmeliaDeleter deleter;
+  @Inject
+  private NodeService nodeService;
+  @Inject
+  private PublicationService publicationService;
+
+  @Override
+  public void init() throws Exception {
+    String cron = getSchedulingCron();
+    if (!cron.isEmpty()) {
+      final Scheduler scheduler = SchedulerProvider.getVolatileScheduler();
+      scheduler.unscheduleJob(JOB_NAME);
+      scheduler.scheduleJob(new OldBinItemsDeleter(), JobTrigger.triggerAt(cron));
+    }
+    new OldBinItemsDeleter().execute(JobExecutionContext.createWith(JOB_NAME, new Date()));
+  }
+
+  @Override
+  public void release() throws Exception {
+    Scheduler scheduler = SchedulerProvider.getVolatileScheduler();
+    if (scheduler.isJobScheduled(JOB_NAME)) {
+      scheduler.unscheduleJob(JOB_NAME);
+    }
+  }
+
+  private String getSchedulingCron() {
+    SettingBundle settings = ResourceLocator.getSettingBundle(SETTINGS_NAME);
+    return settings.getString("kmelia.autoDeletionCron", "");
+  }
+
+  private class OldBinItemsDeleter extends Job {
+
+    OldBinItemsDeleter() {
+      super(JOB_NAME);
+    }
+
+    @Transactional
+    @Override
+    public void execute(final JobExecutionContext context) {
+      int delay = getDeletionDelay();
+      if (delay > 0) {
+        try {
+          final LocalDate now = LocalDate.now();
+          WAComponent.getByName(COMPONENT_NAME)
+              .ifPresent(component ->
+                  component.getAllInstanceIds()
+                      .forEach(instanceId -> {
+                        NodePK bin = new NodePK(NodePK.BIN_NODE_ID, instanceId);
+                        nodeService.getChildrenDetails(bin).stream()
+                            .filter(node -> isOlder(node, now))
+                            .forEach(topic ->
+                                deleter.deleteTopic(topic.getNodePK()));
+                        publicationService.getDetailsByFatherPK(bin).stream()
+                            .filter(publication -> isOlder(publication, now))
+                            .forEach(publication ->
+                                deleter.deletePublication(publication.getPK()));
+                      }));
+
+        } catch (SilverpeasRuntimeException e) {
+          SilverLogger.getLogger(this).error(e.getMessage(), e);
+        }
+      }
+    }
+
+    private int getDeletionDelay() {
+      SettingBundle settings = ResourceLocator.getSettingBundle(SETTINGS_NAME);
+      int delay = settings.getInteger("kmelia.autoDeletionDelay", 0);
+      return Math.max(delay, 0);
+    }
+
+    private boolean isOlder(Contribution contribution, LocalDate date) {
+      final LocalDate removeDayDateWithDelay = toLocalDate(contribution.getLastUpdateDate())
+          .plusDays(getDeletionDelay());
+      return removeDayDateWithDelay.isBefore(date) ||
+          removeDayDateWithDelay.isEqual(date);
+    }
+  }
+}
+  

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaBinsScheduledPurger.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaBinsScheduledPurger.java
@@ -61,7 +61,7 @@ public class KmeliaBinsScheduledPurger implements Initialization {
 
   private static final String COMPONENT_NAME = "kmelia";
   private static final String SETTINGS_NAME = "org.silverpeas.kmelia.settings.kmeliaSettings";
-  private static final String JOB_NAME = "OldBinItemsDeleter";
+  private static final String JOB_NAME = "BinOlderItemsDeleter";
 
   @Inject
   private KmeliaDeleter deleter;
@@ -76,9 +76,9 @@ public class KmeliaBinsScheduledPurger implements Initialization {
     if (!cron.isEmpty()) {
       final Scheduler scheduler = SchedulerProvider.getVolatileScheduler();
       scheduler.unscheduleJob(JOB_NAME);
-      scheduler.scheduleJob(new OldBinItemsDeleter(), JobTrigger.triggerAt(cron));
+      scheduler.scheduleJob(new BinOlderItemsDeleter(), JobTrigger.triggerAt(cron));
     }
-    new OldBinItemsDeleter().execute(JobExecutionContext.createWith(JOB_NAME, new Date()));
+    new BinOlderItemsDeleter().execute(JobExecutionContext.createWith(JOB_NAME, new Date()));
   }
 
   @Override
@@ -94,9 +94,9 @@ public class KmeliaBinsScheduledPurger implements Initialization {
     return settings.getString("kmelia.autoDeletionCron", "");
   }
 
-  private class OldBinItemsDeleter extends Job {
+  private class BinOlderItemsDeleter extends Job {
 
-    OldBinItemsDeleter() {
+    BinOlderItemsDeleter() {
       super(JOB_NAME);
     }
 

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaDeleter.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaDeleter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.kmelia.service;
+
+import org.silverpeas.core.contribution.publication.model.PublicationPK;
+import org.silverpeas.core.node.model.NodePK;
+
+/**
+ * Deleter of contributions managed in a Kmelia application.
+ *
+ * @author mmoquillon
+ */
+public interface KmeliaDeleter {
+
+  /**
+   * Deletes definitively the specified topic and all descendants. Delete all links between
+   * descendants and publications. Its publications will deleted. Delete All subscriptions and
+   * favorites on its topics and all descendants
+   *
+   * @param pkToDelete the id of the topic to delete
+   */
+  void deleteTopic(NodePK pkToDelete);
+
+  /**
+   * Deletes definitively the specified publication.
+   *
+   * @param pubPK the unique identifier of the publication to delete.
+   */
+  void deletePublication(PublicationPK pubPK);
+}
+  

--- a/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
+++ b/kmelia/kmelia-library/src/main/java/org/silverpeas/components/kmelia/service/KmeliaService.java
@@ -124,16 +124,6 @@ public interface KmeliaService extends ApplicationService {
    */
   NodeDetail getSubTopicDetail(NodePK nodePK);
 
-  /**
-   * Delete a topic and all descendants. Delete all links between descendants and publications. Its
-   * publications will deleted. Delete All subscriptions and favorites on its topics and all
-   * descendants
-   *
-   * @param nodePK the id of the topic to delete
-   * @since 1.0
-   */
-  void deleteTopic(NodePK nodePK);
-
   void changeTopicStatus(String newStatus, NodePK nodePK, boolean recursiveChanges);
 
   void sortSubTopics(NodePK fatherPK, boolean recursive, String[] criteria);

--- a/questionReply/questionReply-war/src/main/java/org/silverpeas/components/questionreply/control/QuestionReplySessionController.java
+++ b/questionReply/questionReply-war/src/main/java/org/silverpeas/components/questionreply/control/QuestionReplySessionController.java
@@ -658,7 +658,7 @@ public class QuestionReplySessionController extends AbstractComponentSessionCont
         QuestionManagerProvider.getQuestionManager().updateQuestion(question);
       }
       NodePK nodePk = new NodePK(categoryId, getComponentId());
-      getNodeService().removeNode(nodePk);
+      getNodeService().deleteNode(nodePk);
     } catch (Exception e) {
       throw new QuestionReplyException(e);
     }

--- a/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/model/DefaultQuickInfoService.java
+++ b/quickinfo/quickinfo-library/src/main/java/org/silverpeas/components/quickinfo/model/DefaultQuickInfoService.java
@@ -348,7 +348,7 @@ public class DefaultQuickInfoService implements QuickInfoService {
     final PublicationPK foreignPK = news.getForeignPK();
 
     // Deleting publication
-    getPublicationService().removePublication(foreignPK);
+    getPublicationService().deletePublication(foreignPK);
 
     // De-reffering contribution in taxonomy
     try (final Connection connection = DBUtil.openConnection()) {

--- a/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
+++ b/webSites/webSites-library/src/main/java/org/silverpeas/components/websites/service/DefaultWebSiteService.java
@@ -233,7 +233,7 @@ public class DefaultWebSiteService implements WebSiteService {
         }
       }
       // Delete the topic
-      nodeService.removeNode(pkToDelete);
+      nodeService.deleteNode(pkToDelete);
     } catch (Exception re) {
       throw new WebSitesRuntimeException(re);
     }
@@ -357,7 +357,7 @@ public class DefaultWebSiteService implements WebSiteService {
 
     try {
       publicationService.removeAllFathers(pubPK);
-      publicationService.removePublication(pubPK);
+      publicationService.deletePublication(pubPK);
     } catch (Exception re) {
       throw new WebSitesRuntimeException(re);
     }

--- a/yellowpages/yellowpages-library/src/main/java/org/silverpeas/components/yellowpages/service/DefaultYellowpagesService.java
+++ b/yellowpages/yellowpages-library/src/main/java/org/silverpeas/components/yellowpages/service/DefaultYellowpagesService.java
@@ -338,7 +338,7 @@ public class DefaultYellowpagesService implements YellowpagesService {
 
     // Delete the topic
     try {
-      nodeService.removeNode(pkToDelete);
+      nodeService.deleteNode(pkToDelete);
     } catch (Exception re) {
       throw new YellowpagesRuntimeException(re);
     }


### PR DESCRIPTION
Implement a scheduled bins purger for the Kmelia instances. This purger is disabled by default. To enable it, just set the following properties `kmelia.autoDeletionDelay` and `kmelia.autoDeletionCron` in the configuration file `kmeliaSettings.properties`. The first property is to specify the threshold in days a contribution can be kept in a bin before its definitive deletion, and the second property is a CRON statement to plan the execution of the purger.

For its working, the purger uses the new `NodeDetail` and `PublicationDetail` removal attributes to compute the number of days the topics and the publications are in the bins in order to know if they have exceeded the delay.

This PR requires the following one https://github.com/Silverpeas/Silverpeas-Core/pull/1403