### PR TITLE
Bug #14806

### DIFF
--- a/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/model/Subscribe.java
+++ b/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/model/Subscribe.java
@@ -60,7 +60,7 @@ public class Subscribe implements Serializable {
   }
 
   public String getField1() {
-    return field1;
+    return field1 == null ? "" : field1;
   }
 
   public void setField1(String field1) {
@@ -68,7 +68,7 @@ public class Subscribe implements Serializable {
   }
 
   public String getField2() {
-    return field2;
+    return field2 == null ? "" : field2;
   }
 
   public void setField2(String field2) {

--- a/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/service/DefaultClassifiedService.java
+++ b/classifieds/classifieds-library/src/main/java/org/silverpeas/components/classifieds/service/DefaultClassifiedService.java
@@ -31,7 +31,6 @@ import org.silverpeas.components.classifieds.model.Subscribe;
 import org.silverpeas.components.classifieds.notification.ClassifiedSubscriptionUserNotification;
 import org.silverpeas.components.classifieds.notification.ClassifiedSupervisorUserNotification;
 import org.silverpeas.components.classifieds.notification.ClassifiedValidationUserNotification;
-import org.silverpeas.kernel.exception.NotFoundException;
 import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.user.model.UserDetail;
@@ -56,20 +55,15 @@ import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.kernel.bundle.LocalizationBundle;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 import org.silverpeas.kernel.bundle.SettingBundle;
-import org.silverpeas.kernel.util.StringUtil;
+import org.silverpeas.kernel.exception.NotFoundException;
 import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.silverpeas.core.SilverpeasExceptionMessages.*;
 
@@ -348,7 +342,8 @@ public class DefaultClassifiedService implements ClassifiedService {
       Collections.reverse(classifieds);
     } catch (Exception e) {
       throw new ClassifiedsRuntimeException(e.getMessage(), e);
-    } return classifieds;
+    }
+    return classifieds;
   }
 
   @Override
@@ -418,7 +413,8 @@ public class DefaultClassifiedService implements ClassifiedService {
   }
 
   @Override
-  public void draftOutClassified(ContributionIdentifier classifiedId, String profile, boolean isValidationEnabled) {
+  public void draftOutClassified(ContributionIdentifier classifiedId, String profile,
+      boolean isValidationEnabled) {
     ClassifiedDetail classified = getContributionById(classifiedId)
         .orElseThrow(() -> new NotFoundException(NO_SUCH_CLASSIFIED + classifiedId.asString()));
     String status = classified.getStatus();
@@ -485,9 +481,8 @@ public class DefaultClassifiedService implements ClassifiedService {
       Collection<Subscribe> subscriptions =
           getSubscribesByUser(subscribe.getInstanceId(), subscribe.getUserId());
       for (Subscribe sub : subscriptions) {
-        if (sub.getField1()
-            .equals(subscribe.getField1()) && sub.getField2()
-            .equals(subscribe.getField2())) {
+        if (sub.getField1().equals(subscribe.getField1())
+            && sub.getField2().equals(subscribe.getField2())) {
           return false;
         }
       }

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/SubscriptionField.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/SubscriptionField.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.classifieds.servlets;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A field of the classified form used by the search and on which also a user can subscribe for a
+ * given value to be notified about the classifieds having such value for the field.
+ *
+ * @author mmoquillon
+ */
+public class SubscriptionField {
+  private final String key;
+  private final String label;
+  private final Set<SubscriptionFieldValue> values = new HashSet<>();
+
+  public SubscriptionField(String key, String label) {
+    this.key = key;
+    this.label = label;
+  }
+
+  public SubscriptionField valuedBy(String valueKey, String valueLabel) {
+    values.add(new SubscriptionFieldValue(valueKey, valueLabel));
+    return this;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public Set<SubscriptionFieldValue> getValues() {
+    return values;
+  }
+}
+  

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/SubscriptionFieldValue.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/SubscriptionFieldValue.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.classifieds.servlets;
+
+/**
+ * Value of a field of the classified form on which a user can subscribe to be notified about the
+ * classifieds having such value for the field.
+ *
+ * @author mmoquillon
+ */
+public class SubscriptionFieldValue {
+
+  private final String key;
+  private final String value;
+
+  /**
+   * Constructs a new {@link SubscriptionFieldValue} instance.
+   *
+   * @param key the key identified uniquely of the field value.
+   * @param value a value of the field.
+   */
+  SubscriptionFieldValue(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  /**
+   * Gets the unique identifier of the field value.
+   * @return the unique identifier of the field value.
+   */
+  public String getKey() {
+    return key;
+  }
+
+  /**
+   * Gets the value of the field.
+   * @return the value of the field.
+   */
+  public String getValue() {
+    return value;
+  }
+
+}
+  

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedCreationHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedCreationHandler.java
@@ -24,23 +24,18 @@
 
 package org.silverpeas.components.classifieds.servlets.handler;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.commons.fileupload.FileItem;
-
 import org.silverpeas.components.classifieds.control.ClassifiedsRole;
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
 import org.silverpeas.components.classifieds.model.ClassifiedDetail;
 import org.silverpeas.components.classifieds.servlets.FunctionHandler;
-import org.silverpeas.core.contribution.content.form.DataRecord;
-import org.silverpeas.core.contribution.content.form.Form;
-import org.silverpeas.core.contribution.content.form.PagesContext;
-import org.silverpeas.core.contribution.content.form.RecordSet;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
-import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Use Case : for all users, show all adds of given category
@@ -86,20 +81,7 @@ public class ClassifiedCreationHandler extends FunctionHandler {
       PublicationTemplate pubTemplate = getPublicationTemplate(classifiedsSC);
       if (pubTemplate != null) {
         // populate data record
-        RecordSet set = pubTemplate.getRecordSet();
-        Form form = pubTemplate.getUpdateForm();
-        DataRecord data = set.getRecord(classifiedId);
-        if (data == null) {
-          data = set.getEmptyRecord();
-          data.setId(classifiedId);
-        }
-        PagesContext context = new PagesContext("myForm", "0", classifiedsSC.getLanguage(), false,
-            classifiedsSC.getComponentId(), classifiedsSC.getUserId());
-        context.setObjectId(classifiedId);
-
-        // save data record
-        form.update(items, data, context);
-        set.save(data);
+        setDataRecord(classifiedsSC, pubTemplate, classifiedId, items);
         classifiedsSC.updateClassified(classified, false, false, false);
       }
     }

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedRefuseHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedRefuseHandler.java
@@ -25,16 +25,14 @@
 package org.silverpeas.components.classifieds.servlets.handler;
 
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
-import org.silverpeas.components.classifieds.servlets.FunctionHandler;
 import org.silverpeas.core.util.MultiSilverpeasBundle;
 import org.silverpeas.core.web.http.HttpRequest;
-import org.silverpeas.core.web.mvc.webcomponent.WebMessager;
 
 /**
  * Use Case : for all users, show all adds of given category
  * @author Ludovic Bertin
  */
-public class ClassifiedRefuseHandler extends FunctionHandler {
+public class ClassifiedRefuseHandler extends ClassifiedValidationHandler {
 
   @Override
   public String getDestination(ClassifiedsSessionController classifiedsSC,
@@ -49,17 +47,6 @@ public class ClassifiedRefuseHandler extends FunctionHandler {
 
     MultiSilverpeasBundle resources = classifiedsSC.getResources();
     String message = resources.getString("classifieds.classifiedRefused") + "...\n";
-    if (!classifiedsSC.getSessionClassifieds().isEmpty()) {
-      WebMessager.getInstance()
-          .addSuccess(message + resources.getString("classifieds.redirect.next"));
-      // More classifieds to validate, go to the next one
-      return HandlerProvider.getHandler("Next").computeDestination(classifiedsSC, request);
-    }
-
-    // go back to classifieds to validate
-    WebMessager.getInstance()
-        .addSuccess(message + resources.getString("classifieds.toValidate.nomore"));
-    return HandlerProvider.getHandler("ViewClassifiedToValidate")
-        .computeDestination(classifiedsSC, request);
+    return nextDestination(classifiedsSC, request, message);
   }
 }

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedUpdateFormHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedUpdateFormHandler.java
@@ -48,8 +48,8 @@ public class ClassifiedUpdateFormHandler extends FunctionHandler {
     ClassifiedDetail classified = classifiedsSC.getClassifiedWithImages(classifiedId);
 
     // Get form template and data
-    Form formView = null;
-    DataRecord data = null;
+    Form formView;
+    DataRecord data;
     PublicationTemplate pubTemplate = getPublicationTemplate(classifiedsSC);
     if (pubTemplate != null) {
       formView = pubTemplate.getUpdateForm();

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedUpdateHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedUpdateHandler.java
@@ -24,22 +24,17 @@
 
 package org.silverpeas.components.classifieds.servlets.handler;
 
-import java.util.List;
-
 import org.apache.commons.fileupload.FileItem;
-
 import org.silverpeas.components.classifieds.control.ClassifiedsRole;
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
 import org.silverpeas.components.classifieds.model.ClassifiedDetail;
 import org.silverpeas.components.classifieds.servlets.FunctionHandler;
-import org.silverpeas.core.contribution.content.form.DataRecord;
-import org.silverpeas.core.contribution.content.form.Form;
-import org.silverpeas.core.contribution.content.form.PagesContext;
-import org.silverpeas.core.contribution.content.form.RecordSet;
-import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
-import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
+import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
 import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.kernel.util.StringUtil;
+
+import java.util.List;
 
 /**
  * Use Case : for all users, show all adds of given category
@@ -75,19 +70,7 @@ public class ClassifiedUpdateHandler extends FunctionHandler {
       // Populate data record
       PublicationTemplate pub = getPublicationTemplate(classifiedsSC);
       if (pub != null) {
-        RecordSet set = pub.getRecordSet();
-        Form form = pub.getUpdateForm();
-        DataRecord data = set.getRecord(classifiedId);
-        if (data == null) {
-          data = set.getEmptyRecord();
-          data.setId(classifiedId);
-        }
-        PagesContext context = new PagesContext("myForm", "0", classifiedsSC.getLanguage(), false,
-            classifiedsSC.getComponentId(), classifiedsSC.getUserId());
-        context.setObjectId(classifiedId);
-        // mise à jour des données saisies
-        form.update(items, data, context);
-        set.save(data);
+        setDataRecord(classifiedsSC, pub, classifiedId, items);
       }
       //Update classified
       classifiedsSC

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedValidateHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedValidateHandler.java
@@ -25,16 +25,14 @@
 package org.silverpeas.components.classifieds.servlets.handler;
 
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
-import org.silverpeas.components.classifieds.servlets.FunctionHandler;
 import org.silverpeas.core.util.MultiSilverpeasBundle;
 import org.silverpeas.core.web.http.HttpRequest;
-import org.silverpeas.core.web.mvc.webcomponent.WebMessager;
 
 /**
  * Use Case : for all users, show all adds of given category
  * @author Ludovic Bertin
  */
-public class ClassifiedValidateHandler extends FunctionHandler {
+public class ClassifiedValidateHandler extends ClassifiedValidationHandler {
 
   @Override
   public String getDestination(ClassifiedsSessionController classifiedsSC,
@@ -48,17 +46,6 @@ public class ClassifiedValidateHandler extends FunctionHandler {
 
     MultiSilverpeasBundle resources = classifiedsSC.getResources();
     String message = resources.getString("classifieds.classifiedValidated") + "...<br/>";
-    if (!classifiedsSC.getSessionClassifieds().isEmpty()) {
-      WebMessager.getInstance()
-          .addSuccess(message + resources.getString("classifieds.redirect.next"));
-      // More classifieds to validate, go to the next one
-      return HandlerProvider.getHandler("Next").computeDestination(classifiedsSC, request);
-    }
-
-    // go back to classified visualization
-    WebMessager.getInstance()
-        .addSuccess(message + resources.getString("classifieds.toValidate.nomore"));
-    return HandlerProvider.getHandler("ViewClassifiedToValidate")
-        .computeDestination(classifiedsSC, request);
+    return nextDestination(classifiedsSC, request, message);
   }
 }

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedValidationHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/ClassifiedValidationHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.components.classifieds.servlets.handler;
+
+import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
+import org.silverpeas.components.classifieds.servlets.FunctionHandler;
+import org.silverpeas.core.util.MultiSilverpeasBundle;
+import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.core.web.mvc.webcomponent.WebMessager;
+
+/**
+ * Handler takin in charge the validation of a classified.
+ *
+ * @author mmoquillon
+ */
+public abstract class ClassifiedValidationHandler extends FunctionHandler {
+
+  /**
+   * Once the validation (reject or accept) done, compute the next destination of the user web
+   * navigation.
+   * @param classifiedsSC the controller
+   * @param request the HTTP request
+   * @param message the message to print out to the user
+   * @return the URL of the web page to go to
+   */
+  protected final String nextDestination(ClassifiedsSessionController classifiedsSC,
+      HttpRequest request, String message) {
+    MultiSilverpeasBundle resources = classifiedsSC.getResources();
+    if (!classifiedsSC.getSessionClassifieds().isEmpty()) {
+      WebMessager.getInstance()
+          .addSuccess(message + resources.getString("classifieds.redirect.next"));
+      // More classifieds to validate, go to the next one
+      return HandlerProvider.getHandler("Next").computeDestination(classifiedsSC, request);
+    }
+
+    // go back to classifieds to validate
+    WebMessager.getInstance()
+        .addSuccess(message + resources.getString("classifieds.toValidate.nomore"));
+    return HandlerProvider.getHandler("ViewClassifiedToValidate")
+        .computeDestination(classifiedsSC, request);
+  }
+}
+  

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/DefaultHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/DefaultHandler.java
@@ -24,25 +24,28 @@
 
 package org.silverpeas.components.classifieds.servlets.handler;
 
+import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
+import org.silverpeas.components.classifieds.model.Category;
+import org.silverpeas.components.classifieds.model.ClassifiedDetail;
+import org.silverpeas.components.classifieds.servlets.FunctionHandler;
+import org.silverpeas.components.classifieds.servlets.SubscriptionField;
 import org.silverpeas.core.contribution.content.form.DataRecord;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
 import org.silverpeas.core.contribution.content.form.Form;
 import org.silverpeas.core.contribution.content.form.RecordSet;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
-import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
-import org.silverpeas.components.classifieds.model.Category;
-import org.silverpeas.components.classifieds.model.ClassifiedDetail;
-import org.silverpeas.components.classifieds.servlets.FunctionHandler;
 import org.silverpeas.core.index.indexing.model.FieldDescription;
 import org.silverpeas.core.index.search.model.QueryDescription;
-import org.silverpeas.kernel.logging.SilverLogger;
 import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.kernel.logging.SilverLogger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Default use case : show all categories and for each one, list last published adds
+ *
  * @author Ludovic Bertin
  */
 public class DefaultHandler extends FunctionHandler {
@@ -83,6 +86,10 @@ public class DefaultHandler extends FunctionHandler {
       Collection<Category> categories = null;
 
       if (pubTemplate != null) {
+        // subscription fieds
+        var fields = getSubscriptionFields(pubTemplate, request.getUserLanguage());
+        request.setAttribute("Fields", fields);
+
         // Template Name
         String templateFileName = pubTemplate.getFileName();
         String templateName = templateFileName.substring(0, templateFileName.lastIndexOf("."));
@@ -101,6 +108,9 @@ public class DefaultHandler extends FunctionHandler {
       return "accueil.jsp";
     } else {
       //Affichage page d'accueil annonces listées
+      List<SubscriptionField> fields = pubTemplate != null ?
+          getSubscriptionFields(pubTemplate, request.getUserLanguage()) : List.of();
+      request.setAttribute("Fields", fields);
       request.setAttribute("Classifieds", classifiedsSC.getAllValidClassifieds());
 
       // Returns jsp to redirect to
@@ -111,12 +121,13 @@ public class DefaultHandler extends FunctionHandler {
 
   /**
    * Build collection of categories filled with the collection of corresponding classifieds.
+   *
    * @param templateName XML form template name
    * @param label field label
    * @param stringKeys listbox key list
    * @param stringValues listbox value list
    * @param classifiedsSC Classified Session Controller
-   * @return
+   * @return a collection with the classifieds categories
    */
   private Collection<Category> createCategory(String templateName, String label, String stringKeys,
       String stringValues, ClassifiedsSessionController classifiedsSC) {

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/HandlerProvider.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/HandlerProvider.java
@@ -34,9 +34,9 @@ public class HandlerProvider {
   /**
    * Map the function name to the function handler
    */
-  private static Map<String, FunctionHandler> handlerMap = null;
+  private static final Map<String, FunctionHandler> handlerMap;
 
-  /**
+  /*
    * Inits the function handler
    */
   static {

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SearchHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SearchHandler.java
@@ -96,9 +96,9 @@ public class SearchHandler extends FunctionHandler {
         for (String fieldName : fieldNames) {
           Field field = data.getField(fieldName);
           String fieldValue = field.getStringValue();
-          if (fieldValue != null && fieldValue.trim().length() > 0) {
+          if (fieldValue != null && !fieldValue.trim().isEmpty()) {
             // multiple checkbox
-            String fieldQuery = fieldValue.trim().replaceAll("##", " AND ");
+            String fieldQuery = fieldValue.trim().replace("##", " AND ");
             query.addFieldQuery(
                 new FieldDescription(templateName + "$$" + fieldName, fieldQuery, null));
           }

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SearchResultsHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SearchResultsHandler.java
@@ -41,11 +41,7 @@ public class SearchResultsHandler extends FunctionHandler {
     String id = request.getParameter("Id");
     String type = request.getParameter("Type");
 
-    if ("Classified".equals(type)) {
-      request.setAttribute("ClassifiedId", id);
-      return HandlerProvider.getHandler("ViewClassified")
-          .computeDestination(classifiedsSC, request);
-    } else if (type.startsWith("Comment")) {
+    if ("Classified".equals(type) || type.startsWith("Comment")) {
       request.setAttribute("ClassifiedId", id);
       return HandlerProvider.getHandler("ViewClassified")
           .computeDestination(classifiedsSC, request);

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SubscriptionCreateFormHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SubscriptionCreateFormHandler.java
@@ -26,9 +26,6 @@ package org.silverpeas.components.classifieds.servlets.handler;
 
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
 import org.silverpeas.components.classifieds.servlets.FunctionHandler;
-import org.silverpeas.core.contribution.content.form.DataRecord;
-import org.silverpeas.core.contribution.content.form.Form;
-import org.silverpeas.core.contribution.content.form.RecordSet;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
 import org.silverpeas.core.web.http.HttpRequest;
 
@@ -41,20 +38,9 @@ public class SubscriptionCreateFormHandler extends FunctionHandler {
   @Override
   public String getDestination(ClassifiedsSessionController classifiedsSC,
       HttpRequest request) throws Exception {
-
-    // Get form template and data
-    Form formUpdate = null;
-    DataRecord data = null;
-    PublicationTemplate pubTemplate = getPublicationTemplate(classifiedsSC);
-    if (pubTemplate != null) {
-      formUpdate = pubTemplate.getSearchForm();
-      RecordSet recordSet = pubTemplate.getRecordSet();
-      data = recordSet.getEmptyRecord();
-    }
-
-    // Stores objects in request
-    request.setAttribute("Form", formUpdate);
-    request.setAttribute("Data", data);
+    PublicationTemplate template = getPublicationTemplate(classifiedsSC);
+    var fields = getSubscriptionFields(template, request.getUserLanguage());
+    request.setAttribute("Fields", fields);
 
     // Returns jsp to redirect to
     return "subscriptionManager.jsp";

--- a/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SubscriptionListHandler.java
+++ b/classifieds/classifieds-war/src/main/java/org/silverpeas/components/classifieds/servlets/handler/SubscriptionListHandler.java
@@ -27,15 +27,10 @@ package org.silverpeas.components.classifieds.servlets.handler;
 import org.silverpeas.components.classifieds.control.ClassifiedsSessionController;
 import org.silverpeas.components.classifieds.model.Subscribe;
 import org.silverpeas.components.classifieds.servlets.FunctionHandler;
-import org.silverpeas.core.contribution.content.form.DataRecord;
-import org.silverpeas.core.contribution.content.form.FieldTemplate;
-import org.silverpeas.core.contribution.content.form.Form;
-import org.silverpeas.core.contribution.content.form.RecordSet;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplate;
 import org.silverpeas.core.web.http.HttpRequest;
 
 import java.util.Collection;
-import java.util.HashMap;
 
 /**
  * Use Case : for all users, show all adds of given category
@@ -49,27 +44,12 @@ public class SubscriptionListHandler extends FunctionHandler {
 
     // Retrieves user subscriptions
     Collection<Subscribe> subscribes = classifiedsSC.getSubscribesByUser();
-    HashMap<String,String> fieldsLabel = new HashMap<>();
-
-    // Get form template and data
-    Form formUpdate = null;
-    DataRecord data = null;
-    PublicationTemplate pubTemplate = getPublicationTemplate(classifiedsSC);
-    if (pubTemplate != null) {
-      formUpdate = pubTemplate.getSearchForm();
-      RecordSet recordSet = pubTemplate.getRecordSet();
-      data = recordSet.getEmptyRecord();
-      //Store search fields label
-      for (FieldTemplate fieldTemplate : formUpdate.getFieldTemplates()) {
-        fieldsLabel.put(fieldTemplate.getFieldName(),fieldTemplate.getLabel(request.getUserLanguage()));
-      }
-    }
-
-    // Stores objects in request
     request.setAttribute("Subscribes", subscribes);
-    request.setAttribute("Form", formUpdate);
-    request.setAttribute("Data", data);
-    request.setAttribute("FieldsLabel", fieldsLabel);
+
+    // get subscription fields
+    PublicationTemplate template = getPublicationTemplate(classifiedsSC);
+    var fields = getSubscriptionFields(template, request.getUserLanguage());
+    request.setAttribute("Fields", fields);
 
     // Returns jsp to redirect to
     return "subscriptions.jsp";

--- a/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/subscriptionManager.jsp
+++ b/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/subscriptionManager.jsp
@@ -25,10 +25,6 @@
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
-<%@page import="org.silverpeas.core.contribution.content.form.Form"%>
-<%@page import="org.silverpeas.core.contribution.content.form.PagesContext"%>
-<%@page import="org.silverpeas.core.contribution.content.form.DataRecord"%>
-
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -40,9 +36,7 @@
 <view:setBundle bundle="${requestScope.resources.multilangBundle}" />
 <view:setBundle bundle="${requestScope.resources.iconsBundle}" var="icons" />
 
-<c:set var="formSearch" value="${requestScope.Form}" />
-<c:set var="data" value="${requestScope.Data}" />
-<c:set var="instanceId" value="${requestScope.InstanceId}" />
+<c:set var="fields" value="${requestScope.Fields}"/>
 
 <fmt:message var="dialogTitle" key="classifieds.subscriptionsAdd"/>
 <fmt:message var="validateLabel" key="GML.validate"/>
@@ -80,27 +74,30 @@
 <div id="subscription-adding" style="display: none">
 	<br/>
 	<form name="SubscriptionForm" action="AddSubscription" method="post" enctype="multipart/form-data">
-	<c:if test="${not empty formSearch}">
-		<table>
-			<caption></caption>
-			<th id="subscriptionFormHeader"></th>
-			<!-- AFFICHAGE du formulaire -->
-			<tr>
-				<td colspan="2">
-					<%
-						String language = (String) pageContext.getAttribute("language");
-						String instanceId = (String) pageContext.getAttribute("instanceId");
-						Form formSearch = (Form) pageContext.getAttribute("formSearch");
-						DataRecord data = (DataRecord) pageContext.getAttribute("data");
-
-						PagesContext context = new PagesContext("formSearch", "0", language, false, instanceId, null, null);
-					    context.setIgnoreDefaultValues(true);
-						formSearch.display(out, context, data);
-					%>
-				</td>
-			</tr>
-		</table>
-		<br/>
+	<c:if test="${not empty fields}">
+        <div class="forms mode-search">
+            <ul class="fields">
+                <c:forEach items="${fields}" var="field">
+                <jsp:useBean id="field"
+                             type="org.silverpeas.components.classifieds.servlets.SubscriptionField"/>
+                <li class="field field_${field.key}" id="form-row-${field.key}">
+                    <div>
+                        <label for="${field.key}">${field.label}</label>
+                    </div>
+                    <div class="fieldInput">
+                        <select id="${field.key}" name="${field.key}">
+                            <option value="" selected></option>
+                            <c:forEach items="${field.values}" var="value">
+                            <jsp:useBean id="value"
+                                         type="org.silverpeas.components.classifieds.servlets.SubscriptionFieldValue"/>
+                            <option value="${value.key}">${value.value}</option>
+                            </c:forEach>
+                        </select>
+                    </div>
+                </li>
+                </c:forEach>
+            </ul>
+        </div>
 	</c:if>
 	</form>
 </div>

--- a/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/subscriptions.jsp
+++ b/classifieds/classifieds-war/src/main/webapp/classifieds/jsp/subscriptions.jsp
@@ -46,8 +46,7 @@
 <c:set var="componentLabel" value="${browseContext[1]}" />
 
 <c:set var="subscribes" value="${requestScope.Subscribes}" />
-<c:set var="fieldsLabel" value="${requestScope.FieldsLabel}" />
-<c:set var="data" value="${requestScope.Data}" />
+<c:set var="fields" value="${requestScope.Fields}"/>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -86,16 +85,16 @@
                 <p>
                   &nbsp; &#149; &nbsp;
                   <c:if test="${not empty subscribe.fieldName1}">
-                    ${fieldsLabel[data.fields[0].name]}:&nbsp;<strong>${subscribe.fieldName1}</strong>&nbsp;
+                    ${fields[0].label}:&nbsp;<strong>${subscribe.fieldName1}</strong>&nbsp;
                   </c:if>
                   <c:if test="${not empty subscribe.fieldName2}">
-                    ${fieldsLabel[data.fields[1].name]}:&nbsp;<strong>${subscribe.fieldName2}</strong>
+                    ${fields[1].label}:&nbsp;<strong>${subscribe.fieldName2}</strong>
                   </c:if>
                   <a href="DeleteSubscription?SubscribeId=${subscribe.subscribeId}">
                     <fmt:message var="iconDelete" key="classifieds.smallDelete" bundle="${icons}" />
                     <c:url var="iconDeleteUrl" value="${iconDelete}"/>
                     <fmt:message var="deleteLabel" key="GML.delete" />
-                    <img src="${iconDeleteUrl}" border="0" alt="${deleteLabel}" title="${deleteLabel}" align="absmiddle" />
+                    <img src="${iconDeleteUrl}" border="0" alt="${deleteLabel}" title="${deleteLabel}" />
                   </a>
                 </p>
               </td>
@@ -104,7 +103,7 @@
         </c:if>
         <c:if test="${empty subscribes}">
           <tr>
-            <td colspan="5" valign="middle" align="center" width="100%">
+            <td colspan="5">
               <br /> <fmt:message key="classifieds.SubscribeEmpty" /> <br /></td>
           </tr>
         </c:if>


### PR DESCRIPTION
Fix the bug:
- Now the form used to create subscription is decoupled from the search form used to search and filter classifieds. It is generated directly from the two fields to use for search and for subscription.
- Only one value is selectable for each field used for subscription: so they are selectable through a selection list.
- When a field isn't valued for a subscription, set its value to an empty String.

Remove duplication code by providing reusable method in parent classes (the ClassifiedValidationHandler abstract class has been added for this purpose).

Add two new classes, SubscriptionField and SubscriptionFieldValue to model the two fields and their selectable values used in the subscription. They are used to generate the HTML form for subscription.