### PR TITLE
Feature #15411

### DIFF
--- a/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/servlets/QuickInfoRequestRouter.java
+++ b/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/servlets/QuickInfoRequestRouter.java
@@ -150,7 +150,7 @@ public class QuickInfoRequestRouter extends ComponentRequestRouter<QuickInfoSess
         request.setAttribute("News", news);
         request.setAttribute("ViewOnly", true);
         destination = getDestination("View", quickInfo, request);
-      } else if ("DisplayReadingTracking".equals(function)) {
+      } else if ("ReadingControl".equals(function)) {
         String id = request.getParameter("Id");
         News news = quickInfo.getNews(id, false);
         request.setAttribute("News", news);

--- a/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/servlets/QuickInfoRequestRouter.java
+++ b/quickinfo/quickinfo-war/src/main/java/org/silverpeas/components/quickinfo/servlets/QuickInfoRequestRouter.java
@@ -28,6 +28,7 @@ import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.date.Period;
 import org.silverpeas.core.io.media.image.thumbnail.control.ThumbnailController;
 import org.silverpeas.core.io.upload.UploadedFile;
+import org.silverpeas.core.security.authorization.ForbiddenRuntimeException;
 import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.file.FileItem;
 import org.silverpeas.kernel.util.StringUtil;
@@ -149,6 +150,15 @@ public class QuickInfoRequestRouter extends ComponentRequestRouter<QuickInfoSess
         request.setAttribute("News", news);
         request.setAttribute("ViewOnly", true);
         destination = getDestination("View", quickInfo, request);
+      } else if ("DisplayReadingTracking".equals(function)) {
+        String id = request.getParameter("Id");
+        News news = quickInfo.getNews(id, false);
+        request.setAttribute("News", news);
+        SilverpeasRole role = quickInfo.getHighestSilverpeasUserRole();
+        if (!role.isGreaterThanOrEquals(SilverpeasRole.MANAGER)) {
+          throwHttpForbiddenError();
+        }
+        destination = "/quickinfo/jsp/readingTracking.jsp";
       } else if ("Previous".equals(function)) {
         request.setAttribute("News", quickInfo.getPrevious());
         destination = getDestination("View", quickInfo, request);

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -107,7 +107,7 @@ function clipboardCopy() {
 }
 
 function displayReadingTracking() {
-  $("#newsForm").attr("action", "DisplayReadingTracking");
+  $("#newsForm").attr("action", "ReadingControl");
   $("#newsForm").submit();
 }
 

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/news.jsp
@@ -45,6 +45,7 @@
 <c:set var="highestUserRole" value="<%=SilverpeasRole.fromString(role)%>"/>
 <jsp:useBean id="highestUserRole" type="org.silverpeas.core.admin.user.model.SilverpeasRole"/>
 <c:set var="contributor" value="${role == 'admin' || role == 'publisher'}"/>
+<c:set var="manager" value="${role == 'admin' || role == 'Manager'}"/>
 <c:set var="userId" value="${sessionScope['SilverSessionController'].userId}"/>
 <c:set var="appSettings" value="${requestScope['AppSettings']}"/>
 <c:set var="viewOnly" value="${not empty requestScope['ViewOnly'] ? requestScope['ViewOnly'] : false}"/>
@@ -105,6 +106,11 @@ function clipboardCopy() {
   top.IdleFrame.location.href = '<c:url value="${componentURL}"/>copy?&Id=${news.id}';
 }
 
+function displayReadingTracking() {
+  $("#newsForm").attr("action", "DisplayReadingTracking");
+  $("#newsForm").submit();
+}
+
 function putNewsInBasket() {
   const basketManager = new BasketManager();
   basketManager.putContributionInBasket('${news.identifier.asString()}');
@@ -151,6 +157,12 @@ function putNewsInBasket() {
       <view:operationSeparator/>
       <view:operation altText="${putInSelectionBasketMsg}" action="javascript:onclick=putNewsInBasket()"/>
     </c:if>
+  </c:if>
+  <c:if test="${manager}">
+    <view:operationSeparator/>
+    <fmt:message var="readingTrackingMsg" key="GML.ReadingControlTitle"/>
+    <view:operation action="javascript:onclick=displayReadingTracking()"
+                    altText="${readingTrackingMsg}"/>
   </c:if>
 </view:operationPane>
 </c:if>

--- a/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/readingTracking.jsp
+++ b/quickinfo/quickinfo-war/src/main/webapp/quickinfo/jsp/readingTracking.jsp
@@ -29,36 +29,26 @@
 <%@ taglib uri="silverpeas.tags.viewGenerator" prefix="view"%>
 <%@ taglib tagdir="/WEB-INF/tags/silverpeas/util" prefix="viewTags" %>
 
-<%@ include file="checkKmelia.jsp" %>
-
 <c:set var="currentLang" value="${requestScope.Language}"/>
 <fmt:setLocale value="${currentLang}"/>
 <view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
 
-<fmt:message var="title" key="ReadingControlTitle"/>
-<c:set var="publication" value="${requestScope.Publication}"/>
-<jsp:useBean id="publication"
-             type="org.silverpeas.core.contribution.publication.model.PublicationDetail"/>
-<c:set var="linkedPath" value="${requestScope.LinkedPathString}"/>
+<fmt:message var="title" key="GML.ReadingControlTitle"/>
+<c:set var="news" value="${requestScope['News']}"/>
+<jsp:useBean id="news" type="org.silverpeas.components.quickinfo.model.News"/>
 
 <view:sp-page>
   <view:sp-head-part title="${title}"/>
   <view:sp-body-part>
-    <view:browseBar path="${linkedPath}" extraInformations="${publication.getName(currentLang)}"/>
+    <view:browseBar>
+      <view:browseBarElt label="${news.title}" link="View?Id=${news.id}"/>
+    </view:browseBar>
     <view:window>
-      <%
-        if (kmeliaScc.getSessionOwner()) {
-          KmeliaDisplayHelper.displayAllOperations(publication.getId(), kmeliaScc, gef,
-              "ViewReadingControl", resources, out, kmaxMode);
-        } else {
-          KmeliaDisplayHelper.displayUserOperations(kmeliaScc, out);
-        }
-      %>
       <view:frame>
         <viewTags:displayReadingControl
-            componentInstanceId="${publication.instanceId}"
-            contributionId="${publication.id}"
-            type="Publication"/>
+            componentInstanceId="${news.publication.instanceId}"
+            contributionId="${news.id}"
+            type="${news.contributionType}"/>
       </view:frame>
     </view:window>
   </view:sp-body-part>


### PR DESCRIPTION
Modify the Kmelia JSP readingControlManager.jsp to use the new tag <view:displayReadingControl>

Add a way for administrators and managers to access the reading tracking of a news in a QuickInfo instance. The new JSP, readingTracking.jsp, use the new tag <view:dispayReadingControl> to display reading tracking information per users.

Require to merge before https://github.com/Silverpeas/Silverpeas-Core/pull/1454